### PR TITLE
fix: OpenAI gpt-5 chat params, GUI active document, executor sandbox, sketch prompts

### DIFF
--- a/freecad_ai/core/active_document.py
+++ b/freecad_ai/core/active_document.py
@@ -1,0 +1,71 @@
+"""Resolve the document the user is actually editing.
+
+FreeCAD can desynchronize ``App.ActiveDocument`` from the document shown in the
+GUI (e.g. another tab is focused in the MDI). Tools and ``execute_code`` must
+target the same ``App::Document`` as the visible window — prefer
+``FreeCADGui.ActiveDocument.Document`` when available.
+"""
+
+
+def resolve_active_document():
+    """Return the ``App::Document`` to use for tools and code execution.
+
+    Resolution order:
+
+    1. ``FreeCADGui.ActiveDocument.Document`` when the GUI has an active view
+    2. ``FreeCAD.ActiveDocument``
+
+    Returns ``None`` if no document is available.
+    """
+    try:
+        import FreeCAD as App
+    except ImportError:
+        return None
+
+    try:
+        import FreeCADGui as Gui
+        gdoc = getattr(Gui, "ActiveDocument", None)
+        if gdoc is not None:
+            inner = getattr(gdoc, "Document", None)
+            if inner is not None:
+                return inner
+    except Exception:
+        pass
+
+    try:
+        return App.ActiveDocument if App.ActiveDocument else None
+    except Exception:
+        return None
+
+
+def sync_app_active_document(doc) -> None:
+    """Align ``App.ActiveDocument`` with *doc* so scripts using it hit the same file."""
+    if doc is None:
+        return
+    try:
+        import FreeCAD as App
+        App.setActiveDocument(doc.Name)
+    except Exception:
+        pass
+
+
+def refresh_gui_for_document(doc) -> None:
+    """Best-effort GUI refresh after the document changes."""
+    if doc is None:
+        return
+    try:
+        import FreeCAD as App
+        import FreeCADGui as Gui
+        App.setActiveDocument(doc.Name)
+        if hasattr(Gui, "updateGui"):
+            Gui.updateGui()
+    except Exception:
+        pass
+
+
+def get_synced_active_document():
+    """Return :func:`resolve_active_document` and sync ``App`` to match."""
+    doc = resolve_active_document()
+    if doc is not None:
+        sync_app_active_document(doc)
+    return doc

--- a/freecad_ai/core/context.py
+++ b/freecad_ai/core/context.py
@@ -16,9 +16,12 @@ def get_document_context() -> str:
     except ImportError:
         return "(FreeCAD not available — running outside FreeCAD)"
 
-    doc = App.ActiveDocument
+    from .active_document import resolve_active_document, sync_app_active_document
+
+    doc = resolve_active_document()
     if doc is None:
         return "No document is currently open."
+    sync_app_active_document(doc)
 
     lines = []
 

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -14,6 +14,7 @@ import io
 import json
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -45,7 +46,6 @@ def _find_freecad_cmd() -> str:
     Handles AppImages, wrapper scripts, and standard installs.
     """
     import glob
-    import shutil
 
     # 1. Look for AppImages in ~/bin (preferred — direct binary, not a wrapper script)
     appimage_patterns = [
@@ -76,25 +76,7 @@ def _find_freecad_cmd() -> str:
     return ""
 
 
-def _code_requires_live_document(code: str) -> bool:
-    """Return True if code cannot be meaningfully tested in the sandbox harness.
-
-    The subprocess sandbox always runs inside a fresh empty document named
-    ``SandboxTest``. Code that references objects in the user's file via
-    ``getObject`` / ``getDocument`` would fail there or (if errors are swallowed)
-    appear to succeed without doing anything in the real session.
-    """
-    if not (code and code.strip()):
-        return False
-    markers = (
-        "getObject(",
-        "getDocument(",
-        "getObjectsByLabel(",
-    )
-    return any(m in code for m in markers)
-
-
-def _sandbox_test(code: str, timeout: int = 15) -> tuple:
+def _sandbox_test(code: str, timeout: int = 15, document_path: str | None = None) -> tuple:
     """Test code in a headless FreeCAD subprocess.
 
     Returns (safe: bool, error_message: str).
@@ -107,12 +89,23 @@ def _sandbox_test(code: str, timeout: int = 15) -> tuple:
     result_file = tempfile.mktemp(suffix=".json")
     script_file = tempfile.mktemp(suffix=".py")
 
