### PR TITLE
feat(create_datum_plane): parametric datum planes (offset from plane/face/selection)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-create-datum-plane.md
+++ b/docs/superpowers/plans/2026-06-02-create-datum-plane.md
@@ -1,0 +1,543 @@
+# create_datum_plane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `create_datum_plane` tool that creates a parametric datum plane offset from an origin plane, a planar face, an existing plane, or the GUI selection — referenceable by `create_sketch`'s `support`.
+
+**Architecture:** Reuse piece #1's resolution layer (now on `master`): a thin pure wrapper `_resolve_datum_plane_attachment` delegates to `_resolve_sketch_attachment` and remaps `standalone`→error. The handler mirrors `_handle_create_sketch` — gather facts (params or selection), resolve, pick the container Body, create a `PartDesign::Plane` (in a Body) or `Part::DatumPlane` (standalone), attach via `FlatFace` + `AttachmentOffset` along the normal, recompute, verify.
+
+**Tech Stack:** Python 3.11, FreeCAD 1.1.1 Python API, pytest. Unit tests run without FreeCAD (`env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/ -q`); integration tests run inside FreeCAD via the `run_freecad_script` fixture (`-m integration`).
+
+**Branch:** `feature/datum-plane` (already created off `master`; spec committed at `1df3616`).
+
+---
+
+## File structure
+
+- **Modify** `freecad_ai/tools/freecad_tools.py`
+  - Add pure `_resolve_datum_plane_attachment(...)` immediately after `_resolve_sketch_attachment` (it ends just before the `_PLANE_TYPE_IDS = (...)` line, ~line 332).
+  - Add handler `_handle_create_datum_plane(...)` and `CREATE_DATUM_PLANE` `ToolDefinition` right before the `# ── edit_sketch ─` section comment.
+  - Register `CREATE_DATUM_PLANE` in `ALL_TOOLS` (after `CREATE_SKETCH,` at ~line 5106).
+- **Test (unit)** `tests/unit/test_datum_plane.py` — wrapper resolver tests (no FreeCAD).
+- **Test (integration)** `tests/integration/test_datum_plane_integration.py` — real-FreeCAD tests.
+- **Docs** wiki `../freecad-ai-wiki/Tool-Reference.md` — add a `create_datum_plane` entry.
+
+Reused as-is (already on master): `_resolve_sketch_attachment`, `_classify_support`, `_owning_body_name`, `_inspect_face`, `_read_planar_selection`, `_get_body_plane`, `_get_object`, `_suggest_similar`, `_with_undo`, `_PLANE_TYPE_IDS`.
+
+---
+
+## Task 1: Pure resolver wrapper
+
+**Files:**
+- Modify: `freecad_ai/tools/freecad_tools.py` (add after `_resolve_sketch_attachment`)
+- Test: `tests/unit/test_datum_plane.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_datum_plane.py`:
+
+```python
+"""Unit tests for the pure create_datum_plane reference resolver (no FreeCAD)."""
+
+from freecad_ai.tools.freecad_tools import _resolve_datum_plane_attachment
+
+
+def _resolve(**kw):
+    base = dict(
+        support="", face="", plane="XY", body_present=False,
+        support_kind="", face_exists=False, face_planar=False, in_body=None,
+    )
+    base.update(kw)
+    return _resolve_datum_plane_attachment(**base)
+
+
+class TestResolveDatumPlaneAttachment:
+    def test_standalone_becomes_no_reference_error(self):
+        # No support, no body → sketch resolver would say "standalone", but a
+        # datum plane needs a reference.
+        spec = _resolve(plane="XY", body_present=False)
+        assert spec["mode"] == "error"
+        assert "reference" in spec["message"].lower()
+
+    def test_face_passes_through(self):
+        spec = _resolve(support="Box", face="Face6", support_kind="solid",
+                        face_exists=True, face_planar=True, in_body="Body")
+        assert spec == {"mode": "face", "support": "Box", "sub": "Face6",
+                        "in_body": "Body"}
+
+    def test_plane_passes_through(self):
+        spec = _resolve(support="DatumPlane", support_kind="plane", in_body=None)
+        assert spec == {"mode": "plane", "support": "DatumPlane", "in_body": None}
+
+    def test_origin_passes_through(self):
+        spec = _resolve(plane="XZ", body_present=True)
+        assert spec == {"mode": "origin", "plane": "XZ"}
+
+    def test_resolver_error_passes_through(self):
+        # face without support is an error in the underlying resolver.
+        spec = _resolve(face="Face1")
+        assert spec["mode"] == "error"
+        assert "support" in spec["message"].lower()
+
+    def test_non_planar_face_error_passes_through(self):
+        spec = _resolve(support="Cyl", face="Face1", support_kind="solid",
+                        face_exists=True, face_planar=False)
+        assert spec["mode"] == "error"
+        assert "planar" in spec["message"].lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_datum_plane.py -q`
+Expected: FAIL — `ImportError: cannot import name '_resolve_datum_plane_attachment'`.
+
+- [ ] **Step 3: Implement the wrapper**
+
+In `freecad_ai/tools/freecad_tools.py`, immediately AFTER the `_resolve_sketch_attachment` function returns (i.e. just before the `_PLANE_TYPE_IDS = (...)` line, ~line 332), add:
+
+```python
+def _resolve_datum_plane_attachment(support, face, plane, body_present,
+                                    support_kind, face_exists, face_planar, in_body):
+    """Reference resolution for create_datum_plane. Pure — no FreeCAD calls.
+
+    Delegates to ``_resolve_sketch_attachment`` and remaps the one datum-specific
+    decision: a datum plane cannot be free-floating, so a ``standalone`` result
+    (no usable reference) becomes an error. All other modes pass through.
+    """
+    spec = _resolve_sketch_attachment(
+        support, face, plane, body_present,
+        support_kind, face_exists, face_planar, in_body)
+    if spec["mode"] == "standalone":
+        return {"mode": "error",
+                "message": ("create_datum_plane needs a reference: pass a plane "
+                            "(XY/XZ/YZ) with body_name, or a support object "
+                            "(optionally with a face).")}
+    return spec
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_datum_plane.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add freecad_ai/tools/freecad_tools.py tests/unit/test_datum_plane.py
+git commit -m "feat(create_datum_plane): pure reference resolver wrapper"
+```
+
+---
+
+## Task 2: Handler + ToolDefinition + registration
+
+**Files:**
+- Modify: `freecad_ai/tools/freecad_tools.py` (add handler + ToolDefinition before `# ── edit_sketch ─`; register in `ALL_TOOLS`)
+
+- [ ] **Step 1: Add the handler and ToolDefinition**
+
+Find the `# ── edit_sketch ─` section comment (it follows the `CREATE_SKETCH = ToolDefinition(...)` block). Immediately BEFORE that comment line, insert:
+
+```python
+# ── create_datum_plane ──────────────────────────────────────
+
+def _handle_create_datum_plane(
+    plane: str = "XY",
+    support: str = "",
+    face: str = "",
+    offset: float = 0.0,
+    body_name: str = "",
+    label: str = "",
+) -> ToolResult:
+    """Create a parametric datum plane offset from a reference."""
+    import FreeCAD as App
+
+    def do(doc):
+        warnings = []
+
+        body = None
+        if body_name:
+            body = _get_object(doc, body_name)
+            if not body:
+                hint = _suggest_similar(doc, body_name, "Body")
+                return ToolResult(success=False, output="", error=f"Body '{body_name}' not found.{hint}")
+
+        # Bare-call selection fallback — same gate as create_sketch: only when
+        # no explicit reference and the default plane were given.
+        sup, fc = support, face
+        if (not support and not face and not body_name
+                and plane.upper() == "XY"):
+            picked = _read_planar_selection()
+            if picked:
+                sup, fc = picked
+
+        sup_kind = ""
+        face_exists = face_planar = False
+        in_body = None
+        sup_obj = None
+        if sup:
+            sup_obj = _get_object(doc, sup)
+            if sup_obj is None:
+                sup_kind = "missing"
+            else:
+                sup = sup_obj.Name
+                sup_kind = _classify_support(sup_obj)
+                in_body = _owning_body_name(sup_obj, doc.Objects)
+                if fc:
+                    face_exists, face_planar = _inspect_face(sup_obj, fc)
+
+        spec = _resolve_datum_plane_attachment(
+            sup, fc, plane, body is not None,
+            sup_kind, face_exists, face_planar, in_body,
+        )
+        if spec["mode"] == "error":
+            hint = _suggest_similar(doc, support) if sup_kind == "missing" else ""
+            return ToolResult(success=False, output="", error=spec["message"] + hint)
+
+        # Choose the container the datum plane is created in (same logic as
+        # create_sketch).
+        if spec["mode"] in ("face", "plane"):
+            if body_name:
+                warnings.append("body_name ignored — datum plane placed relative to support.")
+            if spec.get("in_body"):
+                container = _get_object(doc, spec["in_body"])
+            elif sup_obj is not None and getattr(sup_obj, "TypeId", "") == "PartDesign::Body":
+                container = sup_obj
+            else:
+                container = None
+        else:  # origin
+            container = body
+
+        # PartDesign::Plane inside a Body, else a standalone Part::DatumPlane.
+        if container is not None:
+            datum = container.newObject("PartDesign::Plane", label or "DatumPlane")
+        else:
+            datum = doc.addObject("Part::DatumPlane", label or "DatumPlane")
+
+        # Attach to the reference. All modes use FlatFace, so the datum's local
+        # Z is the reference normal and the offset is always (0, 0, offset).
+        if spec["mode"] == "face":
+            datum.AttachmentSupport = [(sup_obj, spec["sub"])]
+            datum.MapMode = "FlatFace"
+        elif spec["mode"] == "plane":
+            datum.AttachmentSupport = [(sup_obj, "")]
+            datum.MapMode = "FlatFace"
+        elif spec["mode"] == "origin":
+            plane_feat = _get_body_plane(container, spec["plane"])
+            if plane_feat:
+                datum.AttachmentSupport = [(plane_feat, "")]
+                datum.MapMode = "FlatFace"
+
+        if offset != 0:
+            datum.AttachmentOffset = App.Placement(
+                App.Vector(0, 0, offset), App.Rotation())
+
+        doc.recompute()
+
+        # If the attachment can't resolve, FreeCAD marks the feature's State as
+        # Invalid/Error. (The executor sandbox is the higher-level net.)
+        state = list(getattr(datum, "State", []) or [])
+        if any(s in ("Invalid", "Error") for s in state):
+            ref = spec.get("support") or spec.get("plane") or "reference"
+            return ToolResult(
+                success=False, output="",
+                error=(f"Failed to attach datum plane to '{ref}'"
+                       + (f":{spec['sub']}" if spec.get("sub") else "")
+                       + " — attachment did not resolve."))
+
+        return ToolResult(
+            success=True,
+            output=(("⚠ " + " ".join(warnings) + "\n" if warnings else "")
+                    + f"Created datum plane '{datum.Name}' ({datum.TypeId})."
+                    + f" Use support='{datum.Name}' in create_sketch."),
+            data={"name": datum.Name, "label": datum.Label,
+                  "type_id": datum.TypeId},
+        )
+
+    return _with_undo("Create Datum Plane", do)
+
+
+CREATE_DATUM_PLANE = ToolDefinition(
+    name="create_datum_plane",
+    description=(
+        "Create a parametric datum plane offset (parallel) from a reference — "
+        "useful as a mid-plane, an offset sketch plane, or a mirror reference. "
+        "Reference options: an origin plane (plane=XY/XZ/YZ, needs body_name); a "
+        "planar face of an object (support='Obj', face='Face6' — names from "
+        "list_faces); or an existing plane by name (support='PlaneName'). With no "
+        "reference, the current planar-face/plane selection is used. The result "
+        "is a PartDesign::Plane inside a Body, or a standalone Part::DatumPlane, "
+        "and can be passed to create_sketch as support='<name>'."
+    ),
+    category="modeling",
+    parameters=[
+        ToolParam("plane", "string", "Origin-plane reference: XY, XZ, or YZ "
+                  "(used when no support; needs body_name).",
+                  required=False, default="XY", enum=["XY", "XZ", "YZ"]),
+        ToolParam("support", "string", "Object to offset from: a solid (with "
+                  "`face`) or an existing plane object by name.",
+                  required=False, default=""),
+        ToolParam("face", "string", "Planar sub-element of `support`, e.g. "
+                  "'Face6' (from list_faces). Requires `support`.",
+                  required=False, default=""),
+        ToolParam("offset", "number", "Parallel offset along the reference "
+                  "normal in mm (may be negative).",
+                  required=False, default=0.0),
+        ToolParam("body_name", "string", "Body to create the PartDesign::Plane "
+                  "in (required for an origin-plane reference).",
+                  required=False, default=""),
+        ToolParam("label", "string", "Display label for the datum plane.",
+                  required=False, default=""),
+    ],
+    handler=_handle_create_datum_plane,
+)
+
+
+```
+
+- [ ] **Step 2: Register in ALL_TOOLS**
+
+Find the `ALL_TOOLS = [` list (~line 5103). After the `    CREATE_SKETCH,` line, add:
+
+```python
+    CREATE_DATUM_PLANE,
+```
+
+- [ ] **Step 3: Verify the module loads and the tool is registered**
+
+Run:
+```bash
+env -u PYTHONPATH .venv/bin/python -c "from freecad_ai.tools.freecad_tools import CREATE_DATUM_PLANE, ALL_TOOLS; print(CREATE_DATUM_PLANE.name); print('registered:', CREATE_DATUM_PLANE in ALL_TOOLS); print([p.name for p in CREATE_DATUM_PLANE.parameters])"
+```
+Expected: prints `create_datum_plane`; `registered: True`; param list `['plane', 'support', 'face', 'offset', 'body_name', 'label']`.
+
+- [ ] **Step 4: Run the unit + registry suites to confirm no regression**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_datum_plane.py tests/unit/test_sketch_attachment.py tests/unit/test_new_tools.py tests/unit/test_registry.py -q`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add freecad_ai/tools/freecad_tools.py
+git commit -m "feat(create_datum_plane): handler, tool definition, registration"
+```
+
+---
+
+## Task 3: Integration tests (real FreeCAD)
+
+**Files:**
+- Create: `tests/integration/test_datum_plane_integration.py`
+
+- [ ] **Step 1: Write the integration tests**
+
+Create `tests/integration/test_datum_plane_integration.py`:
+
+```python
+"""Integration tests for create_datum_plane (runs inside FreeCAD).
+
+Uses the run_freecad_script fixture (see tests/integration/conftest.py).
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestCreateDatumPlane:
+    def test_offset_from_origin_plane_in_body(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_body, _handle_create_datum_plane
+
+_handle_create_body(label="Body")
+doc.recompute()
+r = _handle_create_datum_plane(plane="XY", body_name="Body", offset=20.0)
+doc.recompute()
+dp = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "type_id": dp.TypeId if dp else None,
+    "z": dp.Placement.Base.z if dp else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["type_id"] == "PartDesign::Plane"
+        assert abs(d["z"] - 20.0) < 1e-6
+
+    def test_offset_from_body_feature_face(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane
+
+body = doc.addObject("PartDesign::Body", "Body")
+box = body.newObject("PartDesign::AdditiveBox", "Box")
+box.Length = 10; box.Width = 10; box.Height = 10
+doc.recompute()
+
+# A planar face of the box feature (reference an earlier feature, not the tip).
+planar = None
+for i, f in enumerate(box.Shape.Faces, start=1):
+    if isinstance(f.Surface, Part.Plane):
+        planar = "Face%d" % i
+        break
+
+r = _handle_create_datum_plane(support="Box", face=planar)
+doc.recompute()
+dp = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "type_id": dp.TypeId if dp else None,
+    "face": planar,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["type_id"] == "PartDesign::Plane"
+
+    def test_offset_from_standalone_solid_face(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_create_datum_plane(support="Box", face="Face6", offset=3.0)
+doc.recompute()
+dp = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "type_id": dp.TypeId if dp else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["type_id"] == "Part::DatumPlane"
+
+    def test_sketch_on_created_datum_plane(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane, _handle_create_sketch
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+dp_r = _handle_create_datum_plane(support="Box", face="Face6", offset=5.0)
+doc.recompute()
+
+sk_r = _handle_create_sketch(support=dp_r.data["name"])
+doc.recompute()
+sk = doc.getObject(sk_r.data["name"]) if sk_r.success else None
+results["data"] = {
+    "datum_ok": dp_r.success,
+    "datum_err": dp_r.error,
+    "sketch_ok": sk_r.success,
+    "sketch_err": sk_r.error,
+    "map_mode": sk.MapMode if sk else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["datum_ok"], d["datum_err"]
+        assert d["sketch_ok"], d["sketch_err"]
+        assert d["map_mode"] == "FlatFace"
+
+    def test_no_reference_errors(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane
+
+r = _handle_create_datum_plane(offset=10.0)
+results["data"] = {"success": r.success, "error": r.error}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert not d["success"]
+        assert "reference" in d["error"].lower()
+
+    def test_non_planar_face_errors(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane
+
+feat = doc.addObject("Part::Feature", "Cyl")
+feat.Shape = Part.makeCylinder(5, 10)
+doc.recompute()
+
+nonplanar = None
+for i, f in enumerate(feat.Shape.Faces, start=1):
+    if not isinstance(f.Surface, Part.Plane):
+        nonplanar = "Face%d" % i
+        break
+
+r = _handle_create_datum_plane(support="Cyl", face=nonplanar)
+results["data"] = {"success": r.success, "error": r.error, "face": nonplanar}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["face"] is not None
+        assert not d["success"]
+        assert "planar" in d["error"].lower()
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/integration/test_datum_plane_integration.py -m integration -v`
+Expected: 6 passed (each spawns a FreeCAD subprocess; allow 1-3 min total).
+
+If a test fails, read `result["data"]["error"]`. Do NOT change the production code to make a test pass unless the test itself is demonstrably wrong; if a real production bug surfaces, STOP and report it (DONE_WITH_CONCERNS / BLOCKED) with the exact error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_datum_plane_integration.py
+git commit -m "test(create_datum_plane): integration tests"
+```
+
+---
+
+## Task 4: Docs — verify description and update wiki
+
+**Files:**
+- Modify: `../freecad-ai-wiki/Tool-Reference.md`
+
+- [ ] **Step 1: Confirm the in-code description renders**
+
+Run: `env -u PYTHONPATH .venv/bin/python -c "from freecad_ai.tools.freecad_tools import CREATE_DATUM_PLANE; print(CREATE_DATUM_PLANE.description)"`
+Expected: prints the description mentioning origin plane / face / existing plane references and that the result is usable as `create_sketch` `support`.
+
+- [ ] **Step 2: Add a wiki entry**
+
+Open `../freecad-ai-wiki/Tool-Reference.md`. Find how the `create_sketch` entry is formatted (parameter table + notes). Add a new `create_datum_plane` section in the SAME style, near `create_sketch`, documenting:
+- One-line purpose: "Create a parametric datum plane offset (parallel) from an origin plane, a planar face, or an existing plane."
+- Parameter table rows for `plane`, `support`, `face`, `offset`, `body_name`, `label` (descriptions matching the ToolParam text from Task 2).
+- A note: "Produces a `PartDesign::Plane` inside a Body, or a standalone `Part::DatumPlane`. Pass the result name to `create_sketch(support=...)` to sketch on it. Origin-plane references need `body_name`. Offset is along the reference normal (parallel planes only — no tilt)."
+
+Match the file's existing heading level and table format; do not impose a new style.
+
+- [ ] **Step 3: Commit the wiki (in the wiki repo only; do NOT push)**
+
+```bash
+cd ../freecad-ai-wiki
+git add Tool-Reference.md
+git commit -m "docs(tool-reference): create_datum_plane"
+cd -
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** reference resolution + standalone→error → Task 1 (`_resolve_datum_plane_attachment`). Params/behavior/container/object-type/attachment/offset/verification → Task 2 handler. Registration → Task 2 Step 2. Origin/face/standalone/end-to-end/no-reference/non-planar cases → Task 3. Docs → Task 4. Selection fallback → Task 2 (same gate as create_sketch). Backward-compat (purely additive) → no existing tool touched; verified by running the existing suites in Task 2 Step 4.
+- **Type/name consistency:** `_resolve_datum_plane_attachment` returns the same spec-dict shape as `_resolve_sketch_attachment` (keys `mode`/`support`/`sub`/`in_body`/`plane`/`message`), consumed identically in the handler. Tool name `create_datum_plane`, constant `CREATE_DATUM_PLANE`, handler `_handle_create_datum_plane` used consistently across tasks.
+- **No placeholders:** every code step shows complete code.
+- **Offset simplification vs create_sketch:** create_sketch keeps a legacy per-origin-plane `offset_map`; this new tool uses a single `(0,0,offset)` along the FlatFace local-Z for all modes (equivalent for FlatFace attachment, simpler). Intentional, noted here.

