### PR TITLE
fix: restore button text under OpenDark/OpenLight themes

### DIFF
--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -67,8 +67,17 @@ _BINARY_MAGIC = (
     b"\x00asm",        # WebAssembly
 )
 
-# set of themes that brakes ui buttons text
+# Themes that ship a global QPushButton stylesheet which overrides
+# padding/margins and clips the labels of buttons in this dock.
 _STYLESHEET_CONFLICT_THEMES = frozenset({"opendark", "openlight"})
+
+# Color rules per viewport-capture mode (applied to _capture_btn).
+_CAPTURE_MODE_COLORS = {
+    "off": "",
+    "every_message": "font-weight: bold; color: #4fc3f7;",  # light blue
+    "after_changes": "font-weight: bold; color: #aed581;",  # light green
+}
+
 
 def _is_binary_content(data: bytes) -> bool:
     """Detect binary content by magic bytes and null-byte presence."""
@@ -1059,8 +1068,10 @@ class ChatDockWidget(QDockWidget):
         save_log_btn.clicked.connect(self._save_session_log)
         footer.addWidget(save_log_btn)
 
+        # _capture_btn is intentionally excluded — its stylesheet is
+        # composed in _capture_btn_stylesheet() so that mode color and
+        # conflict-busting padding share a single setStyleSheet call.
         self._theme_ui_conflict_buttons = [
-            self._capture_btn,
             settings_btn,
             new_chat_btn,
             load_chat_btn,
@@ -1085,21 +1096,50 @@ class ChatDockWidget(QDockWidget):
         refresh_theme_cache()
         self._apply_theme()
 
-    def _resolve_stylesheet_conflict(self, theme_name:str):
+    def _resolve_stylesheet_conflict(self, theme_name: str):
         """OpenDark/OpenLight theme packs inject global QPushButton styles that
         override padding/margins, causing button text to be clipped.
         Re-applying explicit padding via setStyleSheet restores correct sizing.
+        Each button keeps its construction-time setMaximumWidth(); only the
+        padding stylesheet is reapplied here.
         """
         if theme_name.casefold() in _STYLESHEET_CONFLICT_THEMES:
             for btn in self._theme_ui_conflict_buttons:
-                btn.setMaximumWidth(100)
-                btn.setStyleSheet("QPushButton { padding: 4px 16px; margin: 1px;}")
+                btn.setStyleSheet(
+                    "QPushButton { padding: 4px 16px; margin: 1px; }"
+                )
+
+    def _capture_btn_stylesheet(self) -> str:
+        """Build the _capture_btn stylesheet by composing capture-mode
+        color and (under conflicting themes) explicit padding.
+
+        Both rule sets are applied via a single setStyleSheet call so
+        that capture-mode cycling and theme refresh can never overwrite
+        each other's contribution.
+        """
+        mode = (
+            getattr(self, "_capture_mode_override", None)
+            or get_config().viewport_capture
+        )
+        color = _CAPTURE_MODE_COLORS.get(mode, "")
+        needs_padding = (
+            get_freecad_mode_name().casefold() in _STYLESHEET_CONFLICT_THEMES
+        )
+        if not color and not needs_padding:
+            return ""
+        rules = []
+        if needs_padding:
+            rules.append("padding: 4px 16px; margin: 1px;")
+        if color:
+            rules.append(color)
+        return "QPushButton { " + " ".join(rules) + " }"
 
     def _apply_theme(self):
         """Reapply all theme-dependent stylesheets."""
         colors = _get_theme_colors()
         theme_name = get_freecad_mode_name(force_refresh=True)
         self._resolve_stylesheet_conflict(theme_name)
+        self._capture_btn.setStyleSheet(self._capture_btn_stylesheet())
         self.chat_display.setStyleSheet(get_chat_display_stylesheet())
         self.input_edit.setStyleSheet(
             f"QTextEdit {{ background-color: {colors['chat_bg']}; color: {colors['chat_text']}; "
@@ -1407,13 +1447,9 @@ class ChatDockWidget(QDockWidget):
         next_mode = modes[(idx + 1) % len(modes)]
         self._capture_mode_override = next_mode
         self._capture_btn.setToolTip(labels.get(next_mode, next_mode))
-        # Visual feedback: distinct colors per active mode
-        style_map = {
-            "off": "",
-            "every_message": "font-weight: bold; color: #4fc3f7;",  # light blue
-            "after_changes": "font-weight: bold; color: #aed581;",  # light green
-        }
-        self._capture_btn.setStyleSheet(style_map.get(next_mode, ""))
+        # Visual feedback: distinct colors per active mode (composed with
+        # conflict-theme padding via _capture_btn_stylesheet()).
+        self._capture_btn.setStyleSheet(self._capture_btn_stylesheet())
 
     def _on_mode_changed(self, index):
         """Update config when mode is toggled."""

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -38,6 +38,7 @@ from ..core.executor import extract_code_blocks, execute_code
 from .message_view import (
     _get_theme_colors,
     get_chat_display_stylesheet,
+    get_freecad_mode_name,
     refresh_theme_cache,
     render_message,
     render_code_block,
@@ -66,6 +67,8 @@ _BINARY_MAGIC = (
     b"\x00asm",        # WebAssembly
 )
 
+# set of themes that brakes ui buttons text
+_STYLESHEET_CONFLICT_THEMES = frozenset({"opendark", "openlight"})
 
 def _is_binary_content(data: bytes) -> bool:
     """Detect binary content by magic bytes and null-byte presence."""
@@ -1056,6 +1059,14 @@ class ChatDockWidget(QDockWidget):
         save_log_btn.clicked.connect(self._save_session_log)
         footer.addWidget(save_log_btn)
 
+        self._theme_ui_conflict_buttons = [
+            self._capture_btn,
+            settings_btn,
+            new_chat_btn,
+            load_chat_btn,
+            save_log_btn,
+        ]
+
         footer.addStretch()
 
         self.token_label = QLabel(translate("ChatDockWidget", "tokens: ~0"))
@@ -1074,9 +1085,21 @@ class ChatDockWidget(QDockWidget):
         refresh_theme_cache()
         self._apply_theme()
 
+    def _resolve_stylesheet_conflict(self, theme_name:str):
+        """OpenDark/OpenLight theme packs inject global QPushButton styles that
+        override padding/margins, causing button text to be clipped.
+        Re-applying explicit padding via setStyleSheet restores correct sizing.
+        """
+        if theme_name.casefold() in _STYLESHEET_CONFLICT_THEMES:
+            for btn in self._theme_ui_conflict_buttons:
+                btn.setMaximumWidth(100)
+                btn.setStyleSheet("QPushButton { padding: 4px 16px; margin: 1px;}")
+
     def _apply_theme(self):
         """Reapply all theme-dependent stylesheets."""
         colors = _get_theme_colors()
+        theme_name = get_freecad_mode_name(force_refresh=True)
+        self._resolve_stylesheet_conflict(theme_name)
         self.chat_display.setStyleSheet(get_chat_display_stylesheet())
         self.input_edit.setStyleSheet(
             f"QTextEdit {{ background-color: {colors['chat_bg']}; color: {colors['chat_text']}; "


### PR DESCRIPTION

<img width="453" height="942" alt="ui_bug" src="https://github.com/user-attachments/assets/7e2b05e0-f780-4520-8bc5-dd95553ce281" />
<img width="454" height="942" alt="ui_fixed" src="https://github.com/user-attachments/assets/9c6b53a9-5a11-4fce-b1af-92b58b8cb7a6" />
The OpenDark and OpenLight FreeCAD theme packs inject global QPushButton stylesheet rules that override padding and margin on all buttons. This causes the header (Capture, Settings) and footer (+ New Chat, Load, Save Log) button labels to be visually clipped when either theme is active.

The fix re-applies explicit padding via setStyleSheet() for the affected buttons whenever one of the conflicting themes is detected

Changes:
freecad_ai/ui/chat_widget.py
Added _STYLESHEET_CONFLICT_THEMES — a module-level frozenset of lowercased theme names that trigger the issue (opendark, openlight)
Added self._theme_ui_conflict_buttons list in _build_ui() to keep references to the five affected local-variable buttons and make them accessible to the resolver
Added _resolve_stylesheet_conflict(theme_name: str) with a docstring explaining the root cause; 
Updated _apply_theme() to call _resolve_stylesheet_conflict() on every showEvent

Testing Manual:
Testing FreeCad versions: v1.0.2, v1.1.1
Loaded the extension in FreeCAD with the OpenDark and OpenLight preference packs applied. Verified that header and footer buttons display their labels correctly. Confirmed no visual regression under the default FreeCAD Dark and FreeCAD Classic themes.