-    # Write a test harness that runs the code in a fresh document
+    if document_path:
+        open_block = (
+            "    App.openDocument({path!r})\n"
+            "    doc = App.ActiveDocument\n"
+            "    if doc is None:\n"
+            "        raise RuntimeError('Sandbox: openDocument did not set ActiveDocument')\n"
+            "    App.setActiveDocument(doc.Name)"
+        ).format(path=document_path)
+    else:
+        open_block = '    doc = App.newDocument("SandboxTest")'
+
+    # Harness: run user code, then close all documents without saving (temp copy is disposable).
     harness = '''import sys, json, traceback
 result = {{"ok": False, "error": ""}}
 try:
     import FreeCAD as App
-    doc = App.newDocument("SandboxTest")
+{open_block}
     # --- user code ---
 {indented_code}
     # --- end user code ---
@@ -121,9 +114,16 @@ try:
 except Exception as e:
     result["error"] = traceback.format_exc()
 finally:
+    try:
+        import FreeCAD as App
+        for _dn in list(App.listDocuments().keys()):
+            App.closeDocument(_dn)
+    except Exception:
+        pass
     with open({result_path!r}, "w") as f:
         json.dump(result, f)
 '''.format(
+        open_block=open_block,
         indented_code="\n".join("    " + line for line in code.splitlines()),
         result_path=result_file,
     )
@@ -214,18 +214,42 @@ def execute_code(code: str, timeout: int = 30, sandbox: bool = True) -> Executio
             code=code,
         )
 
-    # Layer 2: Subprocess sandbox (skipped when code needs the open document)
-    if sandbox and not _code_requires_live_document(code):
-        safe, sandbox_err = _sandbox_test(code, timeout=min(timeout, 15))
-        if not safe:
-            return ExecutionResult(
-                success=False,
-                stdout="",
-                stderr=sandbox_err,
-                code=code,
-            )
-
     from .active_document import get_synced_active_document, refresh_gui_for_document
+
+    # Layer 2: Subprocess sandbox — optional copy of saved document so getObject-style code validates safely
+    sandbox_copy_path = None
+    if sandbox:
+        pre_doc = get_synced_active_document()
+        fn = getattr(pre_doc, "FileName", "") if pre_doc else ""
+        if fn and os.path.isfile(fn):
+            try:
+                fd, sandbox_copy_path = tempfile.mkstemp(suffix=".FCStd")
+                os.close(fd)
+                shutil.copy2(fn, sandbox_copy_path)
+            except OSError as e:
+                return ExecutionResult(
+                    success=False,
+                    stdout="",
+                    stderr=f"Sandbox: could not copy document for validation: {e}",
+                    code=code,
+                )
+        try:
+            safe, sandbox_err = _sandbox_test(
+                code, timeout=min(timeout, 15), document_path=sandbox_copy_path
+            )
+            if not safe:
+                return ExecutionResult(
+                    success=False,
+                    stdout="",
+                    stderr=sandbox_err,
+                    code=code,
+                )
+        finally:
+            if sandbox_copy_path:
+                try:
+                    os.unlink(sandbox_copy_path)
+                except OSError:
+                    pass
 
     target_doc = get_synced_active_document()
     if target_doc is None:

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -76,6 +76,24 @@ def _find_freecad_cmd() -> str:
     return ""
 
 
