### PR TITLE
Enhance context

### DIFF
--- a/freecad_ai/core/context.py
+++ b/freecad_ai/core/context.py
@@ -154,10 +154,26 @@ def _get_key_properties(obj) -> list[str]:
         except Exception:
             pass
 
-    # Pad/Pocket length
+    # Pad/Pocket properties
     if "Pad" in type_id or "Pocket" in type_id:
+        # Extract type of pad/pocket (Ex: Dimension, Upto surface.. etc)
+        type_name = ""
+        try:
+            p_type = obj.Type
+            type_name = str(p_type)
+            if type_name:
+                props.append(f"Type: {type_name}")
+        except Exception:
+            pass
         try:
             props.append(f"Length: {obj.Length}")
+            if type_name == "TwoLengths" and hasattr(obj, "Length2"):
+                props.append(f"Length2: {obj.Length2}")
+        except Exception:
+            pass
+        try:
+            if obj.Reversed == True:
+                props.append(f"Reversed: true")
         except Exception:
             pass
 
@@ -173,10 +189,32 @@ def _get_key_properties(obj) -> list[str]:
         except Exception:
             pass
 
-    # Revolution angle
+    # Revolution properties
     if "Revolution" in type_id:
+        rev_type_name = ""
+        # Extract type of pad/pocket (Ex: Angle, Upto surface.. etc)
+        try:
+            rev_type = obj.Type
+            rev_type_name = str(rev_type)
+            if rev_type_name:
+                props.append(f"Type: {rev_type_name}")
+        except Exception:
+            pass
         try:
             props.append(f"Angle: {obj.Angle}")
+            if rev_type_name == "TwoAngles" and hasattr(obj, "Angle2"):
+                props.append(f"Angle2: {obj.Angle2}")
+        except Exception:
+            pass
+        # Reference axis of rotation
+        try:
+            if hasattr(obj, "ReferenceAxis"):
+                props.append(f"ReferenceAxis: {obj.ReferenceAxis}")
+        except Exception:
+            pass
+        try:
+            if obj.Reversed == True:
+                props.append("Reversed: true")
         except Exception:
             pass
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,0 +1,78 @@
+"""
+Tests for document context property extraction helpers.
+Specifically, pad and rotation features
+"""
+
+from types import SimpleNamespace
+from freecad_ai.core.context import _get_key_properties
+
+class TestGetKeyProperties:
+    # Pad with TwoLengths should include type, primary/secondary lengths, and reversed flag.
+    def test_pad_two_lengths_gives_length_length2_and_reversed(self):
+        obj = SimpleNamespace(
+            TypeId="PartDesign::Pad",
+            Type="TwoLengths",
+            Length="10 mm",
+            Length2="3 mm",
+            Reversed=True,
+        )
+
+        props = _get_key_properties(obj)
+
+        assert "Type: TwoLengths" in props
+        assert "Length: 10 mm" in props
+        assert "Length2: 3 mm" in props
+        assert "Reversed: true" in props
+
+    # Pocket with non-TwoLengths should not include Length2 or reversed flag when Reversed is False.
+    def test_pocket_dimension_omits_length2_and_reversed(self):
+        obj = SimpleNamespace(
+            TypeId="PartDesign::Pocket",
+            Type="Dimension",
+            Length="7 mm",
+            Reversed=False,
+            Length2="99 mm",
+        )
+
+        props = _get_key_properties(obj)
+
+        assert "Type: Dimension" in props
+        assert "Length: 7 mm" in props
+        assert "Length2: 99 mm" not in props
+        assert "Reversed: true" not in props
+
+    # Revolution with TwoAngles should include type, both angles, reference axis, and reversed flag.
+    def test_revolution_two_angles_gives_angle2_axis_and_reversed(self):
+        obj = SimpleNamespace(
+            TypeId="PartDesign::Revolution",
+            Type="TwoAngles",
+            Angle="180 deg",
+            Angle2="30 deg",
+            ReferenceAxis="(Sketch.Axis, V_Axis)",
+            Reversed=True,
+        )
+
+        props = _get_key_properties(obj)
+
+        assert "Type: TwoAngles" in props
+        assert "Angle: 180 deg" in props
+        assert "Angle2: 30 deg" in props
+        assert "ReferenceAxis: (Sketch.Axis, V_Axis)" in props
+        assert "Reversed: true" in props
+
+    # Revolution with non-TwoAngles should not include Angle2 and should omit reversed when False.
+    def test_revolution_angle_omits_angle2_and_reversed(self):
+        obj = SimpleNamespace(
+            TypeId="PartDesign::Revolution",
+            Type="Angle",
+            Angle="270 deg",
+            Angle2="40 deg",
+            Reversed=False,
+        )
+
+        props = _get_key_properties(obj)
+
+        assert "Type: Angle" in props
+        assert "Angle: 270 deg" in props
+        assert "Angle2: 40 deg" not in props
+        assert "Reversed: true" not in props


### PR DESCRIPTION
## Summary

This PR improves document context extraction for PartDesign features and adds focused unit tests to lock in the new behavior.
The update enriches object summaries for Pad/Pocket and Revolution features so downstream prompts get more complete, explicit feature parameters. Especially useful in editing existing geometries by using prompts where LLM must understand the state of the available geometry.

## Changes

### Context extraction updates (context.py)
Updated context.py to return additional key properties:
- Pad/Pocket:
1. Adds feature Type
2. Adds Length2 when Type is TwoLengths
3. Adds Reversed: true when reversed is enabled

- Revolution:
1. Adds feature Type
2. Adds Angle2 when Type is TwoAngles
3. Adds ReferenceAxis when available
4. Adds Reversed: true when reversed is enabled

### Added tests (test_context.py)
Tests for-
- Pad with TwoLengths includes Type, Length, Length2, Reversed
- Pocket with non-TwoLengths omits Length2 and omits Reversed when false
- Revolution with TwoAngles includes Type, Angle, Angle2, ReferenceAxis, Reversed
- Revolution with non-TwoAngles omits Angle2 and omits Reversed when false


## Testing
- Tests passing

## Notes

- Fork : `yas1nsyed/freecad-ai` 
- Upstream PR target: **`ghbalf/freecad-ai`** `master`.