--- a/docs/superpowers/specs/2026-06-02-create-datum-plane-design.md
+++ b/docs/superpowers/specs/2026-06-02-create-datum-plane-design.md
@@ -1,0 +1,196 @@
+# Design: create_datum_plane tool
+
+- **Date:** 2026-06-02
+- **Status:** Approved design, pending implementation plan
+- **Scope:** Piece #2 of the datum-geometry/transform suite (see Roadmap).
+- **Base:** branch `feature/datum-plane` off `master` (PR #20 / piece #1 already merged — `e76be0a` — so the shared resolution helpers are available).
+
+## Background
+
+Piece #1 (merged) gave `create_sketch` the ability to attach to a planar face,
+a datum/named plane, or the GUI selection, via a reusable resolution layer in
+`freecad_ai/tools/freecad_tools.py`:
+
+- `_resolve_sketch_attachment(support, face, plane, body_present, support_kind,
+  face_exists, face_planar, in_body)` — pure decision returning a spec dict with
+  `mode` ∈ {`face`, `plane`, `origin`, `standalone`, `error`}.
+- helpers `_classify_support`, `_owning_body_name`, `_inspect_face`,
+  `_read_planar_selection`, and the constant `_PLANE_TYPE_IDS`.
+
+`create_datum_plane` is structurally `create_sketch` minus the geometry: resolve
+a reference, pick the container Body, create a plane object, attach it with an
+offset. It therefore **reuses the same resolution layer** rather than
+duplicating it.
+
+A datum plane is a first-class need on the original snap-fit workflow that
+started this line of work ("create a plane at the center of the object to use as
+a mirror reference"). The created plane is referenceable by name as
+`create_sketch`'s `support`, closing the loop: *make an offset plane → sketch on
+it → pad/pocket*.
+
+## Goals
+
+A new tool `create_datum_plane` that creates a **parametric** datum plane offset
+(parallel) from a reference:
+
+1. From an **origin plane** (XY/XZ/YZ) of a Body.
+2. From a **planar face** of an existing object (`support` + `face`).
+3. From an **existing plane object** by name (`support`).
+4. From the **current GUI selection** (bare call) — same fallback as
+   `create_sketch`.
+
+The plane attaches parametrically (via `AttachmentSupport` + `MapMode` +
+`AttachmentOffset`), so it moves if its reference moves — preserving model
+history, which is the through-line of this whole effort (#17/#18).
+
+## Non-goals
+
+- **No tilt/angle.** Offset-along-normal only (parallel planes). Decided with the
+  user; an angled-datum variant can come later if needed.
+- **No 3-point / line-and-point / two-plane-bisector definitions.** YAGNI.
+- No change to `create_sketch` or any existing tool. Purely additive.
+- No new datum *line* (that is piece #3).
+
+## Parameters
+
+Mirror `create_sketch` for a consistent vocabulary. All optional; sensible
+defaults.
+
+| Param | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `plane` | string | `"XY"` | Origin-plane reference (XY/XZ/YZ), used when no `support`. Needs `body_name` (origin planes belong to a Body). |
+| `support` | string | `""` | Object to offset from: a solid (with `face`) or an existing plane object by name. |
+| `face` | string | `""` | Planar sub-element of `support`, e.g. `"Face6"`. Requires `support`. |
+| `offset` | number | `0.0` | Parallel distance along the reference normal (mm). May be negative. |
+| `body_name` | string | `""` | Body to create the `PartDesign::Plane` in (required for an origin-plane reference). |
+| `label` | string | `""` | Display label; defaults to `"DatumPlane"`. |
+
+## Behavior
+
+### Reference resolution (reuses piece #1)
+
+The reference is resolved by a thin **pure** wrapper
+`_resolve_datum_plane_attachment(...)` that takes the same arguments as
+`_resolve_sketch_attachment`, delegates to it, and then converts the one
+datum-specific decision: a `standalone` result becomes an `error` (a datum
+plane, unlike a sketch, cannot be free-floating — it needs a reference). All
+other modes pass through unchanged. Keeping this remap in a pure function (not
+the FreeCAD-importing handler) preserves piece #1's "decision is unit-tested
+without FreeCAD" pattern.
+
+The handler still performs the bare-call selection fallback (when `support`,
+`face`, `body_name` are empty and `plane == "XY"`, consult
+`_read_planar_selection()`) before calling the wrapper. The resulting `mode`
+maps as:
+
+- `face` → reference is `(support_obj, "Face6")`.
+- `plane` → reference is the existing plane object `(support_obj, "")`.
+- `origin` → reference is the Body's origin plane (`_get_body_plane`).
+- `error` → return the error verbatim. (Includes the `standalone`→error remap:
+  `"create_datum_plane needs a reference: pass a plane (XY/XZ/YZ) with body_name,
+  or a support object (optionally with a face)."`)
+
+### Container and object type
+
+Container selection is identical to `create_sketch`:
+
+- reference object lives in a `PartDesign::Body` → that Body;
+- reference object **is** a `PartDesign::Body` → that Body itself;
+- `origin` mode → the named `body`;
+- otherwise → standalone.
+
+Object created:
+
+- container is a Body → `container.newObject("PartDesign::Plane", label or
+  "DatumPlane")`.
+- standalone (reference is a plain `Part::Feature` face, e.g. an imported
+  mesh→solid) → `doc.addObject("Part::DatumPlane", label or "DatumPlane")`.
+
+### Attachment
+
+```text
+datum.AttachmentSupport = [(ref_obj, sub)]   # sub is "Face6" or "" for a plane
+datum.MapMode = "FlatFace"
+datum.AttachmentOffset = App.Placement(App.Vector(0, 0, offset), App.Rotation())
+doc.recompute()
+```
+
+The sketch's/plane's local Z after `FlatFace` is the reference normal, so the
+offset is always along the normal regardless of reference orientation — the same
+convention piece #1 uses for face/plane attachment.
+
+## Validation and errors
+
+Reuse piece #1's guarantees; never segfault.
+
+- Resolver errors (missing support, missing/non-planar face, `face` without
+  `support`, solid-without-face) propagate verbatim (with `_suggest_similar`
+  hint when the support name is unknown).
+- `standalone` resolver result → the no-reference error above.
+- After recompute, verify the attachment resolved via the same `State`
+  Invalid/Error check piece #1 uses; on failure return a clear
+  `"Failed to attach datum plane to '<ref>' — attachment did not resolve."`
+  (The executor sandbox remains the higher-level net.)
+
+## Result
+
+`ToolResult(success=True, output=..., data={"name", "label", "type_id"})`. The
+output names the created plane and notes it can be passed to
+`create_sketch(support="<name>")`. A `body_name`-ignored warning is surfaced the
+same way as `create_sketch` when `body_name` is passed alongside a `support`
+reference.
+
+## Code organization
+
+- New pure `_resolve_datum_plane_attachment(...)` (delegates to
+  `_resolve_sketch_attachment`, remaps `standalone`→error), new handler
+  `_handle_create_datum_plane(...)`, and `CREATE_DATUM_PLANE` `ToolDefinition` in
+  `freecad_ai/tools/freecad_tools.py`, placed near `create_sketch` (the
+  resolution layer it reuses).
+- Register `CREATE_DATUM_PLANE` in `ALL_TOOLS` (the list at `freecad_tools.py:5103`).
+- The reference-resolve → pick-container → attach sequence is ~15 lines shared in
+  spirit with `_handle_create_sketch`. To avoid a churny refactor of just-merged
+  piece-#1 code, this piece **inlines** those lines rather than extracting a
+  shared `_attach_feature(...)` helper now. A future extraction (when piece #3
+  `create_datum_line` adds a third consumer) is noted as a refactor opportunity,
+  not done here.
+
+## Testing
+
+Reference resolution is already unit-tested in piece #1
+(`tests/unit/test_sketch_attachment.py`), so this piece is exercised mainly by
+integration tests (real FreeCAD) plus one small pure check.
+
+**Unit (no FreeCAD):** test `_resolve_datum_plane_attachment`:
+- `standalone` input (no support, no body) → `error` with the no-reference
+  message.
+- `face` / `plane` / `origin` / `error` inputs pass through unchanged (delegation
+  to `_resolve_sketch_attachment` is intact).
+
+**Integration (real FreeCAD, via `run_freecad_script`):**
+- Datum plane offset from XY origin plane in a Body → object is
+  `PartDesign::Plane`, lives in the Body, and its global placement is offset by
+  `offset` in Z.
+- Datum plane offset from a planar face of a Body feature → `PartDesign::Plane`
+  attached, offset along the face normal.
+- Datum plane from a **standalone** `Part::Feature` solid's face → object is
+  `Part::DatumPlane` (standalone), attached to the face.
+- End-to-end: `create_datum_plane` then `create_sketch(support="<plane name>")`
+  succeeds and the sketch attaches to the datum plane (closes the loop; piece #1
+  is on master so this is runnable).
+- No-reference call (`create_datum_plane(offset=10)`, no body/support/selection)
+  → clean error.
+- Non-planar face (`support` = cylinder, curved face) → clean error.
+
+## Backwards compatibility
+
+Purely additive: a new tool and one new entry in `ALL_TOOLS`. No existing tool,
+schema, or behavior changes.
+
+## Roadmap (context only — not this spec)
+
+Piece #2 of four. Remaining: (3) `create_datum_line` (two points, or an origin
+axis + offset); (4) `transform_object` — add a `copy`/duplicate option and a
+relative-vs-absolute mode (it currently overwrites `Placement` and cannot
+duplicate). Wiki `Tool-Reference.md` gets a `create_datum_plane` entry as part of
+this piece's docs step.

--- a/docs/superpowers/specs/2026-06-02-create-datum-plane-design.md
+++ b/docs/superpowers/specs/2026-06-02-create-datum-plane-design.md
@@ -104,7 +104,10 @@ Object created:
 - container is a Body → `container.newObject("PartDesign::Plane", label or
   "DatumPlane")`.
 - standalone (reference is a plain `Part::Feature` face, e.g. an imported
-  mesh→solid) → `doc.addObject("Part::DatumPlane", label or "DatumPlane")`.
+  mesh→solid) → `doc.addObject("PartDesign::Plane", label or "DatumPlane")`.
+  (FreeCAD 1.1 has no separate `Part::DatumPlane` type — `PartDesign::Plane`
+  works both inside a Body via `newObject` and standalone via `addObject`,
+  confirmed empirically.)
 
 ### Attachment
 
@@ -173,8 +176,8 @@ integration tests (real FreeCAD) plus one small pure check.
   `offset` in Z.
 - Datum plane offset from a planar face of a Body feature → `PartDesign::Plane`
   attached, offset along the face normal.
-- Datum plane from a **standalone** `Part::Feature` solid's face → object is
-  `Part::DatumPlane` (standalone), attached to the face.
+- Datum plane from a **standalone** `Part::Feature` solid's face → a standalone
+  `PartDesign::Plane` (created via `doc.addObject`), attached to the face.
 - End-to-end: `create_datum_plane` then `create_sketch(support="<plane name>")`
   succeeds and the sketch attaches to the datum plane (closes the loop; piece #1
   is on master so this is runnable).

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -329,6 +329,25 @@ def _resolve_sketch_attachment(support, face, plane, body_present,
     return {"mode": "standalone"}
 
 
+def _resolve_datum_plane_attachment(support, face, plane, body_present,
+                                    support_kind, face_exists, face_planar, in_body):
+    """Reference resolution for create_datum_plane. Pure — no FreeCAD calls.
+
+    Delegates to ``_resolve_sketch_attachment`` and remaps the one datum-specific
+    decision: a datum plane cannot be free-floating, so a ``standalone`` result
+    (no usable reference) becomes an error. All other modes pass through.
+    """
+    spec = _resolve_sketch_attachment(
+        support, face, plane, body_present,
+        support_kind, face_exists, face_planar, in_body)
+    if spec["mode"] == "standalone":
+        return {"mode": "error",
+                "message": ("create_datum_plane needs a reference: pass a plane "
+                            "(XY/XZ/YZ) with body_name, or a support object "
+                            "(optionally with a face).")}
+    return spec
+
+
 _PLANE_TYPE_IDS = ("App::Plane", "PartDesign::Plane", "Part::DatumPlane")
 
 

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -889,11 +889,12 @@ def _handle_create_datum_plane(
         else:  # origin
             container = body
 
-        # PartDesign::Plane inside a Body, else a standalone Part::DatumPlane.
+        # PartDesign::Plane works both inside a Body (newObject) and standalone
+        # (addObject) — FreeCAD 1.1 has no separate standalone datum-plane type.
         if container is not None:
             datum = container.newObject("PartDesign::Plane", label or "DatumPlane")
         else:
-            datum = doc.addObject("Part::DatumPlane", label or "DatumPlane")
+            datum = doc.addObject("PartDesign::Plane", label or "DatumPlane")
 
         # Attach to the reference. All modes use FlatFace, so the datum's local
         # Z is the reference normal and the offset is always (0, 0, offset).
@@ -960,7 +961,8 @@ CREATE_DATUM_PLANE = ToolDefinition(
         "planar face of an object (support='Obj', face='Face6' — names from "
         "list_faces); or an existing plane by name (support='PlaneName'). With no "
         "reference, the current planar-face/plane selection is used. The result "
-        "is a PartDesign::Plane inside a Body, or a standalone Part::DatumPlane, "
+        "is a PartDesign::Plane (inside a Body, or standalone when the reference "
+        "is not in a Body), "
         "and can be passed to create_sketch as support='<name>'."
     ),
     category="modeling",

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -908,7 +908,15 @@ def _handle_create_datum_plane(
             if plane_feat:
                 datum.AttachmentSupport = [(plane_feat, "")]
                 datum.MapMode = "FlatFace"
+            else:
+                warnings.append(
+                    f"could not resolve the {spec['plane']} origin plane — "
+                    "datum left at the document origin.")
 
+        # AttachmentOffset is in the datum's local frame, whose Z is the
+        # reference normal (FlatFace) for every mode — so (0, 0, offset) is
+        # always along the normal. (create_sketch maps origin-plane offsets to
+        # global axes for legacy reasons; the result is equivalent.)
         if offset != 0:
             datum.AttachmentOffset = App.Placement(
                 App.Vector(0, 0, offset), App.Rotation())
@@ -919,7 +927,12 @@ def _handle_create_datum_plane(
         # Invalid/Error. (The executor sandbox is the higher-level net.)
         state = list(getattr(datum, "State", []) or [])
         if any(s in ("Invalid", "Error") for s in state):
-            ref = spec.get("support") or spec.get("plane") or "reference"
+            if spec.get("support"):
+                ref = spec["support"]
+            elif spec.get("plane"):
+                ref = "origin plane " + spec["plane"]
+            else:
+                ref = "reference"
             return ToolResult(
                 success=False, output="",
                 error=(f"Failed to attach datum plane to '{ref}'"

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -820,6 +820,160 @@ CREATE_SKETCH = ToolDefinition(
 )
 
 
+# ── create_datum_plane ──────────────────────────────────────
+
+def _handle_create_datum_plane(
+    plane: str = "XY",
+    support: str = "",
+    face: str = "",
+    offset: float = 0.0,
+    body_name: str = "",
+    label: str = "",
+) -> ToolResult:
+    """Create a parametric datum plane offset from a reference."""
+    import FreeCAD as App
+
+    def do(doc):
+        warnings = []
+
+        body = None
+        if body_name:
+            body = _get_object(doc, body_name)
+            if not body:
+                hint = _suggest_similar(doc, body_name, "Body")
+                return ToolResult(success=False, output="", error=f"Body '{body_name}' not found.{hint}")
+
+        # Bare-call selection fallback — same gate as create_sketch: only when
+        # no explicit reference and the default plane were given.
+        sup, fc = support, face
+        if (not support and not face and not body_name
+                and plane.upper() == "XY"):
+            picked = _read_planar_selection()
+            if picked:
+                sup, fc = picked
+
+        sup_kind = ""
+        face_exists = face_planar = False
+        in_body = None
+        sup_obj = None
+        if sup:
+            sup_obj = _get_object(doc, sup)
+            if sup_obj is None:
+                sup_kind = "missing"
+            else:
+                sup = sup_obj.Name
+                sup_kind = _classify_support(sup_obj)
+                in_body = _owning_body_name(sup_obj, doc.Objects)
+                if fc:
+                    face_exists, face_planar = _inspect_face(sup_obj, fc)
+
+        spec = _resolve_datum_plane_attachment(
+            sup, fc, plane, body is not None,
+            sup_kind, face_exists, face_planar, in_body,
+        )
+        if spec["mode"] == "error":
+            hint = _suggest_similar(doc, support) if sup_kind == "missing" else ""
+            return ToolResult(success=False, output="", error=spec["message"] + hint)
+
+        # Choose the container the datum plane is created in (same logic as
+        # create_sketch).
+        if spec["mode"] in ("face", "plane"):
+            if body_name:
+                warnings.append("body_name ignored — datum plane placed relative to support.")
+            if spec.get("in_body"):
+                container = _get_object(doc, spec["in_body"])
+            elif sup_obj is not None and getattr(sup_obj, "TypeId", "") == "PartDesign::Body":
+                container = sup_obj
+            else:
+                container = None
+        else:  # origin
+            container = body
+
+        # PartDesign::Plane inside a Body, else a standalone Part::DatumPlane.
+        if container is not None:
+            datum = container.newObject("PartDesign::Plane", label or "DatumPlane")
+        else:
+            datum = doc.addObject("Part::DatumPlane", label or "DatumPlane")
+
+        # Attach to the reference. All modes use FlatFace, so the datum's local
+        # Z is the reference normal and the offset is always (0, 0, offset).
+        if spec["mode"] == "face":
+            datum.AttachmentSupport = [(sup_obj, spec["sub"])]
+            datum.MapMode = "FlatFace"
+        elif spec["mode"] == "plane":
+            datum.AttachmentSupport = [(sup_obj, "")]
+            datum.MapMode = "FlatFace"
+        elif spec["mode"] == "origin":
+            plane_feat = _get_body_plane(container, spec["plane"])
+            if plane_feat:
+                datum.AttachmentSupport = [(plane_feat, "")]
+                datum.MapMode = "FlatFace"
+
+        if offset != 0:
+            datum.AttachmentOffset = App.Placement(
+                App.Vector(0, 0, offset), App.Rotation())
+
+        doc.recompute()
+
+        # If the attachment can't resolve, FreeCAD marks the feature's State as
+        # Invalid/Error. (The executor sandbox is the higher-level net.)
+        state = list(getattr(datum, "State", []) or [])
+        if any(s in ("Invalid", "Error") for s in state):
+            ref = spec.get("support") or spec.get("plane") or "reference"
+            return ToolResult(
+                success=False, output="",
+                error=(f"Failed to attach datum plane to '{ref}'"
+                       + (f":{spec['sub']}" if spec.get("sub") else "")
+                       + " — attachment did not resolve."))
+
+        return ToolResult(
+            success=True,
+            output=(("⚠ " + " ".join(warnings) + "\n" if warnings else "")
+                    + f"Created datum plane '{datum.Name}' ({datum.TypeId})."
+                    + f" Use support='{datum.Name}' in create_sketch."),
+            data={"name": datum.Name, "label": datum.Label,
+                  "type_id": datum.TypeId},
+        )
+
+    return _with_undo("Create Datum Plane", do)
+
+
+CREATE_DATUM_PLANE = ToolDefinition(
+    name="create_datum_plane",
+    description=(
+        "Create a parametric datum plane offset (parallel) from a reference — "
+        "useful as a mid-plane, an offset sketch plane, or a mirror reference. "
+        "Reference options: an origin plane (plane=XY/XZ/YZ, needs body_name); a "
+        "planar face of an object (support='Obj', face='Face6' — names from "
+        "list_faces); or an existing plane by name (support='PlaneName'). With no "
+        "reference, the current planar-face/plane selection is used. The result "
+        "is a PartDesign::Plane inside a Body, or a standalone Part::DatumPlane, "
+        "and can be passed to create_sketch as support='<name>'."
+    ),
+    category="modeling",
+    parameters=[
+        ToolParam("plane", "string", "Origin-plane reference: XY, XZ, or YZ "
+                  "(used when no support; needs body_name).",
+                  required=False, default="XY", enum=["XY", "XZ", "YZ"]),
+        ToolParam("support", "string", "Object to offset from: a solid (with "
+                  "`face`) or an existing plane object by name.",
+                  required=False, default=""),
+        ToolParam("face", "string", "Planar sub-element of `support`, e.g. "
+                  "'Face6' (from list_faces). Requires `support`.",
+                  required=False, default=""),
+        ToolParam("offset", "number", "Parallel offset along the reference "
+                  "normal in mm (may be negative).",
+                  required=False, default=0.0),
+        ToolParam("body_name", "string", "Body to create the PartDesign::Plane "
+                  "in (required for an origin-plane reference).",
+                  required=False, default=""),
+        ToolParam("label", "string", "Display label for the datum plane.",
+                  required=False, default=""),
+    ],
+    handler=_handle_create_datum_plane,
+)
+
+
 # ── edit_sketch ────────────────────────────────────────────
 
 def _handle_edit_sketch(
@@ -5123,6 +5277,7 @@ ALL_TOOLS = [
     CREATE_PRIMITIVE,
     CREATE_BODY,
     CREATE_SKETCH,
+    CREATE_DATUM_PLANE,
     EDIT_SKETCH,
     PAD_SKETCH,
     POCKET_SKETCH,

--- a/tests/integration/test_datum_plane_integration.py
+++ b/tests/integration/test_datum_plane_integration.py
@@ -149,3 +149,48 @@ results["data"] = {"success": r.success, "error": r.error, "face": nonplanar}
         assert d["face"] is not None
         assert not d["success"]
         assert "planar" in d["error"].lower()
+
+    def test_offset_from_xz_origin_plane_is_along_normal(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_body, _handle_create_datum_plane
+
+_handle_create_body(label="Body")
+doc.recompute()
+r = _handle_create_datum_plane(plane="XZ", body_name="Body", offset=15.0)
+doc.recompute()
+dp = doc.getObject(r.data["name"]) if r.success else None
+b = dp.Placement.Base if dp else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "x": b.x if b else None,
+    "y": b.y if b else None,
+    "z": b.z if b else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        # XZ plane normal is global Y → offset moves purely along Y.
+        assert abs(d["x"]) < 1e-6
+        assert abs(d["z"]) < 1e-6
+        assert abs(abs(d["y"]) - 15.0) < 1e-6
+
+    def test_body_name_with_support_warns(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_body, _handle_create_datum_plane
+
+_handle_create_body(label="Body")
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_create_datum_plane(support="Box", face="Face6", body_name="Body")
+doc.recompute()
+results["data"] = {"success": r.success, "error": r.error, "output": r.output}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert "ignored" in d["output"].lower()

--- a/tests/integration/test_datum_plane_integration.py
+++ b/tests/integration/test_datum_plane_integration.py
@@ -1,0 +1,151 @@
+"""Integration tests for create_datum_plane (runs inside FreeCAD).
+
+Uses the run_freecad_script fixture (see tests/integration/conftest.py).
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestCreateDatumPlane:
+    def test_offset_from_origin_plane_in_body(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_body, _handle_create_datum_plane
+
+_handle_create_body(label="Body")
+doc.recompute()
+r = _handle_create_datum_plane(plane="XY", body_name="Body", offset=20.0)
+doc.recompute()
+dp = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "type_id": dp.TypeId if dp else None,
+    "z": dp.Placement.Base.z if dp else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["type_id"] == "PartDesign::Plane"
+        assert abs(d["z"] - 20.0) < 1e-6
+
+    def test_offset_from_body_feature_face(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane
+
+body = doc.addObject("PartDesign::Body", "Body")
+box = body.newObject("PartDesign::AdditiveBox", "Box")
+box.Length = 10; box.Width = 10; box.Height = 10
+doc.recompute()
+
+planar = None
+for i, f in enumerate(box.Shape.Faces, start=1):
+    if isinstance(f.Surface, Part.Plane):
+        planar = "Face%d" % i
+        break
+
+r = _handle_create_datum_plane(support="Box", face=planar)
+doc.recompute()
+dp = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "type_id": dp.TypeId if dp else None,
+    "face": planar,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["type_id"] == "PartDesign::Plane"
+
+    def test_offset_from_standalone_solid_face(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_create_datum_plane(support="Box", face="Face6", offset=3.0)
+doc.recompute()
+dp = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "type_id": dp.TypeId if dp else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["type_id"] == "PartDesign::Plane"
+
+    def test_sketch_on_created_datum_plane(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane, _handle_create_sketch
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+dp_r = _handle_create_datum_plane(support="Box", face="Face6", offset=5.0)
+doc.recompute()
+
+sk_r = _handle_create_sketch(support=dp_r.data["name"])
+doc.recompute()
+sk = doc.getObject(sk_r.data["name"]) if sk_r.success else None
+results["data"] = {
+    "datum_ok": dp_r.success,
+    "datum_err": dp_r.error,
+    "sketch_ok": sk_r.success,
+    "sketch_err": sk_r.error,
+    "map_mode": sk.MapMode if sk else None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["datum_ok"], d["datum_err"]
+        assert d["sketch_ok"], d["sketch_err"]
+        assert d["map_mode"] == "FlatFace"
+
+    def test_no_reference_errors(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane
+
+r = _handle_create_datum_plane(offset=10.0)
+results["data"] = {"success": r.success, "error": r.error}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert not d["success"]
+        assert "reference" in d["error"].lower()
+
+    def test_non_planar_face_errors(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_create_datum_plane
+
+feat = doc.addObject("Part::Feature", "Cyl")
+feat.Shape = Part.makeCylinder(5, 10)
+doc.recompute()
+
+nonplanar = None
+for i, f in enumerate(feat.Shape.Faces, start=1):
+    if not isinstance(f.Surface, Part.Plane):
+        nonplanar = "Face%d" % i
+        break
+
+r = _handle_create_datum_plane(support="Cyl", face=nonplanar)
+results["data"] = {"success": r.success, "error": r.error, "face": nonplanar}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["face"] is not None
+        assert not d["success"]
+        assert "planar" in d["error"].lower()

--- a/tests/unit/test_datum_plane.py
+++ b/tests/unit/test_datum_plane.py
@@ -45,3 +45,21 @@ class TestResolveDatumPlaneAttachment:
                         face_exists=True, face_planar=False)
         assert spec["mode"] == "error"
         assert "planar" in spec["message"].lower()
+
+
+from freecad_ai.tools.freecad_tools import CREATE_DATUM_PLANE, ALL_TOOLS
+
+
+class TestCreateDatumPlaneDefinition:
+    def test_name_and_category(self):
+        assert CREATE_DATUM_PLANE.name == "create_datum_plane"
+        assert CREATE_DATUM_PLANE.category == "modeling"
+
+    def test_registered_in_all_tools(self):
+        assert CREATE_DATUM_PLANE in ALL_TOOLS
+
+    def test_no_array_param_missing_items(self):
+        # GitHub Models rejects array params declared without `items` (issue #10).
+        for p in CREATE_DATUM_PLANE.parameters:
+            if getattr(p, "type", None) == "array":
+                assert getattr(p, "items", None) is not None, p.name

--- a/tests/unit/test_datum_plane.py
+++ b/tests/unit/test_datum_plane.py
@@ -1,0 +1,47 @@
+"""Unit tests for the pure create_datum_plane reference resolver (no FreeCAD)."""
+
+from freecad_ai.tools.freecad_tools import _resolve_datum_plane_attachment
+
+
+def _resolve(**kw):
+    base = dict(
+        support="", face="", plane="XY", body_present=False,
+        support_kind="", face_exists=False, face_planar=False, in_body=None,
+    )
+    base.update(kw)
+    return _resolve_datum_plane_attachment(**base)
+
+
+class TestResolveDatumPlaneAttachment:
+    def test_standalone_becomes_no_reference_error(self):
+        # No support, no body → sketch resolver would say "standalone", but a
+        # datum plane needs a reference.
+        spec = _resolve(plane="XY", body_present=False)
+        assert spec["mode"] == "error"
+        assert "reference" in spec["message"].lower()
+
+    def test_face_passes_through(self):
+        spec = _resolve(support="Box", face="Face6", support_kind="solid",
+                        face_exists=True, face_planar=True, in_body="Body")
+        assert spec == {"mode": "face", "support": "Box", "sub": "Face6",
+                        "in_body": "Body"}
+
+    def test_plane_passes_through(self):
+        spec = _resolve(support="DatumPlane", support_kind="plane", in_body=None)
+        assert spec == {"mode": "plane", "support": "DatumPlane", "in_body": None}
+
+    def test_origin_passes_through(self):
+        spec = _resolve(plane="XZ", body_present=True)
+        assert spec == {"mode": "origin", "plane": "XZ"}
+
+    def test_resolver_error_passes_through(self):
+        # face without support is an error in the underlying resolver.
+        spec = _resolve(face="Face1")
+        assert spec["mode"] == "error"
+        assert "support" in spec["message"].lower()
+
+    def test_non_planar_face_error_passes_through(self):
+        spec = _resolve(support="Cyl", face="Face1", support_kind="solid",
+                        face_exists=True, face_planar=False)
+        assert spec["mode"] == "error"
+        assert "planar" in spec["message"].lower()


### PR DESCRIPTION
Piece #2 of the datum-geometry/transform suite tracked in #18. Adds a `create_datum_plane` tool that creates a parametric datum plane offset (parallel) from an origin plane, a planar face, an existing plane, or the current viewport selection.

## Why
A datum plane is the "mid-plane / offset sketch plane / mirror reference" step on real parametric workflows (e.g. the snap-fit part behind #17/#18). With piece #1 (`create_sketch` face/plane attachment, #20) now on `master`, the created plane is referenceable as `create_sketch(support="<name>")`, closing the loop: **make an offset plane → sketch on it → pad/pocket**.

## What
New tool `create_datum_plane` with params mirroring `create_sketch`: `plane` (XY/XZ/YZ), `support`, `face`, `offset`, `body_name`, `label`, plus the same bare-call GUI-selection fallback.

- Reuses piece #1's resolution layer via a thin **pure** wrapper `_resolve_datum_plane_attachment` (delegates to `_resolve_sketch_attachment`, remaps `standalone`→error — a datum plane needs a reference).
- Produces a `PartDesign::Plane` — inside a Body via `newObject`, or standalone via `addObject` (FreeCAD 1.1 has no separate `Part::DatumPlane` type; verified empirically — see below).
- Parametric attachment (`FlatFace` + `AttachmentOffset` along the reference normal), so the plane moves with its reference — history-preserving, the through-line of #17/#18.
- Offset-only (no tilt). Purely additive: one new tool + one `ALL_TOOLS` entry.

## Notable: a bug caught by integration testing
The first cut used `doc.addObject("Part::DatumPlane", ...)` for the standalone case. Real-FreeCAD integration testing surfaced that `Part::DatumPlane` is **not a valid type** in FreeCAD 1.1; an empirical probe confirmed a standalone `PartDesign::Plane` attaches/offsets/recomputes cleanly, so the standalone branch now uses that (commit `45b0fd6`). Unit tests + code review alone could not have caught this — it only shows up against the live API.

## Test plan
- [x] Unit (no FreeCAD): `tests/unit/test_datum_plane.py` — pure `_resolve_datum_plane_attachment` (standalone→error, all other modes pass through) + ToolDefinition schema guard.
- [x] Integration (real FreeCAD): `tests/integration/test_datum_plane_integration.py` — origin-plane-in-body, body-feature face, standalone-solid face, **end-to-end datum→sketch-on-it**, XZ offset-along-normal, body_name+support warning, no-reference error, non-planar error (8 tests).
- [x] Full unit suite green (866 passed; pre-existing `test_document_attach.py` Qt segfault excluded).

## Follow-ups (remain in #18)
- `create_datum_line` (piece #3) and a `transform_object` copy/relative-mode extension (piece #4).

Wiki `Tool-Reference.md` updated locally (committed in the wiki repo; not pushed — maintainer pushes the wiki manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)