+def _code_requires_live_document(code: str) -> bool:
+    """Return True if code cannot be meaningfully tested in the sandbox harness.
+
+    The subprocess sandbox always runs inside a fresh empty document named
+    ``SandboxTest``. Code that references objects in the user's file via
+    ``getObject`` / ``getDocument`` would fail there or (if errors are swallowed)
+    appear to succeed without doing anything in the real session.
+    """
+    if not (code and code.strip()):
+        return False
+    markers = (
+        "getObject(",
+        "getDocument(",
+        "getObjectsByLabel(",
+    )
+    return any(m in code for m in markers)
+
+
 def _sandbox_test(code: str, timeout: int = 15) -> tuple:
     """Test code in a headless FreeCAD subprocess.
 
@@ -162,11 +180,9 @@ finally:
 def _auto_save(namespace: dict):
     """Save a recovery copy of the active document before executing code."""
     try:
-        app = namespace.get("App") or namespace.get("FreeCAD")
-        if not app or not app.ActiveDocument:
-            return
-        doc = app.ActiveDocument
-        if not doc.FileName:
+        from .active_document import resolve_active_document
+        doc = resolve_active_document()
+        if not doc or not doc.FileName:
             return  # Unsaved document, nothing to back up
         backup = doc.FileName + ".ai-backup"
         doc.saveAs(backup)
@@ -198,8 +214,8 @@ def execute_code(code: str, timeout: int = 30, sandbox: bool = True) -> Executio
             code=code,
         )
 
-    # Layer 2: Subprocess sandbox
-    if sandbox:
+    # Layer 2: Subprocess sandbox (skipped when code needs the open document)
+    if sandbox and not _code_requires_live_document(code):
         safe, sandbox_err = _sandbox_test(code, timeout=min(timeout, 15))
         if not safe:
             return ExecutionResult(
@@ -208,6 +224,21 @@ def execute_code(code: str, timeout: int = 30, sandbox: bool = True) -> Executio
                 stderr=sandbox_err,
                 code=code,
             )
+
+    from .active_document import get_synced_active_document, refresh_gui_for_document
+
+    target_doc = get_synced_active_document()
+    if target_doc is None:
+        return ExecutionResult(
+            success=False,
+            stdout="",
+            stderr=(
+                "No active document — open a document in FreeCAD or click "
+                "its tab so it is the focused window."
+            ),
+            code=code,
+        )
+    doc_name = target_doc.Name
 
     # Build execution namespace with FreeCAD modules
     namespace = _build_namespace()
@@ -223,7 +254,7 @@ def execute_code(code: str, timeout: int = 30, sandbox: bool = True) -> Executio
     sys.stdout = captured_out
     sys.stderr = captured_err
 
-    doc = _get_active_doc(namespace)
+    doc = target_doc
     success = True
     try:
         # Layer 3: Undo transaction
@@ -254,6 +285,13 @@ def execute_code(code: str, timeout: int = 30, sandbox: bool = True) -> Executio
         _recompute(namespace)
         if doc:
             doc.commitTransaction()
+        import FreeCAD as App
+        d = App.getDocument(doc_name)
+        if d is None:
+            raise RuntimeError(
+                "Target document is no longer available after execution."
+            )
+        refresh_gui_for_document(d)
     except Exception:
         success = False
         traceback.print_exc(file=captured_err)
@@ -316,14 +354,6 @@ def _validate_code(code: str) -> list[str]:
     return warnings
 
 
-def _get_active_doc(namespace: dict):
-    """Get the active FreeCAD document, if any."""
-    app = namespace.get("App") or namespace.get("FreeCAD")
-    if app and hasattr(app, "ActiveDocument"):
-        return app.ActiveDocument
-    return None
-
-
 def _build_namespace() -> dict:
     """Build a namespace dict with FreeCAD modules for code execution."""
     ns = {"__builtins__": __builtins__}
@@ -356,7 +386,8 @@ def _build_namespace() -> dict:
 
 
 def _recompute(namespace: dict):
-    """Recompute the active document if available."""
-    app = namespace.get("App") or namespace.get("FreeCAD")
-    if app and hasattr(app, "ActiveDocument") and app.ActiveDocument:
-        app.ActiveDocument.recompute()
+    """Recompute the GUI-aligned active document if available."""
+    from .active_document import resolve_active_document
+    doc = resolve_active_document()
+    if doc:
+        doc.recompute()

--- a/freecad_ai/core/system_prompt.py
+++ b/freecad_ai/core/system_prompt.py
@@ -73,13 +73,6 @@ that perform FreeCAD operations safely. Prefer using tools over generating raw c
 - For camera views (front, top, isometric, etc.): use `set_view`
 - For zooming to a specific object: use `zoom_object`
 - For complex operations not covered by tools: use `execute_code`
-- For **2D layouts** (site plans, lot outlines, footprint rectangles): prefer **`create_sketch`** with **`geometries`** (e.g. `{type: rectangle, x, y, width, height}` and `{type: line, ...}`) instead of long `execute_code` blocks. That tool already runs `addGeometry` and `doc.recompute()` correctly.
-
-**Sketcher + `execute_code` (only if tools are insufficient):**
-- PartDesign sketches live **inside** the body: `body = doc.getObject("BodyInternalName"); sk = body.getObject("SketchInternalName")` — use **Name** values from `get_document_state` / tool results, not only labels.
-- You must `import Part` before `Part.LineSegment` / `Part.Circle`.
-- After `sk.addGeometry(...)`, call `doc.recompute()` (and optionally `sk.recompute()`).
-- Do **not** wrap sketch edits in `try/except: pass` — errors must fail loudly so the user sees them.
 
 **Important:** Always create a PartDesign Body with `create_body` before using sketch/pad/pocket workflows.
 
@@ -326,8 +319,6 @@ doc.recompute()
 CODE_CONVENTIONS_TOOLS = """\
 ## Important FreeCAD Notes
 - When using `execute_code` tool, always use `App.ActiveDocument` and call `doc.recompute()`
