### PR TITLE
fix(sandbox): don't blame code for pre-existing invalid shapes

### DIFF
--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -10,6 +10,7 @@ Safety layers:
   4. Auto-save — save document before execution so crashes don't lose work
 """
 
+import inspect
 import io
 import json
 import os
@@ -76,6 +77,39 @@ def _find_freecad_cmd() -> str:
     return ""
 
 
+def _collect_object_issues(objects_state, baseline_bad):
+    """Return post-execution validation issues the executed code is responsible for.
+
+    ``objects_state`` is a list of ``{"name", "null", "invalid", "invalid_state"}``
+    dicts captured AFTER the user code ran. ``baseline_bad`` is the set of object
+    names that already had a problem (null/invalid shape or Invalid state) BEFORE
+    it ran.
+
+    Objects already broken in the baseline are suppressed: the code didn't
+    introduce their invalidity, so it must not be blamed for it. An STL imported
+    and converted to a solid yields an OCC-invalid Part::Feature, and the sandbox
+    dry-runs against a copy of the saved document — so that invalid solid is
+    present on every run. Reporting it failed unrelated code (e.g. a sketch on a
+    selected face) and sent the model chasing a phantom bug across all retries.
+
+    Only new objects (names absent from ``baseline_bad``) or objects the code
+    newly broke are reported. The shape source of truth lives here so the
+    subprocess harness and the unit tests exercise identical logic.
+    """
+    issues = []
+    for st in objects_state:
+        name = st["name"]
+        if name in baseline_bad:
+            continue
+        if st.get("null"):
+            issues.append("Object '" + name + "' has null shape")
+        elif st.get("invalid"):
+            issues.append("Object '" + name + "' has invalid shape")
+        if st.get("invalid_state"):
+            issues.append("Object '" + name + "' is in Invalid state")
+    return issues
+
+
 def _sandbox_test(code: str, timeout: int = 15, document_path: str | None = None) -> tuple:
     """Test code in a headless FreeCAD subprocess.
 
