### PR TITLE
feat(create_sketch): attach to faces, datum planes, and the GUI selection

### DIFF
--- a/docs/superpowers/plans/2026-06-02-sketch-on-face-and-plane.md
+++ b/docs/superpowers/plans/2026-06-02-sketch-on-face-and-plane.md
@@ -1,0 +1,749 @@
+# create_sketch on faces and arbitrary planes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `create_sketch` attach a sketch to a planar face of an existing object, to a datum/named plane, or to the current GUI selection — in addition to the existing origin planes — with body-aware placement and clean planar-face validation.
+
+**Architecture:** A pure decision function `_resolve_sketch_attachment(...)` (no FreeCAD) chooses the attachment mode from already-inspected facts. Thin FreeCAD helpers gather those facts (classify the support, find its owning Body, inspect the face, read the selection). The `_handle_create_sketch` `do(doc)` body is rewired to: resolve facts → call the pure resolver → create the sketch in the right container → apply the attachment → offset → recompute. Origin-plane and standalone behavior is preserved.
+
+**Tech Stack:** Python 3.11, FreeCAD 1.1.1 Python API, pytest. Unit tests run without FreeCAD (`env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/`); integration tests need the AppImage (`-m integration`).
+
+**Branch:** `feature/sketch-on-face` (already created; spec committed at `f91832c`).
+
+---
+
+## File structure
+
+- **Modify** `freecad_ai/tools/freecad_tools.py`
+  - Add pure `_resolve_sketch_attachment(...)` near `_handle_create_sketch` (~line 266).
+  - Add FreeCAD helpers `_classify_support`, `_owning_body_name`, `_inspect_face`, `_read_planar_selection`.
+  - Rewire `_handle_create_sketch` `do(doc)` attachment section (current lines ~281–311).
+  - Add `support` + `face` params to `_handle_create_sketch` signature and to the `CREATE_SKETCH` `ToolDefinition` (current lines ~268, ~521–538); extend the tool description.
+- **Create** `tests/unit/test_sketch_attachment.py` — unit tests for the pure resolver + fake-based helper tests.
+- **Modify** `tests/integration/` — add `tests/integration/test_sketch_attachment_integration.py` for real-FreeCAD attachment tests.
+- **Modify** wiki `../freecad-ai-wiki/Tool-Reference.md` — document `support`/`face` (done after code, separate commit).
+
+---
+
+## Task 1: Pure attachment resolver
+
+**Files:**
+- Modify: `freecad_ai/tools/freecad_tools.py` (add function above `_handle_create_sketch`, ~line 266)
+- Test: `tests/unit/test_sketch_attachment.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_sketch_attachment.py`:
+
+```python
+"""Unit tests for the pure create_sketch attachment resolver (no FreeCAD)."""
+
+from freecad_ai.tools.freecad_tools import _resolve_sketch_attachment
+
+
+def _resolve(**kw):
+    base = dict(
+        support="", face="", plane="XY", body_present=False,
+        support_kind="", face_exists=False, face_planar=False, in_body=None,
+    )
+    base.update(kw)
+    return _resolve_sketch_attachment(**base)
+
+
+class TestResolveSketchAttachment:
+    # --- explicit face ---
+    def test_planar_face_on_solid_resolves_to_face_mode(self):
+        spec = _resolve(support="Box", face="Face6", support_kind="solid",
+                        face_exists=True, face_planar=True, in_body="Body")
+        assert spec == {"mode": "face", "support": "Box", "sub": "Face6",
+                        "in_body": "Body"}
+
+    def test_face_on_standalone_solid_has_no_body(self):
+        spec = _resolve(support="Imported", face="Face3", support_kind="solid",
+                        face_exists=True, face_planar=True, in_body=None)
+        assert spec["mode"] == "face"
+        assert spec["in_body"] is None
+
+    def test_missing_face_is_error(self):
+        spec = _resolve(support="Box", face="Face99", support_kind="solid",
+                        face_exists=False)
+        assert spec["mode"] == "error"
+        assert "Face99" in spec["message"]
+
+    def test_non_planar_face_is_error(self):
+        spec = _resolve(support="Cyl", face="Face1", support_kind="solid",
+                        face_exists=True, face_planar=False)
+        assert spec["mode"] == "error"
+        assert "planar" in spec["message"].lower()
+
+    # --- explicit plane ---
+    def test_plane_support_without_face_resolves_to_plane_mode(self):
+        spec = _resolve(support="DatumPlane", support_kind="plane", in_body="Body")
+        assert spec == {"mode": "plane", "support": "DatumPlane", "in_body": "Body"}
+
+    # --- validation ---
+    def test_face_without_support_is_error(self):
+        spec = _resolve(face="Face6")  # support empty
+        assert spec["mode"] == "error"
+        assert "support" in spec["message"].lower()
+
+    def test_missing_support_is_error(self):
+        spec = _resolve(support="Nope", support_kind="missing")
+        assert spec["mode"] == "error"
+        assert "not found" in spec["message"].lower()
+
+    def test_solid_support_without_face_is_error(self):
+        spec = _resolve(support="Box", support_kind="solid")
+        assert spec["mode"] == "error"
+        assert "face" in spec["message"].lower()
+
+    # --- fall-through to current behavior ---
+    def test_no_support_with_body_and_origin_plane(self):
+        spec = _resolve(plane="XZ", body_present=True)
+        assert spec == {"mode": "origin", "plane": "XZ"}
+
+    def test_no_support_no_body_is_standalone(self):
+        spec = _resolve(plane="XY", body_present=False)
+        assert spec == {"mode": "standalone"}
+
+    def test_origin_plane_is_case_insensitive(self):
+        spec = _resolve(plane="xy", body_present=True)
+        assert spec == {"mode": "origin", "plane": "XY"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_sketch_attachment.py -q`
+Expected: FAIL — `ImportError: cannot import name '_resolve_sketch_attachment'`.
+
+- [ ] **Step 3: Implement the resolver**
+
+In `freecad_ai/tools/freecad_tools.py`, immediately above `# ── create_sketch ───` (~line 266), add:
+
+```python
+def _resolve_sketch_attachment(support, face, plane, body_present,
+                               support_kind, face_exists, face_planar, in_body):
+    """Decide where a sketch attaches. Pure — no FreeCAD calls.
+
+    Inputs are already-inspected facts so this is unit-testable. When the
+    GUI-selection fallback is used, the caller passes the selected object as
+    ``support`` and its planar face as ``face`` — selection collapses into the
+    same inputs as the explicit params.
+
+    ``support_kind``: ``""`` (no support given and no usable selection),
+    else ``"missing"`` | ``"plane"`` | ``"solid"`` | ``"other"``.
+    ``face_exists`` / ``face_planar`` are meaningful only when ``face`` != "".
+    ``in_body`` is the Body name owning the support, or ``None``.
+
+    Returns one of:
+      {"mode": "face", "support": str, "sub": str, "in_body": str|None}
+      {"mode": "plane", "support": str, "in_body": str|None}
+      {"mode": "origin", "plane": str}
+      {"mode": "standalone"}
+      {"mode": "error", "message": str}
+    """
+    if face and not support:
+        return {"mode": "error", "message": "`face` requires `support`."}
+
+    if support_kind == "missing":
+        return {"mode": "error", "message": f"Object '{support}' not found."}
+
+    if support_kind in ("plane", "solid", "other"):
+        if face:
+            if not face_exists:
+                return {"mode": "error",
+                        "message": f"Face '{face}' not found on '{support}'."}
+            if not face_planar:
+                return {"mode": "error",
+                        "message": (f"Face '{face}' on '{support}' is not planar; "
+                                    "sketches need a planar face.")}
+            return {"mode": "face", "support": support, "sub": face,
+                    "in_body": in_body}
+        if support_kind == "plane":
+            return {"mode": "plane", "support": support, "in_body": in_body}
+        return {"mode": "error",
+                "message": (f"`support` '{support}' is a solid; specify a `face` "
+                            "(e.g. 'Face6'), or pass a datum/origin plane as "
+                            "`support`.")}
+
+    # No support / no usable selection — original behavior.
+    if body_present and plane.upper() in ("XY", "XZ", "YZ"):
+        return {"mode": "origin", "plane": plane.upper()}
+    return {"mode": "standalone"}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_sketch_attachment.py -q`
+Expected: PASS (12 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add freecad_ai/tools/freecad_tools.py tests/unit/test_sketch_attachment.py
+git commit -m "feat(create_sketch): pure attachment resolver"
+```
+
+---
+
+## Task 2: FreeCAD fact-gathering helpers
+
+These translate live FreeCAD objects into the plain facts the resolver needs.
+`_classify_support` and `_owning_body_name` are testable with lightweight fakes;
+`_inspect_face` and `_read_planar_selection` are exercised by the integration
+tests in Task 4.
+
+**Files:**
+- Modify: `freecad_ai/tools/freecad_tools.py` (add helpers below `_resolve_sketch_attachment`)
+- Test: `tests/unit/test_sketch_attachment.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/test_sketch_attachment.py`:
+
+```python
+from freecad_ai.tools.freecad_tools import _classify_support, _owning_body_name
+
+
+class _FakeObj:
+    def __init__(self, type_id, name="Obj", has_solids=False, group_of=None):
+        self.TypeId = type_id
+        self.Name = name
+        self._has_solids = has_solids
+        # FreeCAD groups expose .Group; a Body lists its children there.
+        if group_of is not None:
+            self.Group = group_of
+
+    @property
+    def Shape(self):
+        class _S:
+            Solids = [1] if self._has_solids else []
+        return _S()
+
+
+class TestClassifySupport:
+    def test_datum_plane_is_plane(self):
+        assert _classify_support(_FakeObj("PartDesign::Plane")) == "plane"
+
+    def test_origin_app_plane_is_plane(self):
+        assert _classify_support(_FakeObj("App::Plane")) == "plane"
+
+    def test_part_datum_plane_is_plane(self):
+        assert _classify_support(_FakeObj("Part::DatumPlane")) == "plane"
+
+    def test_solid_feature_is_solid(self):
+        assert _classify_support(
+            _FakeObj("Part::Feature", has_solids=True)) == "solid"
+
+    def test_feature_without_solids_is_other(self):
+        assert _classify_support(
+            _FakeObj("Part::Feature", has_solids=False)) == "other"
+
+    def test_sketch_is_other(self):
+        assert _classify_support(_FakeObj("Sketcher::SketchObject")) == "other"
+
+
+class TestOwningBodyName:
+    def test_object_in_body_returns_body_name(self):
+        child = _FakeObj("PartDesign::Pad", name="Pad")
+        body = _FakeObj("PartDesign::Body", name="Body", group_of=[child])
+        # The fake document is just the list of objects to scan.
+        assert _owning_body_name(child, [body, child]) == "Body"
+
+    def test_standalone_object_returns_none(self):
+        feat = _FakeObj("Part::Feature", name="Imported")
+        assert _owning_body_name(feat, [feat]) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_sketch_attachment.py -q`
+Expected: FAIL — `ImportError` for `_classify_support` / `_owning_body_name`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Add below `_resolve_sketch_attachment` in `freecad_ai/tools/freecad_tools.py`:
+
+```python
+_PLANE_TYPE_IDS = ("App::Plane", "PartDesign::Plane", "Part::DatumPlane")
+
+
+def _classify_support(obj):
+    """Classify a support object for sketch attachment.
+
+    Returns 'plane' for origin/datum planes, 'solid' for shapes with solids,
+    'other' for everything else (sketches, wires, empty features).
+    """
+    if getattr(obj, "TypeId", "") in _PLANE_TYPE_IDS:
+        return "plane"
+    shape = getattr(obj, "Shape", None)
+    try:
+        if shape is not None and shape.Solids:
+            return "solid"
+    except Exception:
+        pass
+    return "other"
+
+
+def _owning_body_name(obj, objects):
+    """Return the Name of the PartDesign::Body that contains ``obj``, or None.
+
+    ``objects`` is the document's object list (``doc.Objects``). A Body lists
+    its children in ``.Group``.
+    """
+    for cand in objects:
+        if getattr(cand, "TypeId", "") != "PartDesign::Body":
+            continue
+        try:
+            if any(getattr(c, "Name", None) == obj.Name for c in cand.Group):
+                return cand.Name
+        except Exception:
+            pass
+    return None
+
+
+def _inspect_face(obj, face_name):
+    """Return (exists, planar) for ``face_name`` on ``obj``'s shape.
+
+    Never raises — a missing face or non-shape object yields (False, False).
+    """
+    import Part
+    try:
+        face = obj.Shape.getElement(face_name)
+    except Exception:
+        return (False, False)
+    if face is None or face.ShapeType != "Face":
+        return (False, False)
+    try:
+        return (True, isinstance(face.Surface, Part.Plane))
+    except Exception:
+        return (True, False)
+
+
+def _read_planar_selection():
+    """Return (object_name, sub_element) for the first usable planar-face or
+    plane selection in the GUI, or None.
+
+    Used as a fallback when create_sketch is called with no support/face. Any
+    error or non-usable selection (edge, vertex, nothing, non-planar face)
+    returns None so the caller falls through to default behavior.
+    """
+    try:
+        import FreeCADGui as Gui
+        import Part
+    except Exception:
+        return None
+    try:
+        sel = Gui.Selection.getSelectionEx()
+    except Exception:
+        return None
+    for s in sel or []:
+        obj = getattr(s, "Object", None)
+        if obj is None:
+            continue
+        subs = getattr(s, "SubElementNames", None) or []
+        if subs:
+            sub = subs[0]
+            try:
+                el = obj.Shape.getElement(sub)
+                if (el is not None and el.ShapeType == "Face"
+                        and isinstance(el.Surface, Part.Plane)):
+                    return (obj.Name, sub)
+            except Exception:
+                continue
+        elif getattr(obj, "TypeId", "") in _PLANE_TYPE_IDS:
+            return (obj.Name, "")
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_sketch_attachment.py -q`
+Expected: PASS (20 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add freecad_ai/tools/freecad_tools.py tests/unit/test_sketch_attachment.py
+git commit -m "feat(create_sketch): FreeCAD fact-gathering helpers for attachment"
+```
+
+---
+
+## Task 3: Wire params and rewire the handler
+
+**Files:**
+- Modify: `freecad_ai/tools/freecad_tools.py` — `_handle_create_sketch` signature (~line 268), attachment section (~lines 281–311), and the `CREATE_SKETCH` `ToolDefinition` (~lines 506–540).
+
+- [ ] **Step 1: Add the two params to the handler signature**
+
+Change (current ~line 268):
+
+```python
+def _handle_create_sketch(
+    plane: str = "XY",
+    body_name: str = "",
+    geometries: list | None = None,
+    constraints: list | None = None,
+    label: str = "",
+    offset: float = 0.0,
+) -> ToolResult:
+```
+
+to:
+
+```python
+def _handle_create_sketch(
+    plane: str = "XY",
+    body_name: str = "",
+    geometries: list | None = None,
+    constraints: list | None = None,
+    label: str = "",
+    offset: float = 0.0,
+    support: str = "",
+    face: str = "",
+) -> ToolResult:
+```
+
+- [ ] **Step 2: Rewire the attachment section**
+
+Replace the current block (from `body = None` through `doc.recompute()` that
+precedes the `geo_count = 0` line — current lines ~282–311):
+
+```python
+        body = None
+        if body_name:
+            body = _get_object(doc, body_name)
+            if not body:
+                hint = _suggest_similar(doc, body_name, "Body")
+                return ToolResult(success=False, output="", error=f"Body '{body_name}' not found.{hint}")
+
+        if body:
+            sketch = body.newObject("Sketcher::SketchObject", label or "Sketch")
+        else:
+            sketch = doc.addObject("Sketcher::SketchObject", label or "Sketch")
+
+        # Attach to plane
+        if body and plane.upper() in ("XY", "XZ", "YZ"):
+            plane_feat = _get_body_plane(body, plane.upper())
+            if plane_feat:
+                sketch.AttachmentSupport = [(plane_feat, "")]
+                sketch.MapMode = "FlatFace"
+
+        # Offset the sketch along the plane normal
+        if offset != 0:
+            offset_map = {
+                "XY": App.Vector(0, 0, offset),
+                "XZ": App.Vector(0, offset, 0),
+                "YZ": App.Vector(offset, 0, 0),
+            }
+            ovec = offset_map.get(plane.upper(), App.Vector(0, 0, offset))
+            sketch.AttachmentOffset = App.Placement(ovec, App.Rotation())
+
+        doc.recompute()
+```
+
+with:
+
+```python
+        warnings = []
+
+        body = None
+        if body_name:
+            body = _get_object(doc, body_name)
+            if not body:
+                hint = _suggest_similar(doc, body_name, "Body")
+                return ToolResult(success=False, output="", error=f"Body '{body_name}' not found.{hint}")
+
+        # Gather attachment facts from explicit params, or fall back to the GUI
+        # selection when neither support nor face was given.
+        sup, fc = support, face
+        if not sup and not fc:
+            picked = _read_planar_selection()
+            if picked:
+                sup, fc = picked
+
+        sup_kind = ""
+        face_exists = face_planar = False
+        in_body = None
+        if sup:
+            sup_obj = _get_object(doc, sup)
+            if sup_obj is None:
+                sup_kind = "missing"
+            else:
+                sup = sup_obj.Name
+                sup_kind = _classify_support(sup_obj)
+                in_body = _owning_body_name(sup_obj, doc.Objects)
+                if fc:
+                    face_exists, face_planar = _inspect_face(sup_obj, fc)
+
+        spec = _resolve_sketch_attachment(
+            sup, fc, plane, body is not None,
+            sup_kind, face_exists, face_planar, in_body,
+        )
+        if spec["mode"] == "error":
+            hint = _suggest_similar(doc, support) if sup_kind == "missing" else ""
+            return ToolResult(success=False, output="", error=spec["message"] + hint)
+
+        # Choose the container the sketch is created in.
+        if spec["mode"] in ("face", "plane"):
+            if body_name:
+                warnings.append("body_name ignored — sketch placed relative to support.")
+            container = _get_object(doc, spec["in_body"]) if spec.get("in_body") else None
+        elif spec["mode"] == "origin":
+            container = body
+        else:  # standalone
+            container = body
+
+        if container is not None:
+            sketch = container.newObject("Sketcher::SketchObject", label or "Sketch")
+        else:
+            sketch = doc.addObject("Sketcher::SketchObject", label or "Sketch")
+
+        # Apply the attachment.
+        if spec["mode"] == "face":
+            sketch.AttachmentSupport = [(_get_object(doc, spec["support"]), spec["sub"])]
+            sketch.MapMode = "FlatFace"
+        elif spec["mode"] == "plane":
+            sketch.AttachmentSupport = [(_get_object(doc, spec["support"]), "")]
+            sketch.MapMode = "FlatFace"
+        elif spec["mode"] == "origin":
+            plane_feat = _get_body_plane(container, spec["plane"])
+            if plane_feat:
+                sketch.AttachmentSupport = [(plane_feat, "")]
+                sketch.MapMode = "FlatFace"
+
+        # Offset along the attachment normal. For face/plane attachments the
+        # sketch's local Z is the face/plane normal, so offset is (0,0,offset).
+        # For origin planes keep the explicit per-plane vector.
+        if offset != 0:
+            if spec["mode"] in ("face", "plane"):
+                sketch.AttachmentOffset = App.Placement(
+                    App.Vector(0, 0, offset), App.Rotation())
+            else:
+                offset_map = {
+                    "XY": App.Vector(0, 0, offset),
+                    "XZ": App.Vector(0, offset, 0),
+                    "YZ": App.Vector(offset, 0, 0),
+                }
+                ovec = offset_map.get(plane.upper(), App.Vector(0, 0, offset))
+                sketch.AttachmentOffset = App.Placement(ovec, App.Rotation())
+
+        doc.recompute()
+
+        # Verify a face/plane attachment actually resolved (no silent failure).
+        if spec["mode"] in ("face", "plane"):
+            try:
+                placement_ok = sketch.Placement is not None and (
+                    sketch.MapMode == "FlatFace")
+            except Exception:
+                placement_ok = False
+            if not placement_ok:
+                return ToolResult(
+                    success=False, output="",
+                    error=(f"Failed to attach sketch to '{spec['support']}'"
+                           + (f":{spec['sub']}" if spec.get('sub') else "")
+                           + " — attachment did not resolve."))
+```
+
+- [ ] **Step 3: Surface warnings in the success result**
+
+In the final `return ToolResult(success=True, ...)` of `do(doc)` (current ~line 491), prepend any warnings to the output. Change the `output=(...)` argument so it begins with:
+
+```python
+            output=(
+                ("⚠ " + " ".join(warnings) + "\n" if warnings else "")
+                + f"Created sketch '{sketch.Name}' with {geo_count} geometries"
+                f" and {constraint_count} constraints.{constraint_status}"
+                f"{constraint_info}"
+                f"\nUse sketch_name='{sketch.Name}' in pad_sketch/pocket_sketch."),
+```
+
+- [ ] **Step 4: Add the params to the ToolDefinition + extend the description**
+
+In `CREATE_SKETCH` (current ~line 506), add to the `parameters=[...]` list (after the `offset` param):
+
+```python
+        ToolParam("support", "string",
+                  "Object to attach the sketch to: a solid (with `face`) or a "
+                  "datum/origin plane object (by name). Overrides `plane`. If "
+                  "omitted and a planar face/plane is selected in the viewport, "
+                  "that selection is used.",
+                  required=False, default=""),
+        ToolParam("face", "string",
+                  "Planar sub-element of `support` to sketch on, e.g. 'Face6'. "
+                  "Get face names from list_faces. Requires `support`. The face "
+                  "must be planar.",
+                  required=False, default=""),
+```
+
+And append to the `description=(...)` string (before the closing `)`):
+
+```python
+        " To sketch on an existing solid's planar face, pass support='Obj' and "
+        "face='Face6' (use list_faces to find the name); to sketch on a datum "
+        "plane pass support='PlaneName'. Without support, attaches to the origin "
+        "`plane` (XY/XZ/YZ) as before."
+```
+
+- [ ] **Step 5: Run the unit suite to confirm nothing regressed**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_sketch_attachment.py tests/unit/test_new_tools.py tests/unit/test_registry.py -q`
+Expected: PASS (no failures; resolver tests still green, tool registry still loads).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add freecad_ai/tools/freecad_tools.py
+git commit -m "feat(create_sketch): attach to faces, datum planes, and selection"
+```
+
+---
+
+## Task 4: Integration tests (real FreeCAD)
+
+**Files:**
+- Create: `tests/integration/test_sketch_attachment_integration.py`
+
+- [ ] **Step 1: Write the integration tests**
+
+```python
+"""Integration tests for create_sketch face/plane attachment (needs FreeCAD)."""
+
+import pytest
+
+from freecad_ai.core.executor import _find_freecad_cmd
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def freecad_available():
+    if not _find_freecad_cmd():
+        pytest.skip("No FreeCAD binary available")
+
+
+@pytest.fixture
+def doc(freecad_available):
+    import FreeCAD as App
+    d = App.newDocument("SketchAttachTest")
+    yield d
+    App.closeDocument(d.Name)
+
+
+def _run(**kwargs):
+    from freecad_ai.tools.freecad_tools import _handle_create_sketch
+    return _handle_create_sketch(**kwargs)
+
+
+class TestCreateSketchAttachment:
+    def test_sketch_on_box_face_attaches(self, doc):
+        import Part
+        feat = doc.addObject("Part::Feature", "Box")
+        feat.Shape = Part.makeBox(10, 10, 10)
+        doc.recompute()
+        res = _run(support="Box", face="Face6")
+        assert res.success, res.error
+        sk = doc.getObject(res.data["name"])
+        assert sk.MapMode == "FlatFace"
+        assert sk.AttachmentSupport  # non-empty
+
+    def test_sketch_on_standalone_solid_face_is_standalone(self, doc):
+        import Part
+        feat = doc.addObject("Part::Feature", "Imported")
+        feat.Shape = Part.makeBox(8, 8, 8)
+        doc.recompute()
+        res = _run(support="Imported", face="Face1")
+        assert res.success, res.error
+        sk = doc.getObject(res.data["name"])
+        # Not inside a Body, but attached to the face.
+        assert sk.MapMode == "FlatFace"
+
+    def test_sketch_on_datum_plane_by_name(self, doc):
+        body = doc.addObject("PartDesign::Body", "Body")
+        dp = body.newObject("PartDesign::Plane", "DatumPlane")
+        doc.recompute()
+        res = _run(support="DatumPlane")
+        assert res.success, res.error
+        sk = doc.getObject(res.data["name"])
+        assert sk.MapMode == "FlatFace"
+
+    def test_non_planar_face_errors_cleanly(self, doc):
+        import Part
+        feat = doc.addObject("Part::Feature", "Cyl")
+        feat.Shape = Part.makeCylinder(5, 10)
+        doc.recompute()
+        # Face1 of a cylinder is the curved lateral surface.
+        res = _run(support="Cyl", face="Face1")
+        assert not res.success
+        assert "planar" in res.error.lower()
+
+    def test_missing_support_errors(self, doc):
+        res = _run(support="DoesNotExist", face="Face1")
+        assert not res.success
+        assert "not found" in res.error.lower()
+
+    def test_origin_plane_still_works(self, doc):
+        body = doc.addObject("PartDesign::Body", "Body")
+        doc.recompute()
+        res = _run(plane="XZ", body_name="Body")
+        assert res.success, res.error
+        sk = doc.getObject(res.data["name"])
+        assert sk.MapMode == "FlatFace"
+
+    def test_standalone_sketch_still_works(self, doc):
+        res = _run(plane="XY")
+        assert res.success, res.error
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/integration/test_sketch_attachment_integration.py -m integration -v`
+Expected: PASS (7 passed). If `Face6`/`Face1` indexing differs on this FreeCAD build, adjust the face name using a quick `list_faces`-style probe, but a `Part.makeBox` has 6 planar faces so any `FaceN` (N=1..6) is planar.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_sketch_attachment_integration.py
+git commit -m "test(create_sketch): integration tests for face/plane attachment"
+```
+
+---
+
+## Task 5: Docs — tool description verification and wiki
+
+**Files:**
+- Modify: `../freecad-ai-wiki/Tool-Reference.md` (the wiki is a sibling repo per project memory)
+
+- [ ] **Step 1: Confirm the in-code description renders**
+
+Run: `env -u PYTHONPATH .venv/bin/python -c "from freecad_ai.tools.freecad_tools import CREATE_SKETCH; print(CREATE_SKETCH.description); print([p.name for p in CREATE_SKETCH.parameters])"`
+Expected: description mentions `support`/`face`; param list includes `support` and `face`.
+
+- [ ] **Step 2: Update the wiki `create_sketch` entry**
+
+In `../freecad-ai-wiki/Tool-Reference.md`, find the `create_sketch` section and add the `support` and `face` parameters to its parameter table, plus a short note:
+
+> `support` + `face` attach the sketch to a planar face of an existing object
+> (e.g. `support="Box", face="Face6"` — get the name from `list_faces`).
+> `support` alone attaches to a datum/origin plane object by name. With no
+> `support`, the sketch uses the origin `plane` (XY/XZ/YZ) as before, or the
+> current planar-face selection if one exists. The face must be planar.
+
+- [ ] **Step 3: Commit the wiki (in the wiki repo)**
+
+```bash
+cd ../freecad-ai-wiki
+git add Tool-Reference.md
+git commit -m "docs(tool-reference): create_sketch support/face attachment"
+cd -
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Goals 1–3 (face / plane / selection) → Tasks 1–4. Body handling → Task 3 (container selection + `in_body`). Validation/errors → resolver (Task 1) + handler verification (Task 3) + integration (Task 4). Testing section → Tasks 1, 2, 4. Backward compat → resolver fall-through + `test_origin_plane_still_works` / `test_standalone_sketch_still_works`.
+- **Deviations from spec (flagged to user, spec updated):** empty/unusable selection falls through to current behavior (not an error); `body_name` + `support` together → warning, not hard error.
+- **Type consistency:** the resolver's returned dict keys (`mode`, `support`, `sub`, `in_body`, `plane`, `message`) are used consistently in Task 3's handler branches. Helper names (`_classify_support`, `_owning_body_name`, `_inspect_face`, `_read_planar_selection`) match between definition (Task 2) and use (Task 3).
+- **No placeholders:** every code step shows complete code.

--- a/docs/superpowers/specs/2026-06-02-sketch-on-face-and-plane-design.md
+++ b/docs/superpowers/specs/2026-06-02-sketch-on-face-and-plane-design.md
@@ -1,0 +1,178 @@
+# Design: create_sketch on faces and arbitrary planes
+
+- **Date:** 2026-06-02
+- **Status:** Approved design, pending implementation plan
+- **Scope:** Piece #1 of a small datum-geometry/transform suite (see Roadmap).
+
+## Background
+
+`create_sketch` (`freecad_tools.py:268`, def `_handle_create_sketch`) can only
+place a sketch on one of the three **origin planes**. The `plane` parameter is
+enum-restricted to `XY`/`XZ`/`YZ` (`freecad_tools.py:522`), and attachment only
+happens when a `body_name` is given:
+
+```python
+if body and plane.upper() in ("XY", "XZ", "YZ"):
+    plane_feat = _get_body_plane(body, plane.upper())
+    if plane_feat:
+        sketch.AttachmentSupport = [(plane_feat, "")]
+        sketch.MapMode = "FlatFace"
+```
+
+`_get_body_plane` hard-maps only those three names into `body.Origin.OriginFeatures`;
+anything else returns `None`. There is no way to:
+
+- sketch on an arbitrary **planar face** of an existing solid, or
+- sketch on a **datum/named plane**.
+
+This gap is what blocked the issue #18 / #17-followup snap-fit workflow:
+@0xrushi selected a face on an imported-and-converted (mesh→solid) part and asked
+for a sketch on it. With no tool path for "sketch on the selected face," the model
+fell out of the structured toolchain into raw `run_macro` Python and ultimately
+baked a static, history-less `Part::Feature`.
+
+The codebase already has the right conventions to build on:
+- A face is referenced as **object name + sub-element**, e.g. `{object: "Box",
+  sub_element: "Face6"}` — returned by `select_geometry` (`freecad_tools.py:4127`)
+  and enumerable via `list_faces` (`freecad_tools.py:1844`).
+- `_get_object(doc, name_or_label)` (`:4345`) resolves Name then Label.
+- `_suggest_similar(doc, name, type_filter)` (`:4392`) produces "did you mean" hints.
+- `_with_undo(label, func)` (`:35`) wraps mutations in an undo transaction.
+
+## Goals
+
+Let `create_sketch` attach a sketch to:
+
+1. **A planar face** of an existing object — `support="Box"`, `face="Face6"`.
+2. **A datum or named plane** — `support="DatumPlane"` (or an origin-plane object),
+   `face=""`.
+3. **The current GUI selection** — when both `support` and `face` are omitted,
+   fall back to the active viewport selection (the literal "sketch on the selected
+   face" flow). This is the only path that needs the GUI; it feeds the same
+   resolution logic as the explicit params.
+
+The existing origin-plane (`plane` ∈ {XY,XZ,YZ}) and standalone behavior is
+preserved unchanged.
+
+## Non-goals
+
+- No non-planar / curved-face sketching. A non-planar `face` is a hard error,
+  not a silent best-effort projection.
+- No new datum-plane creation here — that is piece #2 (`create_datum_plane`),
+  a separate spec. This change only *consumes* a plane referenced by name.
+- No multi-face / averaged-plane attachment. One face or one plane.
+- No change to geometry/constraint handling inside the sketch.
+
+## Parameters
+
+Two new optional params on `create_sketch`; all current params keep their
+current defaults and meaning.
+
+| Param | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `support` | string | `""` | Name/label of the object to attach to: a solid (with `face`) or a plane object (datum/origin). |
+| `face` | string | `""` | Planar sub-element of `support`, e.g. `"Face6"`. Requires `support`. |
+
+`plane`, `body_name`, `geometries`, `constraints`, `label`, `offset` are
+unchanged.
+
+### Attachment resolution order
+
+Resolved by a **pure helper** `_resolve_sketch_attachment(...)` (see Testing),
+which decides *what to attach to* without touching FreeCAD:
+
+1. **Explicit face** — `support` given and `face` non-empty → attach
+   `[(support_obj, face)]`, `MapMode="FlatFace"`.
+2. **Explicit plane** — `support` given, `face` empty, and `support_obj` is a
+   plane (`App::Plane` / `PartDesign::Plane` / `Part::DatumPlane`) → attach
+   `[(support_obj, "")]`, `MapMode="FlatFace"`.
+3. **Selection fallback** — `support` and `face` both empty, and the GUI has a
+   selection → use the first selected `(object, sub_element)`; route through
+   case 1 (face) or case 2 (plane) accordingly.
+4. **Origin plane** — `body` present and `plane` ∈ {XY,XZ,YZ} → current behavior.
+5. **Standalone** — none of the above → sketch at default placement (current
+   behavior).
+
+## Body handling
+
+The body the sketch lands in depends on the support, because a sketch can only
+live in a Body it belongs to:
+
+- If the support object is **inside a `PartDesign::Body`** (walk
+  `obj.getParentGeoFeatureGroup()` / check `body.Group`), create the sketch in
+  that body via `body.newObject(...)`.
+- If the support is a **standalone `Part::Feature`** (an imported mesh→solid, as
+  in #18), create a **standalone** sketch (`doc.addObject(...)`) attached to the
+  face. This is the path that makes the 0xrushi case work — the sketch attaches
+  to the face even though there is no Body.
+- An explicit `body_name` that conflicts with the support's owning body is a
+  clear error rather than a silent mismatch.
+
+`offset` continues to shift the sketch along the resolved plane's normal via
+`AttachmentOffset` (today it is a fixed per-origin-plane vector; for a face/datum
+plane the normal comes from the attachment, so the offset is applied as
+`AttachmentOffset = Placement(Vector(0,0,offset), Rotation())` in the sketch's
+attached frame, whose local Z is the face/plane normal).
+
+## Validation and errors
+
+All failures return `ToolResult(success=False, ...)` with an actionable message;
+none may segfault (per the FreeCAD-API gotchas, bad attachment args can crash).
+
+- `face` given without `support` → error: "`face` requires `support`."
+- `support` not found → error + `_suggest_similar` hint.
+- `support` given, `face` empty, and `support_obj` is **not** a plane (e.g. a
+  solid) → error: "`support` 'X' is a solid; specify a `face` (e.g. 'Face6'),
+  or pass a datum/origin plane as `support`."
+- `face` not found on the support shape (`getElement` raises / missing) → error
+  listing available faces (reuse `list_faces` formatting).
+- `face` exists but is **non-planar** (`face.Surface` is not a `Part.Plane`) →
+  error: "Face 'FaceN' is not planar; sketches need a planar face."
+- Selection fallback with an empty/!-face/!-plane selection → error telling the
+  user to select a planar face or pass `support`/`face`.
+- After attachment, recompute and verify the sketch's placement resolved (the
+  attachment didn't silently fail) before adding geometry.
+
+## Testing
+
+**Pure unit tests (no FreeCAD)** — extract `_resolve_sketch_attachment(...)` that
+takes the params plus lightweight descriptors (support type-id, whether `face`
+is planar, the selection list) and returns a small spec dict, e.g.
+`{"mode": "face", "support": "Box", "sub": "Face6", "in_body": "Body"|None}` or
+`{"mode": "error", "message": "..."}`. Cases:
+- explicit face → face mode;
+- explicit plane (datum/origin object) → plane mode;
+- `face` without `support` → error;
+- non-planar face → error;
+- selection fallback with a planar face → face mode;
+- selection fallback with nothing selected → error;
+- standalone solid vs in-body solid → correct `in_body`;
+- no new args → unchanged origin-plane/standalone behavior (regression guard).
+
+**Integration tests (real FreeCAD, `-m integration`):**
+- sketch on a `Part::Box` face attaches and recomputes valid;
+- sketch on a standalone (imported-style) solid's face → standalone sketch
+  attached (the #18 scenario, minus the invalid geometry);
+- sketch on a datum/origin plane object by name;
+- non-planar face (cylinder side) → clean error, no crash;
+- existing origin-plane call still works (regression).
+
+## Backwards compatibility
+
+- New params default to `""`; existing `create_sketch` calls are byte-for-byte
+  unaffected (same resolution falls through to cases 4/5).
+- `plane` enum stays `XY`/`XZ`/`YZ`. Datum/named planes are reached through
+  `support`, not by overloading `plane`, to avoid ambiguity.
+- Tool description updated to document `support`/`face`, the selection fallback,
+  and the planar-face requirement. Wiki `Tool-Reference.md` updated in the same
+  change.
+
+## Roadmap (context only — not this spec)
+
+This is piece #1. Following pieces get their own specs:
+
+2. `create_datum_plane` — define a `PartDesign::Plane`/`Part::DatumPlane` from an
+   origin/existing plane + offset, or a planar face + offset (no 3-point form).
+3. `create_datum_line` — datum axis from two points or an origin axis + offset.
+4. `transform_object` — add a `copy`/duplicate option and a relative-vs-absolute
+   mode (today it overwrites `Placement` and cannot duplicate).

--- a/docs/superpowers/specs/2026-06-02-sketch-on-face-and-plane-design.md
+++ b/docs/superpowers/specs/2026-06-02-sketch-on-face-and-plane-design.md
@@ -128,8 +128,14 @@ none may segfault (per the FreeCAD-API gotchas, bad attachment args can crash).
   listing available faces (reuse `list_faces` formatting).
 - `face` exists but is **non-planar** (`face.Surface` is not a `Part.Plane`) →
   error: "Face 'FaceN' is not planar; sketches need a planar face."
-- Selection fallback with an empty/!-face/!-plane selection → error telling the
-  user to select a planar face or pass `support`/`face`.
+- Selection fallback only activates when `support`/`face` are both empty **and**
+  a usable planar face or plane is selected. An empty or non-usable selection
+  (edge, vertex, nothing) falls through to the current origin-plane/standalone
+  behavior — it is **not** an error, to preserve backward compatibility for
+  plain `create_sketch(plane=...)` calls made with an unrelated selection active.
+- If `body_name` is passed together with `support`, `body_name` is ignored (the
+  sketch's container is the support's owning Body, or standalone) and a warning
+  is included in the result. This avoids a fragile name-vs-label comparison.
 - After attachment, recompute and verify the sketch's placement resolved (the
   attachment didn't silently fail) before adding geometry.
 

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -352,7 +352,7 @@ def _classify_support(obj):
 def _owning_body_name(obj, objects):
     """Return the Name of the PartDesign::Body that contains ``obj``, or None.
 
-    ``objects`` is the document's object list (``doc.Objects``). A Body lists
+    ``objects`` is an iterable of document objects (e.g. ``doc.Objects``). A Body lists
     its children in ``.Group``.
     """
     for cand in objects:
@@ -369,9 +369,13 @@ def _owning_body_name(obj, objects):
 def _inspect_face(obj, face_name):
     """Return (exists, planar) for ``face_name`` on ``obj``'s shape.
 
-    Never raises — a missing face or non-shape object yields (False, False).
+    Never raises — a missing face, unavailable Part module, or non-shape object
+    yields (False, False).
     """
-    import Part
+    try:
+        import Part
+    except Exception:
+        return (False, False)
     try:
         face = obj.Shape.getElement(face_name)
     except Exception:
@@ -407,14 +411,14 @@ def _read_planar_selection():
             continue
         subs = getattr(s, "SubElementNames", None) or []
         if subs:
-            sub = subs[0]
-            try:
-                el = obj.Shape.getElement(sub)
-                if (el is not None and el.ShapeType == "Face"
-                        and isinstance(el.Surface, Part.Plane)):
-                    return (obj.Name, sub)
-            except Exception:
-                continue
+            for sub in subs:
+                try:
+                    el = obj.Shape.getElement(sub)
+                    if (el is not None and el.ShapeType == "Face"
+                            and isinstance(el.Surface, Part.Plane)):
+                        return (obj.Name, sub)
+                except Exception:
+                    continue
         elif getattr(obj, "TypeId", "") in _PLANE_TYPE_IDS:
             return (obj.Name, "")
     return None

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -284,6 +284,9 @@ def _resolve_sketch_attachment(support, face, plane, body_present,
       {"mode": "standalone"}
       {"mode": "error", "message": str}
     """
+    support = support or ""
+    face = face or ""
+
     if face and not support:
         return {"mode": "error", "message": "`face` requires `support`."}
 
@@ -303,10 +306,22 @@ def _resolve_sketch_attachment(support, face, plane, body_present,
                     "in_body": in_body}
         if support_kind == "plane":
             return {"mode": "plane", "support": support, "in_body": in_body}
+        if support_kind == "solid":
+            return {"mode": "error",
+                    "message": (f"`support` '{support}' is a solid; specify a `face` "
+                                "(e.g. 'Face6'), or pass a datum/origin plane as "
+                                "`support`.")}
+        # support_kind == "other" (e.g. a mesh-derived feature, a wire)
         return {"mode": "error",
-                "message": (f"`support` '{support}' is a solid; specify a `face` "
-                            "(e.g. 'Face6'), or pass a datum/origin plane as "
-                            "`support`.")}
+                "message": (f"`support` '{support}' can't host a sketch on its own; "
+                            "specify a planar `face`, or pass a datum/origin plane "
+                            "as `support`.")}
+
+    if support_kind:
+        # Unknown classification — fail loudly rather than silently falling
+        # through to standalone.
+        return {"mode": "error",
+                "message": f"Unsupported support kind '{support_kind}' for '{support}'."}
 
     # No support / no usable selection — original behavior.
     if body_present and plane.upper() in ("XY", "XZ", "YZ"):

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -433,6 +433,8 @@ def _handle_create_sketch(
     constraints: list | None = None,
     label: str = "",
     offset: float = 0.0,
+    support: str = "",
+    face: str = "",
 ) -> ToolResult:
     """Create a sketch with geometry and constraints."""
     import FreeCAD as App
@@ -440,6 +442,8 @@ def _handle_create_sketch(
     import Sketcher
 
     def do(doc):
+        warnings = []
+
         body = None
         if body_name:
             body = _get_object(doc, body_name)
@@ -447,29 +451,95 @@ def _handle_create_sketch(
                 hint = _suggest_similar(doc, body_name, "Body")
                 return ToolResult(success=False, output="", error=f"Body '{body_name}' not found.{hint}")
 
-        if body:
-            sketch = body.newObject("Sketcher::SketchObject", label or "Sketch")
+        # Gather attachment facts from explicit params, or fall back to the GUI
+        # selection when neither support nor face was given.
+        sup, fc = support, face
+        if not sup and not fc:
+            picked = _read_planar_selection()
+            if picked:
+                sup, fc = picked
+
+        sup_kind = ""
+        face_exists = face_planar = False
+        in_body = None
+        if sup:
+            sup_obj = _get_object(doc, sup)
+            if sup_obj is None:
+                sup_kind = "missing"
+            else:
+                sup = sup_obj.Name
+                sup_kind = _classify_support(sup_obj)
+                in_body = _owning_body_name(sup_obj, doc.Objects)
+                if fc:
+                    face_exists, face_planar = _inspect_face(sup_obj, fc)
+
+        spec = _resolve_sketch_attachment(
+            sup, fc, plane, body is not None,
+            sup_kind, face_exists, face_planar, in_body,
+        )
+        if spec["mode"] == "error":
+            hint = _suggest_similar(doc, support) if sup_kind == "missing" else ""
+            return ToolResult(success=False, output="", error=spec["message"] + hint)
+
+        # Choose the container the sketch is created in.
+        if spec["mode"] in ("face", "plane"):
+            if body_name:
+                warnings.append("body_name ignored — sketch placed relative to support.")
+            container = _get_object(doc, spec["in_body"]) if spec.get("in_body") else None
+        elif spec["mode"] == "origin":
+            container = body
+        else:  # standalone
+            container = body
+
+        if container is not None:
+            sketch = container.newObject("Sketcher::SketchObject", label or "Sketch")
         else:
             sketch = doc.addObject("Sketcher::SketchObject", label or "Sketch")
 
-        # Attach to plane
-        if body and plane.upper() in ("XY", "XZ", "YZ"):
-            plane_feat = _get_body_plane(body, plane.upper())
+        # Apply the attachment.
+        if spec["mode"] == "face":
+            sketch.AttachmentSupport = [(_get_object(doc, spec["support"]), spec["sub"])]
+            sketch.MapMode = "FlatFace"
+        elif spec["mode"] == "plane":
+            sketch.AttachmentSupport = [(_get_object(doc, spec["support"]), "")]
+            sketch.MapMode = "FlatFace"
+        elif spec["mode"] == "origin":
+            plane_feat = _get_body_plane(container, spec["plane"])
             if plane_feat:
                 sketch.AttachmentSupport = [(plane_feat, "")]
                 sketch.MapMode = "FlatFace"
 
-        # Offset the sketch along the plane normal
+        # Offset along the attachment normal. For face/plane attachments the
+        # sketch's local Z is the face/plane normal, so offset is (0,0,offset).
+        # For origin planes keep the explicit per-plane vector.
         if offset != 0:
-            offset_map = {
-                "XY": App.Vector(0, 0, offset),
-                "XZ": App.Vector(0, offset, 0),
-                "YZ": App.Vector(offset, 0, 0),
-            }
-            ovec = offset_map.get(plane.upper(), App.Vector(0, 0, offset))
-            sketch.AttachmentOffset = App.Placement(ovec, App.Rotation())
+            if spec["mode"] in ("face", "plane"):
+                sketch.AttachmentOffset = App.Placement(
+                    App.Vector(0, 0, offset), App.Rotation())
+            else:
+                offset_map = {
+                    "XY": App.Vector(0, 0, offset),
+                    "XZ": App.Vector(0, offset, 0),
+                    "YZ": App.Vector(offset, 0, 0),
+                }
+                ovec = offset_map.get(plane.upper(), App.Vector(0, 0, offset))
+                sketch.AttachmentOffset = App.Placement(ovec, App.Rotation())
 
         doc.recompute()
+
+        # Verify a face/plane attachment actually resolved (no silent failure).
+        if spec["mode"] in ("face", "plane"):
+            try:
+                placement_ok = sketch.Placement is not None and (
+                    sketch.MapMode == "FlatFace")
+            except Exception:
+                placement_ok = False
+            if not placement_ok:
+                return ToolResult(
+                    success=False, output="",
+                    error=(f"Failed to attach sketch to '{spec['support']}'"
+                           + (f":{spec['sub']}" if spec.get('sub') else "")
+                           + " — attachment did not resolve."))
 
         geo_count = 0
         if geometries:
@@ -651,10 +721,12 @@ def _handle_create_sketch(
 
         return ToolResult(
             success=True,
-            output=(f"Created sketch '{sketch.Name}' with {geo_count} geometries"
-                    f" and {constraint_count} constraints.{constraint_status}"
-                    f"{constraint_info}"
-                    f"\nUse sketch_name='{sketch.Name}' in pad_sketch/pocket_sketch."),
+            output=(
+                ("⚠ " + " ".join(warnings) + "\n" if warnings else "")
+                + f"Created sketch '{sketch.Name}' with {geo_count} geometries"
+                f" and {constraint_count} constraints.{constraint_status}"
+                f"{constraint_info}"
+                f"\nUse sketch_name='{sketch.Name}' in pad_sketch/pocket_sketch."),
             data={"name": sketch.Name, "label": sketch.Label,
                   "geometry_count": geo_count, "constraint_count": constraint_count,
                   "constraints": constraint_details,
@@ -677,6 +749,10 @@ CREATE_SKETCH = ToolDefinition(
         "they are already constrained by the coordinates and dimensions you provide. "
         "COORDINATE SYSTEM: FreeCAD sketches use Y-up. When converting from SVG, images, "
         "or screen coordinates (which use Y-down), negate all Y values."
+        " To sketch on an existing solid's planar face, pass support='Obj' and "
+        "face='Face6' (use list_faces to find the name); to sketch on a datum "
+        "plane pass support='PlaneName'. Without support, attaches to the origin "
+        "`plane` (XY/XZ/YZ) as before."
     ),
     category="modeling",
     parameters=[
@@ -696,6 +772,17 @@ CREATE_SKETCH = ToolDefinition(
                   required=False, items={"type": "object"}),
         ToolParam("label", "string", "Display label for the sketch", required=False, default=""),
         ToolParam("offset", "number", "Offset the sketch along the plane normal (e.g. offset=40 on XY places sketch at z=40)", required=False, default=0.0),
+        ToolParam("support", "string",
+                  "Object to attach the sketch to: a solid (with `face`) or a "
+                  "datum/origin plane object (by name). Overrides `plane`. If "
+                  "omitted and a planar face/plane is selected in the viewport, "
+                  "that selection is used.",
+                  required=False, default=""),
+        ToolParam("face", "string",
+                  "Planar sub-element of `support` to sketch on, e.g. 'Face6'. "
+                  "Get face names from list_faces. Requires `support`. The face "
+                  "must be planar.",
+                  required=False, default=""),
     ],
     handler=_handle_create_sketch,
 )

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -454,7 +454,7 @@ def _handle_create_sketch(
         # Gather attachment facts from explicit params, or fall back to the GUI
         # selection when neither support nor face was given.
         sup, fc = support, face
-        if not sup and not fc:
+        if not support and not face:
             picked = _read_planar_selection()
             if picked:
                 sup, fc = picked
@@ -462,6 +462,7 @@ def _handle_create_sketch(
         sup_kind = ""
         face_exists = face_planar = False
         in_body = None
+        sup_obj = None
         if sup:
             sup_obj = _get_object(doc, sup)
             if sup_obj is None:
@@ -496,12 +497,13 @@ def _handle_create_sketch(
         else:
             sketch = doc.addObject("Sketcher::SketchObject", label or "Sketch")
 
-        # Apply the attachment.
+        # Apply the attachment. sup_obj is the resolved support object (non-None
+        # whenever the resolver returned a face/plane mode).
         if spec["mode"] == "face":
-            sketch.AttachmentSupport = [(_get_object(doc, spec["support"]), spec["sub"])]
+            sketch.AttachmentSupport = [(sup_obj, spec["sub"])]
             sketch.MapMode = "FlatFace"
         elif spec["mode"] == "plane":
-            sketch.AttachmentSupport = [(_get_object(doc, spec["support"]), "")]
+            sketch.AttachmentSupport = [(sup_obj, "")]
             sketch.MapMode = "FlatFace"
         elif spec["mode"] == "origin":
             plane_feat = _get_body_plane(container, spec["plane"])
@@ -527,18 +529,16 @@ def _handle_create_sketch(
 
         doc.recompute()
 
-        # Verify a face/plane attachment actually resolved (no silent failure).
+        # If a face/plane attachment can't resolve, FreeCAD marks the sketch's
+        # State as Invalid/Error after recompute. (The executor sandbox is the
+        # higher-level net — it also captures the C++ PositionBySupport error.)
         if spec["mode"] in ("face", "plane"):
-            try:
-                placement_ok = sketch.Placement is not None and (
-                    sketch.MapMode == "FlatFace")
-            except Exception:
-                placement_ok = False
-            if not placement_ok:
+            state = list(getattr(sketch, "State", []) or [])
+            if any(s in ("Invalid", "Error") for s in state):
                 return ToolResult(
                     success=False, output="",
                     error=(f"Failed to attach sketch to '{spec['support']}'"
-                           + (f":{spec['sub']}" if spec.get('sub') else "")
+                           + (f":{spec['sub']}" if spec.get("sub") else "")
                            + " — attachment did not resolve."))
 
         geo_count = 0

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -329,6 +329,97 @@ def _resolve_sketch_attachment(support, face, plane, body_present,
     return {"mode": "standalone"}
 
 
+_PLANE_TYPE_IDS = ("App::Plane", "PartDesign::Plane", "Part::DatumPlane")
+
+
+def _classify_support(obj):
+    """Classify a support object for sketch attachment.
+
+    Returns 'plane' for origin/datum planes, 'solid' for shapes with solids,
+    'other' for everything else (sketches, wires, empty features).
+    """
+    if getattr(obj, "TypeId", "") in _PLANE_TYPE_IDS:
+        return "plane"
+    shape = getattr(obj, "Shape", None)
+    try:
+        if shape is not None and shape.Solids:
+            return "solid"
+    except Exception:
+        pass
+    return "other"
+
+
+def _owning_body_name(obj, objects):
+    """Return the Name of the PartDesign::Body that contains ``obj``, or None.
+
+    ``objects`` is the document's object list (``doc.Objects``). A Body lists
+    its children in ``.Group``.
+    """
+    for cand in objects:
+        if getattr(cand, "TypeId", "") != "PartDesign::Body":
+            continue
+        try:
+            if any(getattr(c, "Name", None) == obj.Name for c in cand.Group):
+                return cand.Name
+        except Exception:
+            pass
+    return None
+
+
+def _inspect_face(obj, face_name):
+    """Return (exists, planar) for ``face_name`` on ``obj``'s shape.
+
+    Never raises — a missing face or non-shape object yields (False, False).
+    """
+    import Part
+    try:
+        face = obj.Shape.getElement(face_name)
+    except Exception:
+        return (False, False)
+    if face is None or face.ShapeType != "Face":
+        return (False, False)
+    try:
+        return (True, isinstance(face.Surface, Part.Plane))
+    except Exception:
+        return (True, False)
+
+
+def _read_planar_selection():
+    """Return (object_name, sub_element) for the first usable planar-face or
+    plane selection in the GUI, or None.
+
+    Used as a fallback when create_sketch is called with no support/face. Any
+    error or non-usable selection (edge, vertex, nothing, non-planar face)
+    returns None so the caller falls through to default behavior.
+    """
+    try:
+        import FreeCADGui as Gui
+        import Part
+    except Exception:
+        return None
+    try:
+        sel = Gui.Selection.getSelectionEx()
+    except Exception:
+        return None
+    for s in sel or []:
+        obj = getattr(s, "Object", None)
+        if obj is None:
+            continue
+        subs = getattr(s, "SubElementNames", None) or []
+        if subs:
+            sub = subs[0]
+            try:
+                el = obj.Shape.getElement(sub)
+                if (el is not None and el.ShapeType == "Face"
+                        and isinstance(el.Surface, Part.Plane)):
+                    return (obj.Name, sub)
+            except Exception:
+                continue
+        elif getattr(obj, "TypeId", "") in _PLANE_TYPE_IDS:
+            return (obj.Name, "")
+    return None
+
+
 # ── create_sketch ───────────────────────────────────────────
 
 def _handle_create_sketch(

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -354,6 +354,8 @@ def _owning_body_name(obj, objects):
 
     ``objects`` is an iterable of document objects (e.g. ``doc.Objects``). A Body lists
     its children in ``.Group``.
+
+    See also ``_find_body_for``, which returns the Body object itself.
     """
     for cand in objects:
         if getattr(cand, "TypeId", "") != "PartDesign::Body":
@@ -454,7 +456,12 @@ def _handle_create_sketch(
         # Gather attachment facts from explicit params, or fall back to the GUI
         # selection when neither support nor face was given.
         sup, fc = support, face
-        if not support and not face:
+        # Only consult the viewport selection for a bare call. An explicit
+        # plane, body_name, support, or face signals intent and must not be
+        # silently overridden by whatever happens to be selected (preserves
+        # backward compatibility for create_sketch(plane=..., body_name=...)).
+        if (not support and not face and not body_name
+                and plane.upper() == "XY"):
             picked = _read_planar_selection()
             if picked:
                 sup, fc = picked
@@ -486,7 +493,13 @@ def _handle_create_sketch(
         if spec["mode"] in ("face", "plane"):
             if body_name:
                 warnings.append("body_name ignored — sketch placed relative to support.")
-            container = _get_object(doc, spec["in_body"]) if spec.get("in_body") else None
+            if spec.get("in_body"):
+                container = _get_object(doc, spec["in_body"])
+            elif sup_obj is not None and getattr(sup_obj, "TypeId", "") == "PartDesign::Body":
+                # Sketching on a Body's own face → keep the sketch inside it.
+                container = sup_obj
+            else:
+                container = None
         elif spec["mode"] == "origin":
             container = body
         else:  # standalone

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -263,6 +263,57 @@ CREATE_BODY = ToolDefinition(
 )
 
 
+def _resolve_sketch_attachment(support, face, plane, body_present,
+                               support_kind, face_exists, face_planar, in_body):
+    """Decide where a sketch attaches. Pure — no FreeCAD calls.
+
+    Inputs are already-inspected facts so this is unit-testable. When the
+    GUI-selection fallback is used, the caller passes the selected object as
+    ``support`` and its planar face as ``face`` — selection collapses into the
+    same inputs as the explicit params.
+
+    ``support_kind``: ``""`` (no support given and no usable selection),
+    else ``"missing"`` | ``"plane"`` | ``"solid"`` | ``"other"``.
+    ``face_exists`` / ``face_planar`` are meaningful only when ``face`` != "".
+    ``in_body`` is the Body name owning the support, or ``None``.
+
+    Returns one of:
+      {"mode": "face", "support": str, "sub": str, "in_body": str|None}
+      {"mode": "plane", "support": str, "in_body": str|None}
+      {"mode": "origin", "plane": str}
+      {"mode": "standalone"}
+      {"mode": "error", "message": str}
+    """
+    if face and not support:
+        return {"mode": "error", "message": "`face` requires `support`."}
+
+    if support_kind == "missing":
+        return {"mode": "error", "message": f"Object '{support}' not found."}
+
+    if support_kind in ("plane", "solid", "other"):
+        if face:
+            if not face_exists:
+                return {"mode": "error",
+                        "message": f"Face '{face}' not found on '{support}'."}
+            if not face_planar:
+                return {"mode": "error",
+                        "message": (f"Face '{face}' on '{support}' is not planar; "
+                                    "sketches need a planar face.")}
+            return {"mode": "face", "support": support, "sub": face,
+                    "in_body": in_body}
+        if support_kind == "plane":
+            return {"mode": "plane", "support": support, "in_body": in_body}
+        return {"mode": "error",
+                "message": (f"`support` '{support}' is a solid; specify a `face` "
+                            "(e.g. 'Face6'), or pass a datum/origin plane as "
+                            "`support`.")}
+
+    # No support / no usable selection — original behavior.
+    if body_present and plane.upper() in ("XY", "XZ", "YZ"):
+        return {"mode": "origin", "plane": plane.upper()}
+    return {"mode": "standalone"}
+
+
 # ── create_sketch ───────────────────────────────────────────
 
 def _handle_create_sketch(

--- a/tests/integration/test_sketch_attachment_integration.py
+++ b/tests/integration/test_sketch_attachment_integration.py
@@ -153,3 +153,45 @@ results["data"] = {"success": r.success, "error": r.error}
 """)
         assert result["ok"], result.get("error")
         assert result["data"]["success"], result["data"]["error"]
+
+    def test_offset_on_face_sets_attachment_offset(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_sketch
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_create_sketch(support="Box", face="Face6", offset=5.0)
+doc.recompute()
+sk = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "offset_z": sk.AttachmentOffset.Base.z if sk else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert abs(d["offset_z"] - 5.0) < 1e-6
+
+    def test_body_name_with_support_warns(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_body, _handle_create_sketch
+
+_handle_create_body(label="Body")
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_create_sketch(support="Box", face="Face6", body_name="Body")
+doc.recompute()
+results["data"] = {"success": r.success, "error": r.error, "output": r.output}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert "ignored" in d["output"].lower()

--- a/tests/integration/test_sketch_attachment_integration.py
+++ b/tests/integration/test_sketch_attachment_integration.py
@@ -1,0 +1,155 @@
+"""Integration tests for create_sketch face/plane/selection attachment.
+
+Runs inside FreeCAD via the run_freecad_script fixture (see conftest.py).
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestCreateSketchAttachment:
+    def test_sketch_on_box_face_attaches(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_sketch
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_create_sketch(support="Box", face="Face6")
+doc.recompute()
+sk = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "map_mode": sk.MapMode if sk else None,
+    "has_support": bool(sk.AttachmentSupport) if sk else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["map_mode"] == "FlatFace"
+        assert d["has_support"]
+
+    def test_sketch_on_standalone_solid_face_is_standalone(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_sketch
+
+feat = doc.addObject("Part::Feature", "Imported")
+feat.Shape = Part.makeBox(8, 8, 8)
+doc.recompute()
+
+r = _handle_create_sketch(support="Imported", face="Face1")
+doc.recompute()
+sk = doc.getObject(r.data["name"]) if r.success else None
+grp = sk.getParentGeoFeatureGroup() if sk else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "map_mode": sk.MapMode if sk else None,
+    "in_body": grp.Name if grp else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["map_mode"] == "FlatFace"
+        # A standalone Part::Feature is not a Body, so the sketch is standalone.
+        assert d["in_body"] is None
+
+    def test_sketch_on_datum_plane_by_name(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_sketch
+
+body = doc.addObject("PartDesign::Body", "Body")
+body.newObject("PartDesign::Plane", "DatumPlane")
+doc.recompute()
+
+r = _handle_create_sketch(support="DatumPlane")
+doc.recompute()
+sk = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "map_mode": sk.MapMode if sk else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["map_mode"] == "FlatFace"
+
+    def test_non_planar_face_errors_cleanly(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_sketch
+
+feat = doc.addObject("Part::Feature", "Cyl")
+feat.Shape = Part.makeCylinder(5, 10)
+doc.recompute()
+
+# Find a non-planar (curved) face to target.
+nonplanar = None
+for i, f in enumerate(feat.Shape.Faces, start=1):
+    if not isinstance(f.Surface, Part.Plane):
+        nonplanar = "Face%d" % i
+        break
+
+r = _handle_create_sketch(support="Cyl", face=nonplanar)
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "targeted_face": nonplanar,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["targeted_face"] is not None  # cylinder has a curved face
+        assert not d["success"]
+        assert "planar" in d["error"].lower()
+
+    def test_missing_support_errors(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_sketch
+
+r = _handle_create_sketch(support="DoesNotExist", face="Face1")
+results["data"] = {"success": r.success, "error": r.error}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert not d["success"]
+        assert "not found" in d["error"].lower()
+
+    def test_origin_plane_still_works(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_body, _handle_create_sketch
+
+_handle_create_body(label="Body")
+doc.recompute()
+r = _handle_create_sketch(plane="XZ", body_name="Body")
+doc.recompute()
+sk = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "map_mode": sk.MapMode if sk else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["map_mode"] == "FlatFace"
+
+    def test_standalone_sketch_still_works(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_sketch
+
+r = _handle_create_sketch(plane="XY")
+results["data"] = {"success": r.success, "error": r.error}
+""")
+        assert result["ok"], result.get("error")
+        assert result["data"]["success"], result["data"]["error"]

--- a/tests/unit/test_sketch_attachment.py
+++ b/tests/unit/test_sketch_attachment.py
@@ -135,6 +135,21 @@ class TestClassifySupport:
     def test_sketch_is_other(self):
         assert _classify_support(_FakeObj("Sketcher::SketchObject")) == "other"
 
+    def test_solids_access_error_is_other(self):
+        class _Boom:
+            TypeId = "Part::Feature"
+            Name = "Boom"
+
+            @property
+            def Shape(self):
+                class _S:
+                    @property
+                    def Solids(self):
+                        raise RuntimeError("boom")
+                return _S()
+
+        assert _classify_support(_Boom()) == "other"
+
 
 class TestOwningBodyName:
     def test_object_in_body_returns_body_name(self):

--- a/tests/unit/test_sketch_attachment.py
+++ b/tests/unit/test_sketch_attachment.py
@@ -1,0 +1,73 @@
+"""Unit tests for the pure create_sketch attachment resolver (no FreeCAD)."""
+
+from freecad_ai.tools.freecad_tools import _resolve_sketch_attachment
+
+
+def _resolve(**kw):
+    base = dict(
+        support="", face="", plane="XY", body_present=False,
+        support_kind="", face_exists=False, face_planar=False, in_body=None,
+    )
+    base.update(kw)
+    return _resolve_sketch_attachment(**base)
+
+
+class TestResolveSketchAttachment:
+    # --- explicit face ---
+    def test_planar_face_on_solid_resolves_to_face_mode(self):
+        spec = _resolve(support="Box", face="Face6", support_kind="solid",
+                        face_exists=True, face_planar=True, in_body="Body")
+        assert spec == {"mode": "face", "support": "Box", "sub": "Face6",
+                        "in_body": "Body"}
+
+    def test_face_on_standalone_solid_has_no_body(self):
+        spec = _resolve(support="Imported", face="Face3", support_kind="solid",
+                        face_exists=True, face_planar=True, in_body=None)
+        assert spec["mode"] == "face"
+        assert spec["in_body"] is None
+
+    def test_missing_face_is_error(self):
+        spec = _resolve(support="Box", face="Face99", support_kind="solid",
+                        face_exists=False)
+        assert spec["mode"] == "error"
+        assert "Face99" in spec["message"]
+
+    def test_non_planar_face_is_error(self):
+        spec = _resolve(support="Cyl", face="Face1", support_kind="solid",
+                        face_exists=True, face_planar=False)
+        assert spec["mode"] == "error"
+        assert "planar" in spec["message"].lower()
+
+    # --- explicit plane ---
+    def test_plane_support_without_face_resolves_to_plane_mode(self):
+        spec = _resolve(support="DatumPlane", support_kind="plane", in_body="Body")
+        assert spec == {"mode": "plane", "support": "DatumPlane", "in_body": "Body"}
+
+    # --- validation ---
+    def test_face_without_support_is_error(self):
+        spec = _resolve(face="Face6")  # support empty
+        assert spec["mode"] == "error"
+        assert "support" in spec["message"].lower()
+
+    def test_missing_support_is_error(self):
+        spec = _resolve(support="Nope", support_kind="missing")
+        assert spec["mode"] == "error"
+        assert "not found" in spec["message"].lower()
+
+    def test_solid_support_without_face_is_error(self):
+        spec = _resolve(support="Box", support_kind="solid")
+        assert spec["mode"] == "error"
+        assert "face" in spec["message"].lower()
+
+    # --- fall-through to current behavior ---
+    def test_no_support_with_body_and_origin_plane(self):
+        spec = _resolve(plane="XZ", body_present=True)
+        assert spec == {"mode": "origin", "plane": "XZ"}
+
+    def test_no_support_no_body_is_standalone(self):
+        spec = _resolve(plane="XY", body_present=False)
+        assert spec == {"mode": "standalone"}
+
+    def test_origin_plane_is_case_insensitive(self):
+        spec = _resolve(plane="xy", body_present=True)
+        assert spec == {"mode": "origin", "plane": "XY"}

--- a/tests/unit/test_sketch_attachment.py
+++ b/tests/unit/test_sketch_attachment.py
@@ -1,6 +1,6 @@
 """Unit tests for the pure create_sketch attachment resolver (no FreeCAD)."""
 
-from freecad_ai.tools.freecad_tools import _resolve_sketch_attachment
+from freecad_ai.tools.freecad_tools import _resolve_sketch_attachment, _classify_support, _owning_body_name
 
 
 def _resolve(**kw):
@@ -96,3 +96,53 @@ class TestResolveSketchAttachment:
     def test_none_face_is_treated_as_absent(self):
         spec = _resolve(support="", face=None, plane="XY", body_present=True)
         assert spec == {"mode": "origin", "plane": "XY"}
+
+
+class _FakeObj:
+    def __init__(self, type_id, name="Obj", has_solids=False, group_of=None):
+        self.TypeId = type_id
+        self.Name = name
+        self._has_solids = has_solids
+        # FreeCAD groups expose .Group; a Body lists its children there.
+        if group_of is not None:
+            self.Group = group_of
+
+    @property
+    def Shape(self):
+        class _S:
+            Solids = [1] if self._has_solids else []
+        return _S()
+
+
+class TestClassifySupport:
+    def test_datum_plane_is_plane(self):
+        assert _classify_support(_FakeObj("PartDesign::Plane")) == "plane"
+
+    def test_origin_app_plane_is_plane(self):
+        assert _classify_support(_FakeObj("App::Plane")) == "plane"
+
+    def test_part_datum_plane_is_plane(self):
+        assert _classify_support(_FakeObj("Part::DatumPlane")) == "plane"
+
+    def test_solid_feature_is_solid(self):
+        assert _classify_support(
+            _FakeObj("Part::Feature", has_solids=True)) == "solid"
+
+    def test_feature_without_solids_is_other(self):
+        assert _classify_support(
+            _FakeObj("Part::Feature", has_solids=False)) == "other"
+
+    def test_sketch_is_other(self):
+        assert _classify_support(_FakeObj("Sketcher::SketchObject")) == "other"
+
+
+class TestOwningBodyName:
+    def test_object_in_body_returns_body_name(self):
+        child = _FakeObj("PartDesign::Pad", name="Pad")
+        body = _FakeObj("PartDesign::Body", name="Body", group_of=[child])
+        # The fake document is just the list of objects to scan.
+        assert _owning_body_name(child, [body, child]) == "Body"
+
+    def test_standalone_object_returns_none(self):
+        feat = _FakeObj("Part::Feature", name="Imported")
+        assert _owning_body_name(feat, [feat]) is None

--- a/tests/unit/test_sketch_attachment.py
+++ b/tests/unit/test_sketch_attachment.py
@@ -71,3 +71,28 @@ class TestResolveSketchAttachment:
     def test_origin_plane_is_case_insensitive(self):
         spec = _resolve(plane="xy", body_present=True)
         assert spec == {"mode": "origin", "plane": "XY"}
+
+    def test_other_support_without_face_is_error_not_solid(self):
+        spec = _resolve(support="Mesh", support_kind="other")
+        assert spec["mode"] == "error"
+        assert "is a solid" not in spec["message"]
+        assert "face" in spec["message"].lower()
+
+    def test_other_support_with_planar_face_resolves_to_face_mode(self):
+        spec = _resolve(support="Mesh", face="Face2", support_kind="other",
+                        face_exists=True, face_planar=True, in_body=None)
+        assert spec == {"mode": "face", "support": "Mesh", "sub": "Face2",
+                        "in_body": None}
+
+    def test_standalone_regardless_of_plane_when_no_body(self):
+        spec = _resolve(plane="XZ", body_present=False)
+        assert spec == {"mode": "standalone"}
+
+    def test_unknown_support_kind_is_error(self):
+        spec = _resolve(support="X", support_kind="bogus")
+        assert spec["mode"] == "error"
+        assert "bogus" in spec["message"]
+
+    def test_none_face_is_treated_as_absent(self):
+        spec = _resolve(support="", face=None, plane="XY", body_present=True)
+        assert spec == {"mode": "origin", "plane": "XY"}


### PR DESCRIPTION
Piece #1 of the datum-geometry/transform suite tracked in #18. Lets `create_sketch` attach a sketch to a planar face of an existing object, to a datum/named plane, or to the current viewport selection — in addition to the existing origin planes.

## Why
Issue #18 (snap-fit follow-up to #17): a user selected a face on an imported mesh→solid part and asked for a sketch on it. `create_sketch` only supported the XY/XZ/YZ origin planes, so there was no structured path for "sketch on this face" — the model dropped to raw `run_macro` Python and baked a static, history-less `Part::Feature`. This adds the missing capability.

## What
New optional params on `create_sketch` (fully backward-compatible — defaults unchanged):
- `support` — object to attach to: a solid (with `face`) or a datum/origin plane by name.
- `face` — planar sub-element of `support`, e.g. `Face6` (names via `list_faces`).

Resolution order: explicit face → explicit plane → **GUI-selection fallback** (only for a bare call — an explicit `plane`/`body_name` is never overridden) → origin plane (existing) → standalone (existing).

Body-aware: a sketch on a feature inside a `PartDesign::Body` is created in that body; on a standalone `Part::Feature` (imported mesh→solid) it's created standalone and attached to the face — the path that unblocks the #18 workflow. Non-planar faces and missing/invalid supports return clean errors (no segfault). `offset` applies along the attachment normal.

## Design
The attachment decision lives in a pure, unit-tested `_resolve_sketch_attachment(...)`; thin FreeCAD helpers (`_classify_support`, `_owning_body_name`, `_inspect_face`, `_read_planar_selection`) gather the facts. Spec + plan: `docs/superpowers/specs/2026-06-02-sketch-on-face-and-plane-design.md` and `docs/superpowers/plans/2026-06-02-sketch-on-face-and-plane.md`.

## Test plan
- [x] Unit: `tests/unit/test_sketch_attachment.py` — pure resolver + helper coverage (no FreeCAD).
- [x] Integration (real FreeCAD): `tests/integration/test_sketch_attachment_integration.py` — face attach, standalone-solid face, datum plane, non-planar rejection, missing support, offset-on-face, body_name+support warning, and origin-plane / standalone regressions (9 tests).
- [x] Full unit suite green (857 passed; pre-existing `test_document_attach.py` Qt segfault excluded).

## Follow-ups (remain in #18)
- `create_datum_plane` (offset/face), `create_datum_line`, and a `transform_object` copy/relative-mode extension.

Wiki `Tool-Reference.md` updated locally (committed in the wiki repo; not pushed — maintainer pushes the wiki manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)