-- For sketches created with `create_sketch` + `body_name`, get the sketch via `doc.getObject("BodyName").getObject("SketchName")`, `import Part`, then add geometry; bare `doc.getObject("Sketch")` can be wrong if the sketch is nested only under the body
-- Prefer `create_sketch` with `geometries` for rectangles/lines instead of hand-written `execute_code` when possible
 - Use primitives over Revolution/Revolve for basic shapes (sphere, cylinder, cone, torus)
 - Revolution WILL CRASH FreeCAD if given a full circle profile — use semicircle + closing line
 - Boolean operations can crash on coplanar faces — add a tiny offset (0.01mm)

--- a/freecad_ai/core/system_prompt.py
+++ b/freecad_ai/core/system_prompt.py
@@ -73,6 +73,13 @@ that perform FreeCAD operations safely. Prefer using tools over generating raw c
 - For camera views (front, top, isometric, etc.): use `set_view`
 - For zooming to a specific object: use `zoom_object`
 - For complex operations not covered by tools: use `execute_code`
+- For **2D layouts** (site plans, lot outlines, footprint rectangles): prefer **`create_sketch`** with **`geometries`** (e.g. `{type: rectangle, x, y, width, height}` and `{type: line, ...}`) instead of long `execute_code` blocks. That tool already runs `addGeometry` and `doc.recompute()` correctly.
+
+**Sketcher + `execute_code` (only if tools are insufficient):**
+- PartDesign sketches live **inside** the body: `body = doc.getObject("BodyInternalName"); sk = body.getObject("SketchInternalName")` — use **Name** values from `get_document_state` / tool results, not only labels.
+- You must `import Part` before `Part.LineSegment` / `Part.Circle`.
+- After `sk.addGeometry(...)`, call `doc.recompute()` (and optionally `sk.recompute()`).
+- Do **not** wrap sketch edits in `try/except: pass` — errors must fail loudly so the user sees them.
 
 **Important:** Always create a PartDesign Body with `create_body` before using sketch/pad/pocket workflows.
 
@@ -308,6 +315,8 @@ doc.recompute()
 - Over-constraining a sketch causes errors — check `sketch.FullyConstrained` after adding constraints
 - Don't add redundant constraints (e.g. Horizontal + angle=0 on the same line)
 - Close sketch profiles properly — unclosed sketches cannot be padded/pocketed
+- **`import Part` is mandatory** for `Part.LineSegment` / `Part.Circle` in sketch code; missing import fails silently if the LLM wraps code in a broad try/except
+- After programmatic `addGeometry`, always **`doc.recompute()`** or geometry won't show in the tree/view
 
 **General:**
 - Use the simplest primitive available rather than constructing shapes from sketches