@@ -107,6 +141,7 @@ def _sandbox_test(code: str, timeout: int = 15, document_path: str | None = None
     #      PositionBySupport attachment failures, topological naming mismatches)
     #   2. Features that build a null/invalid Shape without raising
     harness = '''import sys, json, traceback
+{collect_fn_src}
 result = {{"ok": False, "error": ""}}
 try:
     import FreeCAD as App
@@ -140,14 +175,42 @@ try:
     except ImportError:
         pass
 {open_block}
+
+    # Per-object problem snapshot — shared by the baseline (pre-code) and the
+    # post-execution walk so both judge invalidity identically.
+    def _snap(_obj):
+        _null = False
+        _invalid = False
+        _shape = getattr(_obj, "Shape", None)
+        if _shape is not None:
+            try:
+                _null = bool(_shape.isNull())
+                _invalid = (not _null) and (not _shape.isValid())
+            except Exception:
+                pass
+        _state = getattr(_obj, "State", None)
+        _bad_state = bool(_state and "Invalid" in _state)
+        return {{"name": _obj.Name, "null": _null,
+                 "invalid": _invalid, "invalid_state": _bad_state}}
+
+    # Baseline: objects already broken in the opened document BEFORE user code
+    # runs. The sandbox dry-runs against a copy of the saved document, so an
+    # imported-and-converted mesh→solid that OCC considers invalid is present
+    # on every run; without this snapshot it would fail unrelated code.
+    _baseline_bad = set()
+    for _obj in doc.Objects:
+        _s = _snap(_obj)
+        if _s["null"] or _s["invalid"] or _s["invalid_state"]:
+            _baseline_bad.add(_s["name"])
+
     # --- user code ---
 {indented_code}
     # --- end user code ---
     doc.recompute()
 
-    # Post-execution validation: collect console errors + walk objects for
-    # null/invalid shapes. Either signal means the code "ran" but broke the
-    # model — exactly the case where Python-exception-only checking fails.
+    # Post-execution validation: collect console errors + flag only the shapes
+    # this code created or newly broke. Either signal means the code "ran" but
+    # broke the model — the case where Python-exception-only checking fails.
     _issues = []
     if _observer_installed:
         # De-dup — C++ logs the same error per failed recompute iteration
@@ -156,19 +219,8 @@ try:
             if _e and _e not in _seen:
                 _seen.add(_e)
                 _issues.append("FreeCAD error: " + _e)
-    for _obj in doc.Objects:
-        _shape = getattr(_obj, "Shape", None)
-        if _shape is not None:
-            try:
-                if _shape.isNull():
-                    _issues.append("Object '" + _obj.Name + "' has null shape")
-                elif not _shape.isValid():
-                    _issues.append("Object '" + _obj.Name + "' has invalid shape")
-            except Exception:
-                pass
-        _state = getattr(_obj, "State", None)
-        if _state and "Invalid" in _state:
-            _issues.append("Object '" + _obj.Name + "' is in Invalid state")
+    _objects_state = [_snap(_obj) for _obj in doc.Objects]
+    _issues.extend(_collect_object_issues(_objects_state, _baseline_bad))
 
     if _issues:
         result["error"] = "Post-execution validation found issues:\\n" + "\\n".join(_issues)
@@ -186,6 +238,7 @@ finally:
     with open({result_path!r}, "w") as f:
         json.dump(result, f)
 '''.format(
+        collect_fn_src=inspect.getsource(_collect_object_issues),
         open_block=open_block,
         indented_code="\n".join("    " + line for line in code.splitlines()),
         result_path=result_file,

--- a/tests/integration/test_sandbox_validation.py
+++ b/tests/integration/test_sandbox_validation.py
@@ -6,6 +6,10 @@ not found") or built null/invalid shapes was reported as safe because no
 Python exception was raised during recompute.
 """
 
+import os
+import subprocess
+import tempfile
+
 import pytest
 
 from freecad_ai.core.executor import _sandbox_test, _find_freecad_cmd
@@ -17,6 +21,51 @@ pytestmark = pytest.mark.integration
 def freecad_available():
     if not _find_freecad_cmd():
         pytest.skip("No FreeCAD binary available for sandbox tests")
+
+
+# A solid built from an open (non-watertight) shell is OCC-invalid — the same
+# class of invalidity an imported-and-converted STL mesh→solid produces.
+_INVALID_SOLID = (
+    "import Part\n"
+    "box = Part.makeBox(10, 10, 10)\n"
+    "bad = Part.Solid(Part.Shell(box.Faces[:-1]))\n"
+    "f = doc.addObject('Part::Feature', 'BadImport')\n"
+    "f.Shape = bad\n"
+)
+
+
+@pytest.fixture
+def doc_with_invalid_solid(freecad_available):
+    """Path to a saved .FCStd containing a pre-existing OCC-invalid solid."""
+    fd, doc_path = tempfile.mkstemp(suffix=".FCStd")
+    os.close(fd)
+    os.unlink(doc_path)  # FreeCAD writes it fresh
+    builder = (
+        "import FreeCAD as App, Part\n"
+        "doc = App.newDocument('Inv')\n"
+        "box = Part.makeBox(10, 10, 10)\n"
+        "bad = Part.Solid(Part.Shell(box.Faces[:-1]))\n"
+        "f = doc.addObject('Part::Feature', 'BadImport')\n"
+        "f.Shape = bad\n"
+        "doc.saveAs(" + repr(doc_path) + ")\n"
+        "exit(0)\n"
+    )
+    script = tempfile.mktemp(suffix=".py")
+    with open(script, "w") as fh:
+        fh.write(builder)
+    subprocess.run(
+        [_find_freecad_cmd(), "-c", script],
+        capture_output=True,
+        env={**os.environ, "QT_QPA_PLATFORM": "offscreen"},
+        timeout=120,
+    )
+    assert os.path.isfile(doc_path), "fixture failed to save the invalid document"
+    yield doc_path
+    for p in (doc_path, script):
+        try:
+            os.unlink(p)
+        except OSError:
+            pass
 
 
 class TestSandboxPostExecValidation:
@@ -45,3 +94,36 @@ class TestSandboxPostExecValidation:
         ok, err = _sandbox_test(code, timeout=30)
         assert ok is False, "Sandbox should catch bad attachment"
         assert err, "Sandbox failure must include a reason"
+
+
+class TestSandboxIgnoresPreexistingInvalidity:
+    """Regression: the sandbox opens a copy of the saved document, so a
+    pre-existing OCC-invalid object (e.g. an imported mesh→solid) is present
+    on every dry-run. Code that never touched it — like a sketch on a selected
+    face — was failed by the post-execution validator and the model chased a
+    phantom bug across all retries. The validator must blame the code only for
+    shapes it creates or newly breaks.
+    """
+
+    def test_unrelated_code_passes_despite_preexisting_invalid_solid(
+        self, doc_with_invalid_solid
+    ):
+        # Clean, unrelated code added to a document that already contains an
+        # invalid solid must pass — the invalid solid is not this code's fault.
+        clean = (
+            "import Part\n"
+            "newf = doc.addObject('Part::Feature', 'CleanBox')\n"
+            "newf.Shape = Part.makeBox(5, 5, 5)\n"
+        )
+        ok, err = _sandbox_test(clean, timeout=90, document_path=doc_with_invalid_solid)
+        assert ok is True, (
+            "unrelated valid code must not be failed by a pre-existing invalid "
+            "object; got err=" + err
+        )
+
+    def test_newly_created_invalid_shape_still_caught(self, freecad_available):
+        # Negative control: a NEW invalid object the code creates is still its
+        # fault and must be reported, fix or no fix.
+        ok, err = _sandbox_test(_INVALID_SOLID, timeout=90)
+        assert ok is False, "a newly-created invalid shape must still fail"
+        assert "invalid shape" in err, "failure must name the invalid shape"

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -254,3 +254,76 @@ class TestSandboxTimeout:
             "sandbox dry-run was throttled below the configured execution "
             "timeout — slow-but-valid code will falsely time out"
         )
+
+
+class TestCollectObjectIssues:
+    """Post-execution validation must blame the code only for shapes it
+    created or newly broke — never for objects that were already invalid
+    before the code ran.
+
+    Issue: an STL imported and converted to a solid yields an OCC-invalid
+    Part::Feature. The sandbox opens a copy of the saved document, so that
+    pre-existing invalid solid is present on every dry-run. The validator
+    used to walk *all* objects and report it, failing code (e.g. a sketch on
+    a selected face) that never touched the solid — sending the model to
+    chase a phantom bug across all retries.
+    """
+
+    def test_preexisting_invalid_shape_is_suppressed(self):
+        # The imported mesh→solid was already invalid before the code ran.
+        objects_state = [
+            {"name": "roundedBox_solid", "null": False,
+             "invalid": True, "invalid_state": False},
+        ]
+        baseline_bad = {"roundedBox_solid"}
+        issues = executor._collect_object_issues(objects_state, baseline_bad)
+        assert issues == [], (
+            "code that never touched a pre-existing invalid object must not "
+            "be blamed for it"
+        )
+
+    def test_newly_created_invalid_object_is_reported(self):
+        # A brand-new object the code created has a broken shape — its fault.
+        objects_state = [
+            {"name": "roundedBox_solid", "null": False,
+             "invalid": True, "invalid_state": False},
+            {"name": "SnapFitBox", "null": False,
+             "invalid": True, "invalid_state": False},
+        ]
+        baseline_bad = {"roundedBox_solid"}
+        issues = executor._collect_object_issues(objects_state, baseline_bad)
+        assert issues == ["Object 'SnapFitBox' has invalid shape"]
+
+    def test_object_newly_broken_by_code_is_reported(self):
+        # Object existed and was fine before; the code broke it.
+        objects_state = [
+            {"name": "Pad", "null": False,
+             "invalid": True, "invalid_state": False},
+        ]
+        baseline_bad = set()  # Pad was valid before the code ran
+        issues = executor._collect_object_issues(objects_state, baseline_bad)
+        assert issues == ["Object 'Pad' has invalid shape"]
+
+    def test_null_shape_on_new_object_is_reported(self):
+        objects_state = [
+            {"name": "Pocket", "null": True,
+             "invalid": False, "invalid_state": False},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == ["Object 'Pocket' has null shape"]
+
+    def test_invalid_state_on_new_object_is_reported(self):
+        objects_state = [
+            {"name": "Sketch", "null": False,
+             "invalid": False, "invalid_state": True},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == ["Object 'Sketch' is in Invalid state"]
+
+    def test_valid_object_never_reported(self):
+        objects_state = [
+            {"name": "Box", "null": False,
+             "invalid": False, "invalid_state": False},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == []


### PR DESCRIPTION
Fixes the sandbox over-reporting diagnosed in #18.

## Problem

`_sandbox_test` (`freecad_ai/core/executor.py`) opens a copy of the saved document, then after running the candidate code walked **every** object in `doc.Objects` and reported any null/invalid shape — with no baseline. So a pre-existing OCC-invalid object (e.g. an imported STL converted to a solid) failed code that never touched it.

In the reported session (@0xrushi, snap-fit on a mesh→solid box), three sketch-on-face attempts all failed with errors naming the imported solid, which the sketch code never modified. Blocked from the structured path, the model fell back to raw `Part.cut` + `Part::Feature`, baking a static shape — the "lost modeling history" symptom. This is distinct from the #17 boolean reparenting fix (there is no `PartDesign::Body` here, and `boolean_operation` was never invoked).

## Fix

Snapshot each object's problem state **before** running the candidate code, then report only objects that are **new** or that the code **newly broke**. Pre-existing invalidity is suppressed.

- Decision extracted into a pure, unit-tested `_collect_object_issues(objects_state, baseline_bad)`.
- The subprocess harness reuses the identical source via `inspect.getsource`, so harness and tests can't drift (the sandbox can't import `freecad_ai`).

## Tests

- **Unit** — `tests/unit/test_executor.py::TestCollectObjectIssues` (6): pre-existing invalid suppressed; new / newly-broken / null / invalid-state still reported.
- **Integration** — `tests/integration/test_sandbox_validation.py::TestSandboxIgnoresPreexistingInvalidity`: saves a `.FCStd` with an invalid open-shell solid, confirms unrelated valid code now passes, and that a *newly* created invalid shape is still caught (negative control).

Verification (local, FreeCAD 1.1.1 headless): integration 4 passed; full unit suite 832 passed (excluding only `test_document_attach.py`, a PySide6 segfault present on clean `master`, unrelated).

## Not in scope (tracked in #18)
- No "sketch on a selected face" path in `create_sketch` (XY/XZ/YZ origin planes only).
- An imported mesh-solid is not a `PartDesign::Body`, so parametric history can't be built onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)