### PR TITLE
feat: transform_object relative mode + duplicate_object tool (piece #4, final)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-transform-and-duplicate.md
+++ b/docs/superpowers/plans/2026-06-02-transform-and-duplicate.md
@@ -1,0 +1,619 @@
+# transform_object relative mode + duplicate_object Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `transform_object` a relative-by-default move/rotate mode (fixing the placement-reset footgun) and add a `duplicate_object` tool that makes an independent, history-preserving parametric copy and optionally offsets it.
+
+**Architecture:** Both handlers share one FreeCAD-using helper `_apply_relative_placement(...)` (global translate + rotate-in-place). `transform_object` gains a `relative` bool (default True); `relative=False` keeps today's absolute overwrite. `duplicate_object` uses `doc.copyObject(obj, with_dependencies=True)` then applies the same relative offset to the copy. A tiny pure `_duplicate_label(...)` is the only unit-testable logic bit; placement semantics and `copyObject`'s return shape are pinned by integration tests.
+
+**Tech Stack:** Python 3.11, FreeCAD 1.1.1 (PySide6), pytest. Unit: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/ -q`. Integration (FreeCAD AppImage, `run_freecad_script` fixture): add `-m integration`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-transform-and-duplicate-design.md`
+
+**Branch:** `feature/transform-object` (already created off `master`; spec already committed on it). Note: `create_datum_line` (PR #22) is NOT on this branch, so the end-to-end test builds its datum line directly in the test script.
+
+---
+
+## Conventions to follow (read before starting)
+
+- `ToolParam(name, type, description, required=..., default=..., enum=..., items=...)`.
+- `_get_object(doc, name)` resolves Name then Label; `_suggest_similar(doc, name)` → "did you mean" hint string; `_with_undo(label, do)` wraps the mutation. All exist in `freecad_ai/tools/freecad_tools.py`.
+- Handlers `import FreeCAD as App` INSIDE the function (the unit suite imports the module without FreeCAD).
+- Integration tests: assert `result["ok"]` first, then read `result["data"]`; each test's script sets `results["data"] = {...}`; a fresh `doc` per test.
+- Pyright "Import FreeCAD/Part could not be resolved" warnings are EXPECTED (runtime-only imports), not defects.
+
+---
+
+## Task 1: transform_object relative mode + shared placement helper
+
+**Files:**
+- Modify: `freecad_ai/tools/freecad_tools.py` — add `_apply_relative_placement` (near `_handle_transform_object`, ~line 1805); rewrite `_handle_transform_object` (`:1806`); add the `relative` param + new description to `TRANSFORM_OBJECT` (`:1847`).
+- Test: `tests/unit/test_transform_duplicate.py` (create)
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `tests/unit/test_transform_duplicate.py`:
+
+```python
+"""Unit tests for transform_object relative mode + duplicate_object definitions."""
+
+from freecad_ai.tools.freecad_tools import TRANSFORM_OBJECT
+
+
+class TestTransformObjectDefinition:
+    def test_relative_param_default_true(self):
+        params = {p.name: p for p in TRANSFORM_OBJECT.parameters}
+        assert "relative" in params
+        assert params["relative"].type == "boolean"
+        assert params["relative"].default is True
+
+    def test_no_copy_param(self):
+        names = {p.name for p in TRANSFORM_OBJECT.parameters}
+        assert "copy" not in names
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_transform_duplicate.py -q`
+Expected: FAIL — `assert "relative" in params` fails (param not yet added).
+
+- [ ] **Step 3: Add the shared placement helper**
+
+In `freecad_ai/tools/freecad_tools.py`, immediately BEFORE `def _handle_transform_object` (~line 1805), add:
+
+```python
+def _apply_relative_placement(old, tx, ty, tz, ax, ay, az, angle):
+    """Compose a relative move/rotate onto an existing placement.
+
+    Translate is global (added to the base); rotation is applied in place about
+    the object's own origin (pre-multiplied onto the current rotation, base kept).
+    Uses FreeCAD's placement math — intentionally NOT a pure/standalone helper
+    (reimplementing quaternion composition would be more error-prone). Pinned by
+    integration tests.
+    """
+    import FreeCAD as App
+    new_base = old.Base + App.Vector(tx, ty, tz)
+    delta_rot = App.Rotation(App.Vector(ax, ay, az), angle)
+    new_rot = delta_rot.multiply(old.Rotation)
+    return App.Placement(new_base, new_rot)
+```
+
+- [ ] **Step 4: Rewrite the handler**
+
+Replace the body of `_handle_transform_object` (`:1806`–`:1844`) with:
+
+```python
+def _handle_transform_object(
+    object_name: str,
+    translate_x: float = 0.0,
+    translate_y: float = 0.0,
+    translate_z: float = 0.0,
+    rotate_axis_x: float = 0.0,
+    rotate_axis_y: float = 0.0,
+    rotate_axis_z: float = 1.0,
+    rotate_angle: float = 0.0,
+    relative: bool = True,
+) -> ToolResult:
+    """Move and/or rotate an object, relative to its current placement by default."""
+    import FreeCAD as App
+
+    def do(doc):
+        obj = _get_object(doc, object_name)
+        if not obj:
+            hint = _suggest_similar(doc, object_name)
+            return ToolResult(success=False, output="", error=f"Object '{object_name}' not found.{hint}")
+
+        if relative:
+            obj.Placement = _apply_relative_placement(
+                obj.Placement, translate_x, translate_y, translate_z,
+                rotate_axis_x, rotate_axis_y, rotate_axis_z, rotate_angle)
+        else:
+            obj.Placement = App.Placement(
+                App.Vector(translate_x, translate_y, translate_z),
+                App.Rotation(App.Vector(rotate_axis_x, rotate_axis_y, rotate_axis_z), rotate_angle))
+
+        parts = []
+        if translate_x or translate_y or translate_z:
+            parts.append(f"translated ({translate_x}, {translate_y}, {translate_z})")
+        if rotate_angle:
+            parts.append(f"rotated {rotate_angle}°")
+        mode = "relative" if relative else "absolute"
+        if parts:
+            desc = ", ".join(parts) + f" ({mode})"
+        elif relative:
+            desc = "unchanged (relative, no delta given)"
+        else:
+            desc = "placement reset to origin (absolute)"
+
+        return ToolResult(
+            success=True,
+            output=f"Transformed '{obj.Label}': {desc}",
+            data={"name": obj.Name},
+        )
+
+    return _with_undo("Transform Object", do)
+```
+
+- [ ] **Step 5: Update the ToolDefinition**
+
+Replace the `TRANSFORM_OBJECT = ToolDefinition(...)` block (`:1847`–`:1862`) with:
+
+```python
+TRANSFORM_OBJECT = ToolDefinition(
+    name="transform_object",
+    description=(
+        "Move and/or rotate an object. By default (relative=True) the change is "
+        "applied RELATIVE to the object's current placement — translation adds to "
+        "its position, rotation spins it in place, and 0 means no change. Set "
+        "relative=False for an ABSOLUTE placement (overwrites position and "
+        "orientation; omitted values reset to 0). Does not copy — use "
+        "duplicate_object to make a copy."
+    ),
+    category="modeling",
+    parameters=[
+        ToolParam("object_name", "string", "Internal name of the object to transform"),
+        ToolParam("translate_x", "number", "X translation in mm", required=False, default=0.0),
+        ToolParam("translate_y", "number", "Y translation in mm", required=False, default=0.0),
+        ToolParam("translate_z", "number", "Z translation in mm", required=False, default=0.0),
+        ToolParam("rotate_axis_x", "number", "Rotation axis X component", required=False, default=0.0),
+        ToolParam("rotate_axis_y", "number", "Rotation axis Y component", required=False, default=0.0),
+        ToolParam("rotate_axis_z", "number", "Rotation axis Z component", required=False, default=1.0),
+        ToolParam("rotate_angle", "number", "Rotation angle in degrees", required=False, default=0.0),
+        ToolParam("relative", "boolean", "Apply relative to the current placement "
+                  "(default). False = absolute overwrite.", required=False, default=True),
+    ],
+    handler=_handle_transform_object,
+)
+```
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_transform_duplicate.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add freecad_ai/tools/freecad_tools.py tests/unit/test_transform_duplicate.py
+git commit -m "feat(transform_object): relative-by-default move/rotate + shared placement helper"
+```
+
+---
+
+## Task 2: duplicate_object tool
+
+**Files:**
+- Modify: `freecad_ai/tools/freecad_tools.py` — add `_duplicate_label`, `_handle_duplicate_object`, `DUPLICATE_OBJECT` (right after the `TRANSFORM_OBJECT` block); register `DUPLICATE_OBJECT` in `ALL_TOOLS` (after `    TRANSFORM_OBJECT,` ~line 5303).
+- Test: `tests/unit/test_transform_duplicate.py` (append)
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Append to `tests/unit/test_transform_duplicate.py`:
+
+```python
+from freecad_ai.tools.freecad_tools import (
+    DUPLICATE_OBJECT, ALL_TOOLS, _duplicate_label,
+)
+
+
+class TestDuplicateObjectDefinition:
+    def test_name_and_category(self):
+        assert DUPLICATE_OBJECT.name == "duplicate_object"
+        assert DUPLICATE_OBJECT.category == "modeling"
+
+    def test_registered_in_all_tools(self):
+        assert DUPLICATE_OBJECT in ALL_TOOLS
+
+    def test_array_params_declare_items(self):
+        # Consistency guard (issue #10) even though these params are scalar/string.
+        for p in DUPLICATE_OBJECT.parameters:
+            if getattr(p, "type", None) == "array":
+                assert getattr(p, "items", None) is not None, p.name
+
+
+class TestDuplicateLabel:
+    def test_default_label(self):
+        assert _duplicate_label("Box", "") == "Box_Copy"
+
+    def test_explicit_label_wins(self):
+        assert _duplicate_label("Box", "MyCopy") == "MyCopy"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_transform_duplicate.py -q`
+Expected: FAIL — `ImportError: cannot import name 'DUPLICATE_OBJECT'`.
+
+- [ ] **Step 3: Add the label helper, handler, and ToolDefinition**
+
+In `freecad_ai/tools/freecad_tools.py`, immediately AFTER the `TRANSFORM_OBJECT = ToolDefinition(...)` block (ends ~line 1862, before `# ── fillet_edges ─`), add:
+
+```python
+def _duplicate_label(base_label, requested):
+    """Label for a duplicated object: the requested label, or '<base>_Copy'."""
+    return requested or f"{base_label}_Copy"
+
+
+def _handle_duplicate_object(
+    object_name: str,
+    translate_x: float = 0.0,
+    translate_y: float = 0.0,
+    translate_z: float = 0.0,
+    rotate_axis_x: float = 0.0,
+    rotate_axis_y: float = 0.0,
+    rotate_axis_z: float = 1.0,
+    rotate_angle: float = 0.0,
+    label: str = "",
+) -> ToolResult:
+    """Duplicate an object (independent parametric copy), optionally offsetting it."""
+
+    def do(doc):
+        obj = _get_object(doc, object_name)
+        if not obj:
+            hint = _suggest_similar(doc, object_name)
+            return ToolResult(success=False, output="", error=f"Object '{object_name}' not found.{hint}")
+
+        result = doc.copyObject(obj, True)
+        # copyObject returns the copy of the passed object; guard for a list/None
+        # return across FreeCAD versions (the exact shape is pinned in integration).
+        copy = result[-1] if isinstance(result, (list, tuple)) else result
+        if copy is None:
+            return ToolResult(success=False, output="", error=f"Failed to duplicate '{obj.Label}'.")
+
+        copy.Label = _duplicate_label(obj.Label, label)
+
+        if translate_x or translate_y or translate_z or rotate_angle:
+            copy.Placement = _apply_relative_placement(
+                copy.Placement, translate_x, translate_y, translate_z,
+                rotate_axis_x, rotate_axis_y, rotate_axis_z, rotate_angle)
+
+        doc.recompute()
+
+        state = list(getattr(copy, "State", []) or [])
+        if any(s in ("Invalid", "Error") for s in state):
+            return ToolResult(success=False, output="",
+                              error=f"Duplicate '{copy.Label}' did not recompute cleanly.")
+
+        return ToolResult(
+            success=True,
+            output=(f"Duplicated '{obj.Label}' → '{copy.Label}' ({copy.TypeId}); "
+                    "original unchanged."),
+            data={"name": copy.Name, "label": copy.Label},
+        )
+
+    return _with_undo("Duplicate Object", do)
+
+
+DUPLICATE_OBJECT = ToolDefinition(
+    name="duplicate_object",
+    description=(
+        "Duplicate an object as an independent, editable copy that preserves its "
+        "parametric history (the whole feature tree — e.g. a Body with its sketches "
+        "and pads). The original is left unchanged. Optional translate/rotate offset "
+        "the copy relative to the original (0 = on top of it). To duplicate a solid, "
+        "pass its Body. Note: if the object's placement is driven by an attachment "
+        "(e.g. a datum attached to an edge), the offset won't stick — duplicate a "
+        "fixed-placement object (such as a two-point datum line) for a parallel copy."
+    ),
+    category="modeling",
+    parameters=[
+        ToolParam("object_name", "string", "Internal name of the object to duplicate"),
+        ToolParam("translate_x", "number", "X offset of the copy in mm", required=False, default=0.0),
+        ToolParam("translate_y", "number", "Y offset of the copy in mm", required=False, default=0.0),
+        ToolParam("translate_z", "number", "Z offset of the copy in mm", required=False, default=0.0),
+        ToolParam("rotate_axis_x", "number", "Rotation axis X component", required=False, default=0.0),
+        ToolParam("rotate_axis_y", "number", "Rotation axis Y component", required=False, default=0.0),
+        ToolParam("rotate_axis_z", "number", "Rotation axis Z component", required=False, default=1.0),
+        ToolParam("rotate_angle", "number", "Rotation angle for the copy in degrees", required=False, default=0.0),
+        ToolParam("label", "string", "Label for the copy (default '<original>_Copy')", required=False, default=""),
+    ],
+    handler=_handle_duplicate_object,
+)
+```
+
+- [ ] **Step 4: Register in ALL_TOOLS**
+
+In the `ALL_TOOLS` list, find `    TRANSFORM_OBJECT,` (~line 5303) and add directly below it:
+
+```python
+    DUPLICATE_OBJECT,
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/test_transform_duplicate.py -q`
+Expected: PASS (7 passed — 2 transform + 5 duplicate).
+
+- [ ] **Step 6: Run the full unit suite (no regressions)**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/unit/ -q --deselect tests/unit/test_document_attach.py`
+Expected: all pass (`test_document_attach.py` deselected — it segfaults on an unrelated Qt issue, on clean master too).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add freecad_ai/tools/freecad_tools.py tests/unit/test_transform_duplicate.py
+git commit -m "feat(duplicate_object): independent parametric copy tool with optional offset"
+```
+
+---
+
+## Task 3: Integration tests (real FreeCAD — pins placement semantics + copyObject)
+
+This task pins the empirically-uncertain behavior: the relative composition (rotate-in-place / translate-preserves-rotation), the absolute-mode regression, and **`doc.copyObject`'s return shape** (single object vs list — the guard in Task 2 is provisional). **If `copyObject` returns a list and `result[-1]` is not the copy of `obj`, fix the handler here** (probe what it returns, identify the obj copy, update the guard) — the same discipline that caught the type/MapMode surprises in pieces #2/#3.
+
+**Files:**
+- Test: `tests/integration/test_transform_duplicate_integration.py` (create)
+- Possibly modify: `freecad_ai/tools/freecad_tools.py` (only if integration reveals a wrong `copyObject` return assumption)
+
+- [ ] **Step 1: Write the integration tests**
+
+Create `tests/integration/test_transform_duplicate_integration.py`:
+
+```python
+"""Integration tests for transform_object relative mode + duplicate_object.
+
+Uses the run_freecad_script fixture (see tests/integration/conftest.py).
+"""
+
+import math
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestTransformRelative:
+    def test_relative_translate_preserves_rotation(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_primitive, _handle_transform_object
+
+_handle_create_primitive(shape_type="box", label="Box")
+doc.recompute()
+# First set an absolute rotation (no translation).
+_handle_transform_object(object_name="Box", relative=False, rotate_axis_z=1.0, rotate_angle=90.0)
+doc.recompute()
+# Then a RELATIVE translate — rotation must survive, position must shift.
+r = _handle_transform_object(object_name="Box", translate_x=10.0)
+doc.recompute()
+obj = doc.getObject("Box")
+results["data"] = {
+    "success": r.success,
+    "x": obj.Placement.Base.x,
+    "angle": obj.Placement.Rotation.Angle,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"]
+        assert abs(d["x"] - 10.0) < 1e-6
+        assert abs(d["angle"] - math.pi / 2) < 0.01  # rotation preserved
+
+    def test_relative_rotate_in_place_preserves_position(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_primitive, _handle_transform_object
+
+_handle_create_primitive(shape_type="box", label="Box")
+doc.recompute()
+# Place the box away from the origin (absolute).
+_handle_transform_object(object_name="Box", relative=False, translate_x=5.0)
+doc.recompute()
+# RELATIVE rotate — position must be preserved (the footgun fix).
+r = _handle_transform_object(object_name="Box", rotate_axis_z=1.0, rotate_angle=90.0)
+doc.recompute()
+obj = doc.getObject("Box")
+results["data"] = {
+    "success": r.success,
+    "x": obj.Placement.Base.x,
+    "angle": obj.Placement.Rotation.Angle,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"]
+        assert abs(d["x"] - 5.0) < 1e-6           # position preserved
+        assert abs(d["angle"] - math.pi / 2) < 0.01
+
+    def test_absolute_mode_overwrites(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_primitive, _handle_transform_object
+
+_handle_create_primitive(shape_type="box", label="Box")
+doc.recompute()
+_handle_transform_object(object_name="Box", relative=False, translate_x=7.0)
+doc.recompute()
+# Absolute rotate with no translate → position resets to origin.
+r = _handle_transform_object(object_name="Box", relative=False, rotate_axis_z=1.0, rotate_angle=45.0)
+doc.recompute()
+obj = doc.getObject("Box")
+results["data"] = {
+    "success": r.success,
+    "x": obj.Placement.Base.x,
+    "angle": obj.Placement.Rotation.Angle,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"]
+        assert abs(d["x"]) < 1e-6                  # absolute overwrite reset position
+        assert abs(d["angle"] - math.pi / 4) < 0.01
+
+
+class TestDuplicateObject:
+    def test_duplicate_body_copies_feature_tree(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_duplicate_object
+
+body = doc.addObject("PartDesign::Body", "Body")
+box = body.newObject("PartDesign::AdditiveBox", "Box")
+box.Length = 10; box.Width = 10; box.Height = 10
+doc.recompute()
+
+r = _handle_duplicate_object(object_name="Body")
+doc.recompute()
+copy = doc.getObject(r.data["name"]) if r.success else None
+bodies = [o for o in doc.Objects if o.TypeId == "PartDesign::Body"]
+copy_children = [o.TypeId for o in (copy.Group if copy else [])]
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "copy_type": copy.TypeId if copy else None,
+    "n_bodies": len(bodies),
+    "copy_has_box": any("AdditiveBox" in t for t in copy_children),
+    "original_intact": doc.getObject("Body") is not None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["copy_type"] == "PartDesign::Body"
+        assert d["n_bodies"] == 2                 # original + copy
+        assert d["copy_has_box"]                  # feature tree duplicated
+        assert d["original_intact"]
+
+    def test_duplicate_with_offset(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_duplicate_object
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_duplicate_object(object_name="Box", translate_x=20.0)
+doc.recompute()
+copy = doc.getObject(r.data["name"]) if r.success else None
+orig = doc.getObject("Box")
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "copy_x": copy.Placement.Base.x if copy else None,
+    "orig_x": orig.Placement.Base.x,
+    "distinct": (copy is not None and copy.Name != "Box"),
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["distinct"]
+        assert abs(d["copy_x"] - 20.0) < 1e-6      # copy offset
+        assert abs(d["orig_x"]) < 1e-6             # original untouched
+
+    def test_duplicate_part_feature_is_independent(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_duplicate_object
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_duplicate_object(object_name="Box", label="BoxClone")
+doc.recompute()
+copy = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "copy_label": copy.Label if copy else None,
+    "copy_type": copy.TypeId if copy else None,
+    "copy_valid": copy.Shape.isValid() if copy else False,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["copy_label"] == "BoxClone"
+        assert d["copy_type"] == "Part::Feature"
+        assert d["copy_valid"]
+
+    def test_duplicate_datum_line_parallel_offset(self, run_freecad_script):
+        # Closes the suite: duplicate a fixed-placement datum line, offset it →
+        # a parallel line. (create_datum_line lives on PR #22, not this branch, so
+        # the first line is built directly here as a two-point datum would be.)
+        result = run_freecad_script("""
+import FreeCAD as App
+from freecad_ai.tools.freecad_tools import _handle_duplicate_object
+
+line = doc.addObject("PartDesign::Line", "DatumLine")
+# A fixed Y-directed line through the origin (two-point style placement).
+line.Placement = App.Placement(App.Vector(0, 0, 0),
+                               App.Rotation(App.Vector(0, 0, 1), App.Vector(0, 1, 0)))
+doc.recompute()
+zdir0 = line.Placement.Rotation.multVec(App.Vector(0, 0, 1))
+
+r = _handle_duplicate_object(object_name="DatumLine", translate_x=10.0)
+doc.recompute()
+copy = doc.getObject(r.data["name"]) if r.success else None
+zdir1 = copy.Placement.Rotation.multVec(App.Vector(0, 0, 1)) if copy else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "copy_x": copy.Placement.Base.x if copy else None,
+    "parallel": (copy is not None and
+                 abs(zdir0.x - zdir1.x) < 1e-6 and
+                 abs(zdir0.y - zdir1.y) < 1e-6 and
+                 abs(zdir0.z - zdir1.z) < 1e-6),
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert abs(d["copy_x"] - 10.0) < 1e-6      # offset by 10mm
+        assert d["parallel"]                       # same direction → parallel
+```
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `env -u PYTHONPATH .venv/bin/python -m pytest tests/integration/test_transform_duplicate_integration.py -m integration -q`
+Expected: PASS (7 passed).
+
+**If a duplicate test fails because `doc.copyObject` returns a list (or the copy of `obj` is not the element the guard picks):** write a throwaway probe via `run_freecad_script` that does `r = doc.copyObject(body, True); results["data"] = {"type": type(r).__name__, "is_list": isinstance(r, (list, tuple)), "len": len(r) if isinstance(r,(list,tuple)) else 1}` and inspect which element is the copy of the passed object (compare `.Name`/`.TypeId`). Update the `copy = ...` guard in `_handle_duplicate_object` accordingly (e.g. match by the copied top object rather than `[-1]`), then re-run. Do NOT weaken assertions to dodge a real return-shape bug.
+
+**If `PartDesign::Line` (used only as a test fixture in `test_duplicate_datum_line_parallel_offset`) is unavailable on this branch's FreeCAD:** it was verified valid in piece #3, so this should work; if not, substitute the fixture with any fixed-placement object (e.g. a `Part::Feature` line/edge) — the test's point is the parallel offset of a fixed-placement duplicate, not the specific type.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_transform_duplicate_integration.py freecad_ai/tools/freecad_tools.py
+git commit -m "test(transform/duplicate): integration tests pin relative semantics + copyObject"
+```
+
+(If the handler needed no fix, only the test file is staged — fine.)
+
+---
+
+## Task 4: Docs — wiki Tool-Reference entries
+
+The wiki is a SEPARATE repo at `../freecad-ai-wiki`. Maintainer pushes it manually — **commit locally, do NOT push.**
+
+**Files:**
+- Modify: `../freecad-ai-wiki/Tool-Reference.md`
+
+- [ ] **Step 1: Locate the existing transform_object entry**
+
+Run: `grep -n "transform_object\|scale_object" ../freecad-ai-wiki/Tool-Reference.md`
+Read the `transform_object` entry and a neighbor (e.g. `scale_object`) to match the exact heading level, parameter-table format, and Notes style.
+
+- [ ] **Step 2: Update transform_object and add duplicate_object**
+
+1. Update the `transform_object` entry: document the new `relative` param (default True = compose onto current placement, 0 = no change; False = absolute overwrite) and that it no longer resets position when only rotating; note it does not copy (point to `duplicate_object`).
+2. Add a `duplicate_object` entry directly after it, in the SAME format, covering: independent parametric copy (whole feature tree, original unchanged); the optional relative translate/rotate offset; `label` default `<original>_Copy`; pass a Body to duplicate a solid; the attachment-driven-placement caveat. Include the seven params (`object_name`, `translate_x/y/z`, `rotate_axis_x/y/z`, `rotate_angle`, `label`) in a table matching the neighbor's layout. If neighbors show example invocations, add an analogous example (e.g. `create_datum_line` → `duplicate_object(translate_x=10)` for a parallel line).
+
+- [ ] **Step 3: Commit locally (do NOT push)**
+
+```bash
+cd ../freecad-ai-wiki
+git add Tool-Reference.md
+git commit -m "docs(tool-reference): transform_object relative mode + duplicate_object entry"
+cd -
+```
+
+Report the wiki commit SHA, run `git -C ../freecad-ai-wiki status -sb`, and confirm it is **not pushed**.
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** `transform_object` relative mode + footgun fix (Task 1); `duplicate_object` with `copyObject(with_dependencies=True)` + relative offset + default label (Task 2); placement semantics, absolute-mode regression, copyObject return, full-tree copy, offset, datum-line parallel close-the-loop (Task 3); wiki for both (Task 4). No `copy` flag added to transform; no scale_object change. All covered.
+- **Placeholder scan:** no TBD/TODO; all code shown in full; the two conditionals (copyObject-returns-a-list, PartDesign::Line-fixture) give explicit empirical procedures, not vague instructions.
+- **Type consistency:** `_apply_relative_placement(old, tx, ty, tz, ax, ay, az, angle) -> App.Placement` defined in Task 1, called identically in Task 1's handler and Task 2's `_handle_duplicate_object`. `_duplicate_label(base, requested)` consistent between definition, call site, and unit test. `data` keys (`name`/`label`) match the integration assertions. ToolParam keyword order matches `registry.py`.

--- a/docs/superpowers/specs/2026-06-02-transform-and-duplicate-design.md
+++ b/docs/superpowers/specs/2026-06-02-transform-and-duplicate-design.md
@@ -1,0 +1,224 @@
+# Design: transform_object relative mode + duplicate_object tool
+
+- **Date:** 2026-06-02
+- **Status:** Approved design, pending implementation plan
+- **Scope:** Piece #4 (final) of the datum-geometry/transform suite (see Roadmap).
+- **Base:** branch `feature/transform-object` off `master`. Independent of piece #3
+  (PR #22, still open) — `transform_object` is a different code region, so no
+  merge-first is required.
+
+## Background
+
+`transform_object` (`freecad_tools.py:1806`, `_handle_transform_object`) currently
+does a single thing and does it with a footgun:
+
+```python
+placement = App.Placement(
+    App.Vector(translate_x, translate_y, translate_z),
+    App.Rotation(App.Vector(rotate_axis_x, rotate_axis_y, rotate_axis_z), rotate_angle),
+)
+obj.Placement = placement          # absolute OVERWRITE
+```
+
+Because the placement is overwritten absolutely and the translate params default to
+`0`, calling `transform_object(object_name="X", rotate_angle=90)` to spin an object
+in place **silently moves it to the world origin** (its translation is reset) — the
+result even reports `"placement reset"`. There is no way to nudge-by-delta.
+
+Separately, the suite has a standing need to **duplicate** an object: piece #3
+(`create_datum_line`) deliberately has no offset parameter because the plan was for
+a transform/duplicate capability to provide parallel/offset placement. A `copy`
+flag already exists on `scale_object` (`:3900`), but it bakes a static
+`Part::Feature` snapshot of `obj.Shape`, discarding the parametric feature tree —
+which contradicts this suite's whole through-line (#17/#18: preserve model history).
+
+This piece therefore splits the concern into two single-responsibility tools rather
+than overloading `transform_object` with a `copy` flag (a tool named "transform"
+should not secretly create objects — it is both a naming smell and a
+tool-selection smell for an LLM caller).
+
+The codebase conventions to build on: `_get_object` (Name then Label),
+`_suggest_similar` ("did you mean"), `_with_undo` (undo transaction), and the
+`ToolDefinition`/`ToolParam` registry (array params must declare `items` — issue
+#10).
+
+## Goals
+
+1. **`transform_object` gains a relative mode** (default on) that composes the
+   move/rotate onto the object's existing placement, fixing the reset footgun.
+   Absolute placement remains available.
+2. **A new `duplicate_object` tool** makes an independent, history-preserving copy
+   of an object (the whole feature tree) and optionally offsets the copy in one
+   call, leaving the original untouched.
+
+Both ship in one spec / one plan / one PR — they are a cohesive unit and share the
+relative-placement composition.
+
+## Non-goals
+
+- **No hand-rolled rotation math.** Placement composition uses FreeCAD's
+  `App.Placement` / `App.Rotation`; we do not reimplement axis-angle→quaternion
+  composition in a "pure" helper just to manufacture a unit test (that would
+  duplicate well-tested FreeCAD math — more bug-prone, not less). Placement
+  *semantics* are pinned by integration tests, per the suite's standing principle.
+- **No `copy` flag on `transform_object`** — duplication lives in `duplicate_object`.
+- **No removal of `scale_object`'s existing `copy` flag** — out of scope; left as-is.
+- **No scaling/mirroring** in these tools (separate tools already exist).
+- **No absolute mode for `duplicate_object`** — a duplicate is always offset
+  *relative* to the original (the only sensible semantic); `0` offset = coincident.
+
+## transform_object — relative mode
+
+### New parameter
+
+| Param | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `relative` | boolean | `True` | Compose the move/rotate onto the object's current placement (`0` = no change). `False` reproduces today's absolute overwrite. |
+
+All existing params (`object_name`, `translate_*`, `rotate_axis_*`, `rotate_angle`)
+are unchanged.
+
+### Semantics
+
+Let `old = obj.Placement` and
+`delta_rot = App.Rotation(App.Vector(rotate_axis_x, rotate_axis_y, rotate_axis_z), rotate_angle)`.
+
+- **`relative=True` (default):**
+  - **Translate is global**: `new_base = old.Base + App.Vector(tx, ty, tz)`.
+  - **Rotate is in place**: `new_rot = delta_rot.multiply(old.Rotation)`, with
+    `new_base` (above) kept — so the object pivots about its own placement origin
+    using the given global axis direction, rather than flying to the world origin.
+  - `new.Placement = App.Placement(new_base, new_rot)`.
+  - Translate and rotate are applied **independently** (the translate is not
+    rotated by `delta_rot`), which is the predictable, least-surprising behavior.
+- **`relative=False`:** unchanged from today —
+  `obj.Placement = App.Placement(App.Vector(tx,ty,tz), delta_rot)` (full overwrite).
+
+### Output
+
+The result message states the mode and what changed. The misleading
+`"placement reset"` wording is removed; with `relative=True` and no params, the
+message is e.g. `"'X' unchanged (relative, no delta given)"`. `data={"name": obj.Name}`.
+
+### Backwards compatibility
+
+The default flips from absolute to relative. The two existing integration tests
+(`tests/integration/test_boolean_transform.py::...test_translate` / `test_rotate`)
+operate on a **fresh primitive at the origin**, where relative and absolute
+coincide — so they stay green. The behavior change is observable only for an
+object that already has a non-identity placement; the user has accepted this
+(alpha; the new behavior is the intended one).
+
+## duplicate_object — new tool
+
+### Parameters
+
+| Param | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `object_name` | string | (required) | Object to duplicate (Name or Label). |
+| `translate_x` / `_y` / `_z` | number | `0.0` | Relative offset of the copy from the original (mm). |
+| `rotate_axis_x` / `_y` / `_z` | number | `0,0,1` | Rotation axis for offsetting the copy. |
+| `rotate_angle` | number | `0.0` | Rotation angle for offsetting the copy (deg). |
+| `label` | string | `""` | Label for the copy; defaults to `"<original Label>_Copy"`. |
+
+### Semantics
+
+1. Resolve `obj` via `_get_object`; not found → error + `_suggest_similar` hint.
+2. `copy = doc.copyObject(obj, with_dependencies=True)` — duplicates the whole
+   feature tree (a `PartDesign::Body` and its Sketch/Pad/…; a datum object; or a
+   plain `Part::Feature`) into an independent, editable, parametric copy. The
+   original is untouched. `copyObject`'s exact return shape is **pinned by
+   integration** (it returns the copy of the passed object; guard for the
+   possibility it returns a list across FreeCAD versions).
+3. Set the copy's label: `copy.Label = label or f"{obj.Label}_Copy"`.
+4. Apply the **relative** offset to the copy using the *same* composition as
+   `transform_object`'s relative mode (global translate of `copy.Base`,
+   rotate-in-place of `copy.Rotation`). `copyObject` preserves the original's
+   placement, so a `0` offset leaves the copy coincident with the original and a
+   non-zero offset places it parametrically nearby.
+5. `doc.recompute()`; verify the copy exists and is not in an Invalid/Error state.
+
+### Result
+
+`ToolResult(success=True, output=..., data={"name", "label"})`. The output names
+the copy and notes the original is unchanged.
+
+### Known limitation (documented, not worked around)
+
+If the duplicated object's placement is **driven by an attachment** (e.g. a datum
+line/plane attached to an edge/face via `MapMode`), recompute re-derives its
+placement from the attachment, so the relative offset will not "stick". This is
+expected: to make an offset *parallel* datum line, define it with the two-point
+form of `create_datum_line` (a fixed placement) and then `duplicate_object` it —
+which is precisely the suite's intended workflow. The tool description notes this.
+
+## Validation and errors
+
+Never segfault. Both tools:
+- object not found → `ToolResult(success=False, …)` with `_suggest_similar` hint;
+- wrap mutations in `_with_undo`;
+- `duplicate_object` verifies the copy was created (handles a list/None return
+  from `copyObject`) before transforming it, and checks `State` after recompute.
+
+## Code organization
+
+- Extend `_handle_transform_object` + `TRANSFORM_OBJECT` params in place
+  (`freecad_tools.py:1806`/`:1847`); rewrite the description for relative-default
+  + the `0`=no-change rule.
+- Add `_handle_duplicate_object` + `DUPLICATE_OBJECT` `ToolDefinition` near
+  `transform_object`; register `DUPLICATE_OBJECT` in `ALL_TOOLS`.
+- The relative-composition is a few lines shared in spirit by both handlers. To
+  avoid hand-rolled-quaternion purity (see Non-goals), it is written with `App`
+  types. If a clean *FreeCAD-using* helper `_apply_relative(placement, tx,ty,tz,
+  ax,ay,az,angle) -> App.Placement` removes duplication without reimplementing
+  math, extract it (used by both handlers); it is exercised by integration tests,
+  not unit tests.
+- The only genuinely-pure, unit-testable bit is the default-label rule
+  (`label or f"{base}_Copy"`); a tiny `_duplicate_label(base, requested)` may be
+  extracted for a unit test, or covered by the ToolDefinition tests — implementer's
+  call, low stakes.
+
+## Testing
+
+**Unit (no FreeCAD):**
+- `TRANSFORM_OBJECT` / `DUPLICATE_OBJECT` definition guards: names, `category ==
+  "modeling"`, registered in `ALL_TOOLS`, no array param without `items` (issue
+  #10 — though these tools use only scalar/string params, keep the guard for
+  consistency), `relative` present on transform with default `True`.
+- default-label rule: `label` empty → `"<base>_Copy"`; explicit `label` honored.
+
+**Integration (real FreeCAD, via `run_freecad_script`):**
+- `transform_object(relative=True)` translate on an object that was first rotated →
+  the rotation is **preserved** and the position shifts by the delta (proves
+  no-overwrite).
+- `transform_object(relative=True, rotate_angle=90)` on an object placed off the
+  origin → the **position is preserved** and only the orientation changes (proves
+  the footgun is fixed; rotate-in-place, not rotate-to-origin).
+- `transform_object(relative=False, …)` → absolute overwrite (matches the two
+  existing tests' expectations; regression guard).
+- `duplicate_object` of a `PartDesign::Body` → a new independent Body exists with
+  its own Sketch/Pad copied (feature tree duplicated, not a baked shape), the
+  original is unchanged, and the copy is editable.
+- `duplicate_object` with a non-zero `translate_*` → the copy is offset by the
+  delta while the original stays put.
+- `duplicate_object` of a plain `Part::Feature` → independent copy.
+- **End-to-end (closes the suite):** `create_datum_line(point1=…, point2=…)` then
+  `duplicate_object(<line>, translate_x=10)` → a second datum line parallel to the
+  first, offset by 10 mm. (Requires piece #3; runnable on this branch only after
+  #22 merges, OR by inlining an equivalent two-point datum line via run_macro-style
+  setup in the test — the plan will use whichever is available; if #22 is unmerged
+  at implementation time, build the first line directly in the test script.)
+
+## Backwards compatibility
+
+- `transform_object`: one new param (`relative`, default `True`); existing-tool
+  behavior changes only for already-placed objects (accepted). No schema break.
+- `duplicate_object`: purely additive (new tool + one `ALL_TOOLS` entry).
+
+## Roadmap
+
+Piece #4 of four — the **final** piece; it completes the suite begun with
+`create_sketch` face/plane attachment (#20), `create_datum_plane` (#21), and
+`create_datum_line` (#22). Wiki `Tool-Reference.md` gets a new `duplicate_object`
+entry and an updated `transform_object` entry (relative mode) as this piece's docs
+step — committed locally, not pushed (maintainer pushes the wiki manually).

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -1803,6 +1803,22 @@ BOOLEAN_OPERATION = ToolDefinition(
 
 # ── transform_object ────────────────────────────────────────
 
+def _apply_relative_placement(old, tx, ty, tz, ax, ay, az, angle):
+    """Compose a relative move/rotate onto an existing placement.
+
+    Translate is global (added to the base); rotation is applied in place about
+    the object's own origin (pre-multiplied onto the current rotation, base kept).
+    Uses FreeCAD's placement math — intentionally NOT a pure/standalone helper
+    (reimplementing quaternion composition would be more error-prone). Pinned by
+    integration tests.
+    """
+    import FreeCAD as App
+    new_base = old.Base + App.Vector(tx, ty, tz)
+    delta_rot = App.Rotation(App.Vector(ax, ay, az), angle)
+    new_rot = delta_rot.multiply(old.Rotation)
+    return App.Placement(new_base, new_rot)
+
+
 def _handle_transform_object(
     object_name: str,
     translate_x: float = 0.0,
@@ -1812,8 +1828,9 @@ def _handle_transform_object(
     rotate_axis_y: float = 0.0,
     rotate_axis_z: float = 1.0,
     rotate_angle: float = 0.0,
+    relative: bool = True,
 ) -> ToolResult:
-    """Move and/or rotate an object."""
+    """Move and/or rotate an object, relative to its current placement by default."""
     import FreeCAD as App
 
     def do(doc):
@@ -1822,18 +1839,27 @@ def _handle_transform_object(
             hint = _suggest_similar(doc, object_name)
             return ToolResult(success=False, output="", error=f"Object '{object_name}' not found.{hint}")
 
-        placement = App.Placement(
-            App.Vector(translate_x, translate_y, translate_z),
-            App.Rotation(App.Vector(rotate_axis_x, rotate_axis_y, rotate_axis_z), rotate_angle),
-        )
-        obj.Placement = placement
+        if relative:
+            obj.Placement = _apply_relative_placement(
+                obj.Placement, translate_x, translate_y, translate_z,
+                rotate_axis_x, rotate_axis_y, rotate_axis_z, rotate_angle)
+        else:
+            obj.Placement = App.Placement(
+                App.Vector(translate_x, translate_y, translate_z),
+                App.Rotation(App.Vector(rotate_axis_x, rotate_axis_y, rotate_axis_z), rotate_angle))
 
         parts = []
         if translate_x or translate_y or translate_z:
-            parts.append(f"moved to ({translate_x}, {translate_y}, {translate_z})")
+            parts.append(f"translated ({translate_x}, {translate_y}, {translate_z})")
         if rotate_angle:
-            parts.append(f"rotated {rotate_angle} degrees")
-        desc = ", ".join(parts) if parts else "placement reset"
+            parts.append(f"rotated {rotate_angle}°")
+        mode = "relative" if relative else "absolute"
+        if parts:
+            desc = ", ".join(parts) + f" ({mode})"
+        elif relative:
+            desc = "unchanged (relative, no delta given)"
+        else:
+            desc = "placement reset to origin (absolute)"
 
         return ToolResult(
             success=True,
@@ -1846,7 +1872,14 @@ def _handle_transform_object(
 
 TRANSFORM_OBJECT = ToolDefinition(
     name="transform_object",
-    description="Move and/or rotate an object by setting its Placement.",
+    description=(
+        "Move and/or rotate an object. By default (relative=True) the change is "
+        "applied RELATIVE to the object's current placement — translation adds to "
+        "its position, rotation spins it in place, and 0 means no change. Set "
+        "relative=False for an ABSOLUTE placement (overwrites position and "
+        "orientation; omitted values reset to 0). Does not copy — use "
+        "duplicate_object to make a copy."
+    ),
     category="modeling",
     parameters=[
         ToolParam("object_name", "string", "Internal name of the object to transform"),
@@ -1857,6 +1890,8 @@ TRANSFORM_OBJECT = ToolDefinition(
         ToolParam("rotate_axis_y", "number", "Rotation axis Y component", required=False, default=0.0),
         ToolParam("rotate_axis_z", "number", "Rotation axis Z component", required=False, default=1.0),
         ToolParam("rotate_angle", "number", "Rotation angle in degrees", required=False, default=0.0),
+        ToolParam("relative", "boolean", "Apply relative to the current placement "
+                  "(default). False = absolute overwrite.", required=False, default=True),
     ],
     handler=_handle_transform_object,
 )

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -1922,8 +1922,10 @@ def _handle_duplicate_object(
             return ToolResult(success=False, output="", error=f"Object '{object_name}' not found.{hint}")
 
         result = doc.copyObject(obj, True)
-        # copyObject returns the copy of the passed object; guard for a list/None
-        # return across FreeCAD versions (the exact shape is pinned in integration).
+        # copyObject(single_obj, True) returns a plain DocumentObject on FreeCAD
+        # 1.1.x; the list/tuple branch is a forward-compat guard. [-1] is chosen
+        # because topological order places the most-derived object (e.g. the Body)
+        # last. Pinned by integration.
         copy = result[-1] if isinstance(result, (list, tuple)) else result
         if copy is None:
             return ToolResult(success=False, output="", error=f"Failed to duplicate '{obj.Label}'.")
@@ -1937,6 +1939,9 @@ def _handle_duplicate_object(
 
         doc.recompute()
 
+        # If the copy can't recompute cleanly, State contains Invalid/Error. (For a
+        # Body only the Body-level state is checked here; the executor sandbox
+        # catches child-level failures as the higher-level net.)
         state = list(getattr(copy, "State", []) or [])
         if any(s in ("Invalid", "Error") for s in state):
             return ToolResult(success=False, output="",

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -1897,6 +1897,88 @@ TRANSFORM_OBJECT = ToolDefinition(
 )
 
 
+def _duplicate_label(base_label, requested):
+    """Label for a duplicated object: the requested label, or '<base>_Copy'."""
+    return requested or f"{base_label}_Copy"
+
+
+def _handle_duplicate_object(
+    object_name: str,
+    translate_x: float = 0.0,
+    translate_y: float = 0.0,
+    translate_z: float = 0.0,
+    rotate_axis_x: float = 0.0,
+    rotate_axis_y: float = 0.0,
+    rotate_axis_z: float = 1.0,
+    rotate_angle: float = 0.0,
+    label: str = "",
+) -> ToolResult:
+    """Duplicate an object (independent parametric copy), optionally offsetting it."""
+
+    def do(doc):
+        obj = _get_object(doc, object_name)
+        if not obj:
+            hint = _suggest_similar(doc, object_name)
+            return ToolResult(success=False, output="", error=f"Object '{object_name}' not found.{hint}")
+
+        result = doc.copyObject(obj, True)
+        # copyObject returns the copy of the passed object; guard for a list/None
+        # return across FreeCAD versions (the exact shape is pinned in integration).
+        copy = result[-1] if isinstance(result, (list, tuple)) else result
+        if copy is None:
+            return ToolResult(success=False, output="", error=f"Failed to duplicate '{obj.Label}'.")
+
+        copy.Label = _duplicate_label(obj.Label, label)
+
+        if translate_x or translate_y or translate_z or rotate_angle:
+            copy.Placement = _apply_relative_placement(
+                copy.Placement, translate_x, translate_y, translate_z,
+                rotate_axis_x, rotate_axis_y, rotate_axis_z, rotate_angle)
+
+        doc.recompute()
+
+        state = list(getattr(copy, "State", []) or [])
+        if any(s in ("Invalid", "Error") for s in state):
+            return ToolResult(success=False, output="",
+                              error=f"Duplicate '{copy.Label}' did not recompute cleanly.")
+
+        return ToolResult(
+            success=True,
+            output=(f"Duplicated '{obj.Label}' → '{copy.Label}' ({copy.TypeId}); "
+                    "original unchanged."),
+            data={"name": copy.Name, "label": copy.Label},
+        )
+
+    return _with_undo("Duplicate Object", do)
+
+
+DUPLICATE_OBJECT = ToolDefinition(
+    name="duplicate_object",
+    description=(
+        "Duplicate an object as an independent, editable copy that preserves its "
+        "parametric history (the whole feature tree — e.g. a Body with its sketches "
+        "and pads). The original is left unchanged. Optional translate/rotate offset "
+        "the copy relative to the original (0 = on top of it). To duplicate a solid, "
+        "pass its Body. Note: if the object's placement is driven by an attachment "
+        "(e.g. a datum attached to an edge), the offset won't stick — duplicate a "
+        "fixed-placement object (such as a two-point datum line) for a parallel copy."
+    ),
+    category="modeling",
+    parameters=[
+        ToolParam("object_name", "string", "Internal name of the object to duplicate"),
+        ToolParam("translate_x", "number", "X offset of the copy in mm", required=False, default=0.0),
+        ToolParam("translate_y", "number", "Y offset of the copy in mm", required=False, default=0.0),
+        ToolParam("translate_z", "number", "Z offset of the copy in mm", required=False, default=0.0),
+        ToolParam("rotate_axis_x", "number", "Rotation axis X component", required=False, default=0.0),
+        ToolParam("rotate_axis_y", "number", "Rotation axis Y component", required=False, default=0.0),
+        ToolParam("rotate_axis_z", "number", "Rotation axis Z component", required=False, default=1.0),
+        ToolParam("rotate_angle", "number", "Rotation angle for the copy in degrees", required=False, default=0.0),
+        ToolParam("label", "string", "Label for the copy (default '<original>_Copy')", required=False, default=""),
+    ],
+    handler=_handle_duplicate_object,
+)
+
+
 # ── fillet_edges ────────────────────────────────────────────
 
 def _handle_fillet_edges(
@@ -5336,6 +5418,7 @@ ALL_TOOLS = [
     SWEEP_SKETCH,
     BOOLEAN_OPERATION,
     TRANSFORM_OBJECT,
+    DUPLICATE_OBJECT,
     FILLET_EDGES,
     CHAMFER_EDGES,
     CREATE_INNER_RIDGE,

--- a/tests/integration/test_transform_duplicate_integration.py
+++ b/tests/integration/test_transform_duplicate_integration.py
@@ -1,0 +1,209 @@
+"""Integration tests for transform_object relative mode + duplicate_object.
+
+Uses the run_freecad_script fixture (see tests/integration/conftest.py).
+"""
+
+import math
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestTransformRelative:
+    def test_relative_translate_preserves_rotation(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_primitive, _handle_transform_object
+
+_handle_create_primitive(shape_type="box", label="Box")
+doc.recompute()
+# First set an absolute rotation (no translation).
+_handle_transform_object(object_name="Box", relative=False, rotate_axis_z=1.0, rotate_angle=90.0)
+doc.recompute()
+# Then a RELATIVE translate — rotation must survive, position must shift.
+r = _handle_transform_object(object_name="Box", translate_x=10.0)
+doc.recompute()
+obj = doc.getObject("Box")
+results["data"] = {
+    "success": r.success,
+    "x": obj.Placement.Base.x,
+    "angle": obj.Placement.Rotation.Angle,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"]
+        assert abs(d["x"] - 10.0) < 1e-6
+        assert abs(d["angle"] - math.pi / 2) < 0.01  # rotation preserved
+
+    def test_relative_rotate_in_place_preserves_position(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_primitive, _handle_transform_object
+
+_handle_create_primitive(shape_type="box", label="Box")
+doc.recompute()
+# Place the box away from the origin (absolute).
+_handle_transform_object(object_name="Box", relative=False, translate_x=5.0)
+doc.recompute()
+# RELATIVE rotate — position must be preserved (the footgun fix).
+r = _handle_transform_object(object_name="Box", rotate_axis_z=1.0, rotate_angle=90.0)
+doc.recompute()
+obj = doc.getObject("Box")
+results["data"] = {
+    "success": r.success,
+    "x": obj.Placement.Base.x,
+    "angle": obj.Placement.Rotation.Angle,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"]
+        assert abs(d["x"] - 5.0) < 1e-6           # position preserved
+        assert abs(d["angle"] - math.pi / 2) < 0.01
+
+    def test_absolute_mode_overwrites(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_create_primitive, _handle_transform_object
+
+_handle_create_primitive(shape_type="box", label="Box")
+doc.recompute()
+_handle_transform_object(object_name="Box", relative=False, translate_x=7.0)
+doc.recompute()
+# Absolute rotate with no translate → position resets to origin.
+r = _handle_transform_object(object_name="Box", relative=False, rotate_axis_z=1.0, rotate_angle=45.0)
+doc.recompute()
+obj = doc.getObject("Box")
+results["data"] = {
+    "success": r.success,
+    "x": obj.Placement.Base.x,
+    "angle": obj.Placement.Rotation.Angle,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"]
+        assert abs(d["x"]) < 1e-6                  # absolute overwrite reset position
+        assert abs(d["angle"] - math.pi / 4) < 0.01
+
+
+class TestDuplicateObject:
+    def test_duplicate_body_copies_feature_tree(self, run_freecad_script):
+        result = run_freecad_script("""
+from freecad_ai.tools.freecad_tools import _handle_duplicate_object
+
+body = doc.addObject("PartDesign::Body", "Body")
+box = body.newObject("PartDesign::AdditiveBox", "Box")
+box.Length = 10; box.Width = 10; box.Height = 10
+doc.recompute()
+
+r = _handle_duplicate_object(object_name="Body")
+doc.recompute()
+copy = doc.getObject(r.data["name"]) if r.success else None
+bodies = [o for o in doc.Objects if o.TypeId == "PartDesign::Body"]
+copy_children = [o.TypeId for o in (copy.Group if copy else [])]
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "copy_type": copy.TypeId if copy else None,
+    "n_bodies": len(bodies),
+    "copy_has_box": any("AdditiveBox" in t for t in copy_children),
+    "original_intact": doc.getObject("Body") is not None,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["copy_type"] == "PartDesign::Body"
+        assert d["n_bodies"] == 2                 # original + copy
+        assert d["copy_has_box"]                  # feature tree duplicated
+        assert d["original_intact"]
+
+    def test_duplicate_with_offset(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_duplicate_object
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_duplicate_object(object_name="Box", translate_x=20.0)
+doc.recompute()
+copy = doc.getObject(r.data["name"]) if r.success else None
+orig = doc.getObject("Box")
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "copy_x": copy.Placement.Base.x if copy else None,
+    "orig_x": orig.Placement.Base.x,
+    "distinct": (copy is not None and copy.Name != "Box"),
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["distinct"]
+        assert abs(d["copy_x"] - 20.0) < 1e-6      # copy offset
+        assert abs(d["orig_x"]) < 1e-6             # original untouched
+
+    def test_duplicate_part_feature_is_independent(self, run_freecad_script):
+        result = run_freecad_script("""
+import Part
+from freecad_ai.tools.freecad_tools import _handle_duplicate_object
+
+feat = doc.addObject("Part::Feature", "Box")
+feat.Shape = Part.makeBox(10, 10, 10)
+doc.recompute()
+
+r = _handle_duplicate_object(object_name="Box", label="BoxClone")
+doc.recompute()
+copy = doc.getObject(r.data["name"]) if r.success else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "copy_label": copy.Label if copy else None,
+    "copy_type": copy.TypeId if copy else None,
+    "copy_valid": copy.Shape.isValid() if copy else False,
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert d["copy_label"] == "BoxClone"
+        assert d["copy_type"] == "Part::Feature"
+        assert d["copy_valid"]
+
+    def test_duplicate_datum_line_parallel_offset(self, run_freecad_script):
+        # Closes the suite: duplicate a fixed-placement datum line, offset it →
+        # a parallel line. (create_datum_line lives on PR #22, not this branch, so
+        # the first line is built directly here as a two-point datum would be.)
+        result = run_freecad_script("""
+import FreeCAD as App
+from freecad_ai.tools.freecad_tools import _handle_duplicate_object
+
+line = doc.addObject("PartDesign::Line", "DatumLine")
+# A fixed Y-directed line through the origin (two-point style placement).
+line.Placement = App.Placement(App.Vector(0, 0, 0),
+                               App.Rotation(App.Vector(0, 0, 1), App.Vector(0, 1, 0)))
+doc.recompute()
+zdir0 = line.Placement.Rotation.multVec(App.Vector(0, 0, 1))
+
+r = _handle_duplicate_object(object_name="DatumLine", translate_x=10.0)
+doc.recompute()
+copy = doc.getObject(r.data["name"]) if r.success else None
+zdir1 = copy.Placement.Rotation.multVec(App.Vector(0, 0, 1)) if copy else None
+results["data"] = {
+    "success": r.success,
+    "error": r.error,
+    "copy_x": copy.Placement.Base.x if copy else None,
+    "parallel": (copy is not None and
+                 abs(zdir0.x - zdir1.x) < 1e-6 and
+                 abs(zdir0.y - zdir1.y) < 1e-6 and
+                 abs(zdir0.z - zdir1.z) < 1e-6),
+}
+""")
+        assert result["ok"], result.get("error")
+        d = result["data"]
+        assert d["success"], d["error"]
+        assert abs(d["copy_x"] - 10.0) < 1e-6      # offset by 10mm
+        assert d["parallel"]                       # same direction → parallel

--- a/tests/unit/test_transform_duplicate.py
+++ b/tests/unit/test_transform_duplicate.py
@@ -13,3 +13,31 @@ class TestTransformObjectDefinition:
     def test_no_copy_param(self):
         names = {p.name for p in TRANSFORM_OBJECT.parameters}
         assert "copy" not in names
+
+
+from freecad_ai.tools.freecad_tools import (
+    DUPLICATE_OBJECT, ALL_TOOLS, _duplicate_label,
+)
+
+
+class TestDuplicateObjectDefinition:
+    def test_name_and_category(self):
+        assert DUPLICATE_OBJECT.name == "duplicate_object"
+        assert DUPLICATE_OBJECT.category == "modeling"
+
+    def test_registered_in_all_tools(self):
+        assert DUPLICATE_OBJECT in ALL_TOOLS
+
+    def test_array_params_declare_items(self):
+        # Consistency guard (issue #10) even though these params are scalar/string.
+        for p in DUPLICATE_OBJECT.parameters:
+            if getattr(p, "type", None) == "array":
+                assert getattr(p, "items", None) is not None, p.name
+
+
+class TestDuplicateLabel:
+    def test_default_label(self):
+        assert _duplicate_label("Box", "") == "Box_Copy"
+
+    def test_explicit_label_wins(self):
+        assert _duplicate_label("Box", "MyCopy") == "MyCopy"

--- a/tests/unit/test_transform_duplicate.py
+++ b/tests/unit/test_transform_duplicate.py
@@ -1,0 +1,15 @@
+"""Unit tests for transform_object relative mode + duplicate_object definitions."""
+
+from freecad_ai.tools.freecad_tools import TRANSFORM_OBJECT
+
+
+class TestTransformObjectDefinition:
+    def test_relative_param_default_true(self):
+        params = {p.name: p for p in TRANSFORM_OBJECT.parameters}
+        assert "relative" in params
+        assert params["relative"].type == "boolean"
+        assert params["relative"].default is True
+
+    def test_no_copy_param(self):
+        names = {p.name for p in TRANSFORM_OBJECT.parameters}
+        assert "copy" not in names


### PR DESCRIPTION
## Summary

The **final** piece of the datum-geometry/transform suite. Two single-responsibility tools:

- **`transform_object` gains a `relative` mode (default `True`)** — fixes a real footgun. Today the tool overwrites `Placement` absolutely, so `transform_object(rotate_angle=90)` (translate params left at their `0` defaults) silently **resets the object to the world origin** and even reports `"placement reset"`. With `relative=True`: translation adds to the current position (global), rotation spins the object **in place** about its own origin, and `0` means no change. `relative=False` keeps the old absolute-overwrite behavior.
- **New `duplicate_object` tool** — `doc.copyObject(obj, with_dependencies=True)` makes an **independent, history-preserving copy** of the whole feature tree (a Body with its sketches/pads, a datum, or a Part feature), leaving the original untouched. Optional relative `translate_*`/`rotate_*` place the copy in one call; `label` defaults to `"<original>_Copy"`.

**Why a separate tool rather than a `copy` flag on `transform_object`:** a tool named "transform" shouldn't secretly create objects — it's both a naming smell and a tool-selection smell for an LLM caller. Splitting keeps each tool single-purpose. (The existing `copy` flag on `scale_object` is left as-is; out of scope.)

`duplicate_object` is what provides the **parallel/offset placement** that `create_datum_line` (#22) deliberately omits: `create_datum_line(...)` → `duplicate_object(translate_x=10)` = a parallel datum line. Refs #18.

## Implementation

- Shared `_apply_relative_placement(old, tx,ty,tz, ax,ay,az, angle)` helper (global translate + rotate-in-place), reused by both handlers — no duplicated placement math, and no hand-rolled quaternion code (FreeCAD's `App.Rotation`/`App.Placement` do it; semantics pinned by integration).
- `duplicate_object`: `_handle_duplicate_object` + pure `_duplicate_label` + `DUPLICATE_OBJECT` ToolDefinition, registered in `ALL_TOOLS`.
- Built subagent-driven TDD: per-task spec-compliance + code-quality review, opus final holistic review.

## Verified facts (the value of integration testing)

- The relative composition `delta_rot.multiply(old.Rotation)` is the correct **global-axis rotate-in-place** — confirmed against FreeCAD's `RotationPyImp.cpp` source (`A.multiply(B) = A*B`, and `A*B` applies `B` first).
- `doc.copyObject(obj, True)` returns a **single DocumentObject** (not a list) on FreeCAD 1.1.x — verified empirically; the handler's list-guard is forward-compat only.
- The default flip (absolute→relative) is behavior-preserving for every in-repo caller: the only positioning caller (`EnclosureLid`) acts on an identity-placement Body, where relative-from-identity equals the old absolute result. Existing tests start at the origin, so they stay green.

## Test Plan

- [x] Unit: `tests/unit/test_transform_duplicate.py` — `relative` default, no `copy` param, `DUPLICATE_OBJECT` registration + issue-#10 array-items guard, `_duplicate_label`. Full unit suite: **873 passed**.
- [x] Integration (real FreeCAD): `tests/integration/test_transform_duplicate_integration.py` — relative-translate-preserves-rotation, **relative-rotate-preserves-position (the footgun fix)**, absolute-overwrite regression, Body feature-tree duplication, offset-on-duplicate, Part::Feature independence, and the **parallel datum-line capstone**. **7 passed.**

> ⚠️ I'm an AI assistant handling this on Alfred's behalf. He develops on a headless Linux box over SSH (no GUI), so this was verified via headless-FreeCAD integration tests rather than interactive use — please try it and reopen/comment if anything misbehaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)