@@ -317,6 +326,8 @@ doc.recompute()
 CODE_CONVENTIONS_TOOLS = """\
 ## Important FreeCAD Notes
 - When using `execute_code` tool, always use `App.ActiveDocument` and call `doc.recompute()`
+- For sketches created with `create_sketch` + `body_name`, get the sketch via `doc.getObject("BodyName").getObject("SketchName")`, `import Part`, then add geometry; bare `doc.getObject("Sketch")` can be wrong if the sketch is nested only under the body
+- Prefer `create_sketch` with `geometries` for rectangles/lines instead of hand-written `execute_code` when possible
 - Use primitives over Revolution/Revolve for basic shapes (sphere, cylinder, cone, torus)
 - Revolution WILL CRASH FreeCAD if given a full circle profile — use semicircle + closing line
 - Boolean operations can crash on coplanar faces — add a tiny offset (0.01mm)

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -297,6 +297,16 @@ class LLMClient:
             headers["Authorization"] = f"Bearer {resolved_key}"
         return headers
 
+    def _openai_is_gpt5_family(self) -> bool:
+        """Official OpenAI Chat Completions: gpt-5.x uses max_completion_tokens (not max_tokens)
+        and rejects explicit non-default temperature — omit temperature so the API default applies."""
+        if self.provider_name != "openai":
+            return False
+        return (self.model or "").lower().startswith("gpt-5")
+
+    def _openai_use_max_completion_tokens(self) -> bool:
+        return self._openai_is_gpt5_family()
+
     def _openai_body(self, messages: list[dict], system: str, stream: bool,
                      tools: list[dict] | None = None) -> dict:
         msgs = []
@@ -315,10 +325,15 @@ class LLMClient:
         body = {
             "model": self.model,
             "messages": msgs,
-            "max_tokens": self.max_tokens,
-            "temperature": self.temperature,
             "stream": stream,
         }
+        # gpt-5.x rejects non-default temperature; omit so the API uses its default (1).
+        if not self._openai_is_gpt5_family():
+            body["temperature"] = self.temperature
+        if self._openai_use_max_completion_tokens():
+            body["max_completion_tokens"] = self.max_tokens
+        else:
+            body["max_tokens"] = self.max_tokens
         if tools:
             body["tools"] = tools
             body["tool_choice"] = "auto"

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -297,16 +297,6 @@ class LLMClient:
             headers["Authorization"] = f"Bearer {resolved_key}"
         return headers
 
-    def _openai_is_gpt5_family(self) -> bool:
-        """Official OpenAI Chat Completions: gpt-5.x uses max_completion_tokens (not max_tokens)
-        and rejects explicit non-default temperature — omit temperature so the API default applies."""
-        if self.provider_name != "openai":
-            return False
-        return (self.model or "").lower().startswith("gpt-5")
-
-    def _openai_use_max_completion_tokens(self) -> bool:
-        return self._openai_is_gpt5_family()
-
     def _openai_body(self, messages: list[dict], system: str, stream: bool,
                      tools: list[dict] | None = None) -> dict:
         msgs = []
@@ -325,15 +315,10 @@ class LLMClient:
         body = {
             "model": self.model,
             "messages": msgs,
+            "temperature": self.temperature,
             "stream": stream,
+            "max_tokens": self.max_tokens,
         }
-        # gpt-5.x rejects non-default temperature; omit so the API uses its default (1).
-        if not self._openai_is_gpt5_family():
-            body["temperature"] = self.temperature
-        if self._openai_use_max_completion_tokens():
-            body["max_completion_tokens"] = self.max_tokens
-        else:
-            body["max_tokens"] = self.max_tokens
         if tools:
             body["tools"] = tools
             body["tool_choice"] = "auto"
@@ -366,6 +351,11 @@ class LLMClient:
             body["n"] = 1
             body["presence_penalty"] = 0.0
             body["frequency_penalty"] = 0.0
+        elif self.provider_name == "openai" and (self.model or "").lower().startswith("gpt-5"):
+            # Official OpenAI Chat Completions: gpt-5.x rejects max_tokens and non-default temperature.
+            body.pop("temperature", None)
+            if "max_tokens" in body:
+                body["max_completion_tokens"] = body.pop("max_tokens")
 
     def _send_openai(self, messages: list[dict], system: str, stream: bool = False) -> str:
         body = self._openai_body(messages, system, stream=False)

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -1068,9 +1068,8 @@ def _handle_measure(
 ) -> ToolResult:
     """Measure properties of objects (volume, area, bounding box, distance)."""
     import FreeCAD as App
-    from ..core.active_document import get_synced_active_document
 
-    doc = get_synced_active_document()
+    doc = App.ActiveDocument
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1158,9 +1157,8 @@ MEASURE = ToolDefinition(
 def _handle_describe_model(object_name: str) -> ToolResult:
     """Return a comprehensive geometry summary of an object."""
     import FreeCAD as App
-    from ..core.active_document import get_synced_active_document
 
-    doc = get_synced_active_document()
+    doc = App.ActiveDocument
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1283,14 +1281,14 @@ DESCRIBE_MODEL = ToolDefinition(
 
 def _handle_get_document_state() -> ToolResult:
     """Get the current document state — all objects and their properties."""
-    from ..core.active_document import get_synced_active_document
+    import FreeCAD as App
     from ..core.context import get_document_context
 
-    if not get_synced_active_document():
+    if not App.ActiveDocument:
         return ToolResult(
             success=False,
             output="",
-            error="No active document — open a document in FreeCAD or select its tab.",
+            error="No active document",
             data={},
         )
     ctx = get_document_context()
@@ -1364,9 +1362,8 @@ def _handle_export_model(
     import FreeCAD as App
     import Part
     import Mesh
-    from ..core.active_document import get_synced_active_document
 
-    doc = get_synced_active_document()
+    doc = App.ActiveDocument
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1450,9 +1447,8 @@ EXECUTE_CODE = ToolDefinition(
 def _handle_undo(steps: int = 1, until: str = "") -> ToolResult:
     """Undo operations. Either N steps or until a named transaction is reached."""
     import FreeCAD as App
-    from ..core.active_document import get_synced_active_document
 
-    doc = get_synced_active_document()
+    doc = App.ActiveDocument
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1525,9 +1521,8 @@ UNDO = ToolDefinition(
 def _handle_redo(steps: int = 1) -> ToolResult:
     """Redo previously undone operations."""
     import FreeCAD as App
-    from ..core.active_document import get_synced_active_document
 
-    doc = get_synced_active_document()
+    doc = App.ActiveDocument
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1566,9 +1561,8 @@ REDO = ToolDefinition(
 def _handle_undo_history() -> ToolResult:
     """Show the undo/redo stack."""
     import FreeCAD as App
-    from ..core.active_document import get_synced_active_document
 
-    doc = get_synced_active_document()
+    doc = App.ActiveDocument
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -2921,9 +2915,8 @@ def _handle_zoom_object(object_name: str) -> ToolResult:
     """Zoom the viewport to focus on a specific object."""
     import FreeCAD as App
     import FreeCADGui as Gui
-    from ..core.active_document import get_synced_active_document
 
-    doc = get_synced_active_document()
+    doc = App.ActiveDocument
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -31,10 +31,14 @@ def _coerce_str_list(value):
 
 def _with_undo(label: str, func):
     """Run func inside a FreeCAD undo transaction. Returns ToolResult."""
-    import FreeCAD as App
-    doc = App.ActiveDocument
+    from ..core.active_document import get_synced_active_document
+    doc = get_synced_active_document()
     if not doc:
-        return ToolResult(success=False, output="", error="No active document")
+        return ToolResult(
+            success=False,
+            output="",
+            error="No active document — open a document in FreeCAD or select its tab.",
+        )
     doc.openTransaction(label)
     try:
         result = func(doc)
@@ -1064,8 +1068,9 @@ def _handle_measure(
 ) -> ToolResult:
     """Measure properties of objects (volume, area, bounding box, distance)."""
     import FreeCAD as App
+    from ..core.active_document import get_synced_active_document
 
-    doc = App.ActiveDocument
+    doc = get_synced_active_document()
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1153,8 +1158,9 @@ MEASURE = ToolDefinition(
 def _handle_describe_model(object_name: str) -> ToolResult:
     """Return a comprehensive geometry summary of an object."""
     import FreeCAD as App
+    from ..core.active_document import get_synced_active_document
 
-    doc = App.ActiveDocument
+    doc = get_synced_active_document()
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1277,14 +1283,17 @@ DESCRIBE_MODEL = ToolDefinition(
 
 def _handle_get_document_state() -> ToolResult:
     """Get the current document state — all objects and their properties."""
+    from ..core.active_document import get_synced_active_document
     from ..core.context import get_document_context
-    ctx = get_document_context()
-    if not ctx:
+
+    if not get_synced_active_document():
         return ToolResult(
-            success=True,
-            output="No document is open, or the document is empty.",
-            data={"objects": []},
+            success=False,
+            output="",
+            error="No active document — open a document in FreeCAD or select its tab.",
+            data={},
         )
+    ctx = get_document_context()
     return ToolResult(
         success=True,
         output=ctx,
@@ -1355,8 +1364,9 @@ def _handle_export_model(
     import FreeCAD as App
     import Part
     import Mesh
+    from ..core.active_document import get_synced_active_document
 
-    doc = App.ActiveDocument
+    doc = get_synced_active_document()
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1409,11 +1419,17 @@ EXPORT_MODEL = ToolDefinition(
 
 def _handle_execute_code(code: str) -> ToolResult:
     """Execute arbitrary Python code (fallback tool)."""
+    from ..core.active_document import resolve_active_document
     from ..core.executor import execute_code
+
     result = execute_code(code)
     if result.success:
         output = result.stdout.strip() if result.stdout.strip() else "Code executed successfully"
-        return ToolResult(success=True, output=output, data={"stdout": result.stdout})
+        doc = resolve_active_document()
+        data = {"stdout": result.stdout}
+        if doc:
+            data["document"] = doc.Name
+        return ToolResult(success=True, output=output, data=data)
     else:
         return ToolResult(success=False, output=result.stdout, error=result.stderr)
 
@@ -1434,8 +1450,9 @@ EXECUTE_CODE = ToolDefinition(
 def _handle_undo(steps: int = 1, until: str = "") -> ToolResult:
     """Undo operations. Either N steps or until a named transaction is reached."""
     import FreeCAD as App
+    from ..core.active_document import get_synced_active_document
 
-    doc = App.ActiveDocument
+    doc = get_synced_active_document()
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1508,8 +1525,9 @@ UNDO = ToolDefinition(
 def _handle_redo(steps: int = 1) -> ToolResult:
     """Redo previously undone operations."""
     import FreeCAD as App
+    from ..core.active_document import get_synced_active_document
 
-    doc = App.ActiveDocument
+    doc = get_synced_active_document()
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -1548,8 +1566,9 @@ REDO = ToolDefinition(
 def _handle_undo_history() -> ToolResult:
     """Show the undo/redo stack."""
     import FreeCAD as App
+    from ..core.active_document import get_synced_active_document
 
-    doc = App.ActiveDocument
+    doc = get_synced_active_document()
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 
@@ -2902,8 +2921,9 @@ def _handle_zoom_object(object_name: str) -> ToolResult:
     """Zoom the viewport to focus on a specific object."""
     import FreeCAD as App
     import FreeCADGui as Gui
+    from ..core.active_document import get_synced_active_document
 
-    doc = App.ActiveDocument
+    doc = get_synced_active_document()
     if not doc:
         return ToolResult(success=False, output="", error="No active document")
 

--- a/tests/unit/test_active_document.py
+++ b/tests/unit/test_active_document.py
@@ -1,0 +1,89 @@
+"""Unit tests for GUI-aligned active document resolution."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestActiveDocument(unittest.TestCase):
+    def test_resolve_prefers_gui_active_document(self):
+        inner = MagicMock()
+        inner.Name = "GuiDoc"
+        gdoc = MagicMock()
+        gdoc.Document = inner
+        app_mod = MagicMock()
+        app_mod.ActiveDocument = MagicMock(name="wrong_app_doc")
+
+        gui_mod = MagicMock()
+        gui_mod.ActiveDocument = gdoc
+
+        with patch.dict(sys.modules, {"FreeCAD": app_mod, "FreeCADGui": gui_mod}):
+            from freecad_ai.core import active_document
+
+            self.assertIs(active_document.resolve_active_document(), inner)
+
+    def test_get_synced_calls_set_active_document(self):
+        inner = MagicMock()
+        inner.Name = "SyncedDoc"
+        gdoc = MagicMock()
+        gdoc.Document = inner
+        app_mod = MagicMock()
+        app_mod.ActiveDocument = None
+        gui_mod = MagicMock()
+        gui_mod.ActiveDocument = gdoc
+
+        with patch.dict(sys.modules, {"FreeCAD": app_mod, "FreeCADGui": gui_mod}):
+            from freecad_ai.core import active_document
+
+            out = active_document.get_synced_active_document()
+            self.assertIs(out, inner)
+            app_mod.setActiveDocument.assert_called_once_with("SyncedDoc")
+
+    def test_resolve_falls_back_to_app_when_gui_has_no_document(self):
+        app_doc = MagicMock()
+        app_mod = MagicMock()
+        app_mod.ActiveDocument = app_doc
+        gui_mod = MagicMock()
+        gactive = MagicMock()
+        gactive.Document = None
+        gui_mod.ActiveDocument = gactive
+
+        with patch.dict(sys.modules, {"FreeCAD": app_mod, "FreeCADGui": gui_mod}):
+            from freecad_ai.core import active_document
+
+            self.assertIs(active_document.resolve_active_document(), app_doc)
+
+    def test_resolve_falls_back_when_no_freecadgui(self):
+        app_doc = MagicMock()
+        app_mod = MagicMock()
+        app_mod.ActiveDocument = app_doc
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "FreeCADGui":
+                raise ImportError("no gui")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch.dict(sys.modules, {"FreeCAD": app_mod}):
+            from freecad_ai.core import active_document
+
+            with patch.object(builtins, "__import__", side_effect=fake_import):
+                self.assertIs(active_document.resolve_active_document(), app_doc)
+
+    def test_resolve_returns_none_when_no_document(self):
+        app_mod = MagicMock()
+        app_mod.ActiveDocument = None
+        gui_mod = MagicMock()
+        gui_mod.ActiveDocument = None
+
+        with patch.dict(sys.modules, {"FreeCAD": app_mod, "FreeCADGui": gui_mod}):
+            from freecad_ai.core import active_document
+
+            self.assertIsNone(active_document.resolve_active_document())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_select_geometry.py
+++ b/tests/unit/test_select_geometry.py
@@ -1,5 +1,8 @@
 """Tests for the select_geometry tool definition and handler."""
 
+import sys
+import types
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -69,15 +72,18 @@ class TestSelectGeometryInRegistry:
 
 
 class TestSelectGeometryHandler:
-    @patch("freecad_ai.tools.freecad_tools.SelectionPanel", create=True)
-    def test_cancelled_returns_empty(self, _mock_cls):
+    def _patch_selection_panel(self, mock_panel):
+        """Stub the UI module so tests run without Qt / real SelectionPanel."""
+        fake_mod = types.ModuleType("freecad_ai.ui.selection_panel")
+        fake_mod.SelectionPanel = MagicMock(return_value=mock_panel)
+        return patch.dict(sys.modules, {"freecad_ai.ui.selection_panel": fake_mod})
+
+    def test_cancelled_returns_empty(self):
         """Handler returns graceful message when user cancels."""
         mock_panel = MagicMock()
         mock_panel.exec.return_value = []
 
-        with patch(
-            "freecad_ai.ui.selection_panel.SelectionPanel", return_value=mock_panel
-        ):
+        with self._patch_selection_panel(mock_panel):
             from freecad_ai.tools.freecad_tools import _handle_select_geometry
             result = _handle_select_geometry(prompt="Pick edges")
 
@@ -85,8 +91,7 @@ class TestSelectGeometryHandler:
         assert result.data["selections"] == []
         assert "cancelled" in result.output.lower() or "nothing" in result.output.lower()
 
-    @patch("freecad_ai.tools.freecad_tools.SelectionPanel", create=True)
-    def test_with_selections(self, _mock_cls):
+    def test_with_selections(self):
         """Handler formats selections correctly."""
         sample = [
             {"object": "Pad", "sub_element": "Edge1", "point": [10.0, 0.0, 5.0]},
@@ -95,9 +100,7 @@ class TestSelectGeometryHandler:
         mock_panel = MagicMock()
         mock_panel.exec.return_value = sample
 
-        with patch(
-            "freecad_ai.ui.selection_panel.SelectionPanel", return_value=mock_panel
-        ):
+        with self._patch_selection_panel(mock_panel):
             from freecad_ai.tools.freecad_tools import _handle_select_geometry
             result = _handle_select_geometry(
                 prompt="Select edges to fillet", select_type="edge"


### PR DESCRIPTION
## Summary

Improves reliability when using **OpenAI gpt-5.x**, when **App vs GUI active document** diverge, and when **`execute_code`** references objects in the open file. Adds **prompt guidance** for 2D/site-plan style work (`create_sketch` + `geometries`, Part import, recompute).

## Changes

### LLM (`freecad_ai/llm/client.py`)
- For **provider `openai`** and models whose id starts with **`gpt-5`**: send **`max_completion_tokens`** instead of **`max_tokens`**.
- For the same case: **omit `temperature`** so the API uses its default (gpt-5 rejects non-default sampling in Chat Completions).

### Active document (`freecad_ai/core/active_document.py`, `context.py`, `freecad_tools.py`)
- Prefer **`FreeCADGui.ActiveDocument.Document`**, then fall back to **`App.ActiveDocument`**.
- **`App.setActiveDocument`** so scripts using **`App.ActiveDocument`** match the visible tab.
- **`get_document_state`** and tool paths (**`_with_undo`**, measure, describe, export, undo/redo, zoom, etc.) use the same resolution.
- **`execute_code` tool** includes resolved **`document`** name in **`data`** on success.

### Executor (`freecad_ai/executor.py`)
- **`execute_code`** requires a resolvable document; uses synced GUI document for undo/recompute.
- **Skip subprocess sandbox** when code contains **`getObject(`** / **`getDocument(`** / **`getObjectsByLabel(`** so snippets are not “validated” in an empty `SandboxTest` doc.
- After success: verify document still exists; **`refresh_gui_for_document`** (recompute + `Gui.updateGui` when available).

### Prompts (`freecad_ai/core/system_prompt.py`)
- Prefer **`create_sketch`** with **`geometries`** for lot/site outlines; document **`body.getObject`**, **`import Part`**, **`doc.recompute()`**, avoid silent `try/except` on sketch edits.

## Testing

- `pytest tests/unit/` — **pass** (local run).
- **Manual:** Settings → Test Connection (OpenAI gpt-5.x); open a document, run **get_document_state** / **execute_code** / site-plan style sketch flow.

## Notes

- Fork / branch: `dpappo/freecad-ai` → `contrib/openai-gpt5-active-document-executor`.
- Upstream PR target: **`ghbalf/freecad-ai`** `master`.