### PR TITLE
fix(executor): make code-execution timeout configurable (default 30→60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.16.1-alpha] - 2026-06-06
+
+A bug-fix patch for [issue #14](https://github.com/ghbalf/freecad-ai/issues/14): generated code could time out on large or detailed models regardless of the operation, with no way to extend the limit.
+
+### Fixed
+
+- **Code-execution timeout is now configurable, and the default was raised 30 → 60s** (`freecad_ai/core/executor.py`, `freecad_ai/config.py`, `freecad_ai/ui/settings_dialog.py`). The budget applied to **both** the headless sandbox pre-check and live execution was hardcoded at 30s. Heavy-but-valid geometry operations — most notably scaling a detailed or imported model via `Shape.transformGeometry`, whose cost grows with the model's face count — genuinely exceed 30s and were killed on both paths with no recourse. The previous patch ([0.15.1-alpha](https://github.com/ghbalf/freecad-ai/releases/tag/v0.15.1-alpha)) only moved the wall from 15s to 30s. A new **"Code execution timeout"** setting (Settings, range 5–600s) now controls this budget; `execute_code` reads it when no explicit timeout is given, so large-model users can raise it as needed. ([issue #14](https://github.com/ghbalf/freecad-ai/issues/14), reported by trougnouf; still-broken reports by JohnMcLear and galberding) ([#24](https://github.com/ghbalf/freecad-ai/pull/24))
+
+### Tests
+
+- Unit: `tests/unit/test_config.py` (`execution_timeout` default and round-trip) and `tests/unit/test_executor.py::TestConfigurableExecutionTimeout` (`execute_code` honors the configured value and the new 60s default when no explicit timeout is passed).
+
 ## [0.16.0-alpha] - 2026-06-03
 
 A feature release adding a datum-geometry and transform/duplicate toolset — sketching on faces and named planes, parametric datum planes and lines, relative transforms, and independent parametric copies — together with a sandbox fix that unblocks editing imported (mesh→solid) parts. This work grew out of [issue #18](https://github.com/ghbalf/freecad-ai/issues/18) (reported by 0xrushi): a snap-fit workflow on an imported solid that fell out of the parametric toolchain.

--- a/freecad_ai/__init__.py
+++ b/freecad_ai/__init__.py
@@ -1,3 +1,3 @@
 """FreeCAD AI — AI assistant workbench for FreeCAD."""
 
-__version__ = "0.16.0-alpha"
+__version__ = "0.16.1-alpha"

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -399,6 +399,13 @@ class AppConfig:
     # Max agentic tool-loop turns per user message. 0 = endless (the Stop
     # button is then the only brake). Default 30 preserves prior behavior.
     max_tool_turns: int = 30
+    # Wall-clock budget (seconds) for executing a single generated code block —
+    # applied to BOTH the headless sandbox dry-run and the live SIGALRM. Heavy
+    # but valid geometry ops (e.g. scaling a detailed model via
+    # Shape.transformGeometry, whose cost grows with face count) can exceed the
+    # old hardcoded 30s; the default was bumped to 60 and made user-tunable so
+    # large models are not falsely killed (issue #14).
+    execution_timeout: int = 60
     enable_tools: bool = True
     thinking: str = "off"  # "off", "on", "extended"
     strip_thinking_history: bool | None = None  # None=auto-detect, True/False=override

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -308,7 +308,27 @@ def _auto_save(namespace: dict):
         pass  # Best-effort
 
 
-def execute_code(code: str, timeout: int = 30, sandbox: bool = True,
+_DEFAULT_EXECUTION_TIMEOUT = 60
+
+
+def _configured_timeout(default: int = _DEFAULT_EXECUTION_TIMEOUT) -> int:
+    """Resolve the execution timeout (seconds) from user config.
+
+    Heavy-but-valid geometry ops (e.g. scaling a detailed model via
+    Shape.transformGeometry) can exceed a fixed budget; sourcing it from
+    config lets users raise it for large models instead of hitting a
+    hardcoded wall on both the sandbox and live paths (issue #14). Falls
+    back to ``default`` if config is unavailable or holds a bad value.
+    """
+    try:
+        from ..config import get_config
+        val = int(getattr(get_config(), "execution_timeout", default))
+        return val if val > 0 else default
+    except Exception:
+        return default
+
+
+def execute_code(code: str, timeout: int | None = None, sandbox: bool = True,
                  skip_safety: bool = False) -> ExecutionResult:
     """Execute Python code in FreeCAD's context.
 
@@ -321,10 +341,16 @@ def execute_code(code: str, timeout: int = 30, sandbox: bool = True,
       3. Undo transactions (roll back on Python-level failure)
       4. Auto-save (backup document before execution)
 
+    timeout: Wall-clock budget (seconds) applied to both the sandbox dry-run
+        and the live SIGALRM. ``None`` (the default) resolves it from
+        ``AppConfig.execution_timeout`` so the GUI's setting is honored.
+
     skip_safety: When True, skip static validation, the headless sandbox
         pre-check, and the SIGALRM timeout. The undo transaction (rollback on
         failure) and auto-save remain active. Used by Dangerous mode only.
     """
+    if timeout is None:
+        timeout = _configured_timeout()
     # Layer 1: Static validation (skipped in dangerous mode)
     if not skip_safety:
         warnings = _validate_code(code)

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -280,6 +280,22 @@ class SettingsDialog(QDialog):
             translate("SettingsDialog", "Max tool-loop turns (0 = endless):"),
             self.max_tool_turns_spin)
 
+        self.execution_timeout_spin = QSpinBox()
+        self.execution_timeout_spin.setRange(5, 600)
+        self.execution_timeout_spin.setSingleStep(5)
+        self.execution_timeout_spin.setValue(60)
+        self.execution_timeout_spin.setSuffix(translate("SettingsDialog", " s"))
+        self.execution_timeout_spin.setToolTip(
+            translate("SettingsDialog",
+                      "Time budget for executing one generated code block "
+                      "(sandbox dry-run and live run).\n"
+                      "Raise it for heavy operations on large/detailed models "
+                      "(e.g. scaling). Default: 60.")
+        )
+        fixed_layout.addRow(
+            translate("SettingsDialog", "Code execution timeout:"),
+            self.execution_timeout_spin)
+
         model_params_layout.addLayout(fixed_layout)
 
         # Freeform sampling parameters table (saved per model name)
@@ -815,6 +831,7 @@ class SettingsDialog(QDialog):
         self.max_tokens_spin.setValue(cfg.max_tokens)
         self.context_window_spin.setValue(cfg.context_window)
         self.max_tool_turns_spin.setValue(cfg.max_tool_turns)
+        self.execution_timeout_spin.setValue(cfg.execution_timeout)
 
         # Model parameters table
         self._load_model_params_table(cfg.provider.model, cfg)
@@ -1094,6 +1111,7 @@ class SettingsDialog(QDialog):
         cfg.max_tokens = self.max_tokens_spin.value()
         cfg.context_window = self.context_window_spin.value()
         cfg.max_tool_turns = self.max_tool_turns_spin.value()
+        cfg.execution_timeout = self.execution_timeout_spin.value()
 
         # Save model parameters for the current model
         model_name = self.model_edit.text().strip()

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1">
     <name>FreeCAD AI</name>
     <description>AI-powered assistant for 3D modeling in FreeCAD. Supports multiple LLM providers with Plan/Act modes, structured tool calling, skills, and MCP integration.</description>
-    <version>0.16.0-alpha</version>
-    <date>2026-06-03</date>
+    <version>0.16.1-alpha</version>
+    <date>2026-06-06</date>
     <maintainer email="alfred@mickautsch.de">Alfred Mickautsch</maintainer>
     <license file="LICENSE-CODE">LGPL-2.1-or-later</license>
     <license file="LICENSE-ICON">CC0-1.0</license>

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -98,6 +98,19 @@ class TestAppConfig:
         assert restored.temperature == 0.7
         assert restored.thinking == "on"
 
+    def test_execution_timeout_default(self):
+        # Issue #14 (reopened): the execution timeout was hardcoded at 30s and
+        # too short for heavy-geometry ops (e.g. scaling a detailed model). It
+        # is now a configurable field; the default was bumped 30 -> 60.
+        c = AppConfig()
+        assert c.execution_timeout == 60
+
+    def test_execution_timeout_roundtrip(self):
+        c = AppConfig()
+        c.execution_timeout = 180
+        c2 = AppConfig.from_dict(c.to_dict())
+        assert c2.execution_timeout == 180
+
     def test_chat_dock_state_defaults(self):
         c = AppConfig()
         assert c.chat_dock_floating is False

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -256,6 +256,52 @@ class TestSandboxTimeout:
         )
 
 
+class TestConfigurableExecutionTimeout:
+    """Issue #14 (reopened): the execution timeout was hardcoded at 30s with no
+    user override, so heavy-but-valid operations — scaling a detailed model via
+    Shape.transformGeometry, whose cost is O(geometry complexity) — exceeded 30s
+    and failed on BOTH the sandbox dry-run and the live SIGALRM path. The timeout
+    is now sourced from AppConfig.execution_timeout (default 60) whenever the
+    caller passes no explicit timeout, so users can raise it for big models.
+    """
+
+    def _captured_timeout(self, configured):
+        from freecad_ai.config import AppConfig
+
+        seen = {}
+
+        def _capture(code, timeout=15, document_path=None):
+            seen["timeout"] = timeout
+            return True, ""
+
+        cfg = AppConfig()
+        if configured is not None:
+            cfg.execution_timeout = configured
+
+        with patch("freecad_ai.config.get_config", return_value=cfg):
+            with patch(
+                "freecad_ai.core.executor._sandbox_test", side_effect=_capture
+            ):
+                with patch(
+                    "freecad_ai.core.active_document.get_synced_active_document",
+                    return_value=None,
+                ):
+                    executor.execute_code("x = 1")  # no explicit timeout
+        return seen["timeout"]
+
+    def test_default_execution_timeout_is_60(self):
+        assert self._captured_timeout(None) == 60, (
+            "execute_code() with no explicit timeout must use the bumped "
+            "60s default, not the old hardcoded 30s"
+        )
+
+    def test_configured_execution_timeout_is_honored(self):
+        assert self._captured_timeout(120) == 120, (
+            "execute_code() must source its timeout from "
+            "AppConfig.execution_timeout when the caller passes none"
+        )
+
+
 class TestCollectObjectIssues:
     """Post-execution validation must blame the code only for shapes it
     created or newly broke — never for objects that were already invalid


### PR DESCRIPTION
## Problem

Refs #14. The code-execution timeout was hardcoded at **30s** and applied to **both** the headless sandbox dry-run (`subprocess.run(timeout=…)`) and the live `signal.alarm(…)`. Heavy-but-valid geometry operations — e.g. "make the model smaller" = a scale via `Shape.transformGeometry`, whose cost grows with face count — genuinely exceed 30s on detailed/imported models, and there was no way to raise the budget.

`v0.15.1-alpha` raised the sandbox pre-check cap from 15s→30s, which cleared the *original* report (an op taking 15–30s) but only moved the wall. Reporters @JohnMcLear and @galberding still hit `Sandbox: code timed out after 30 seconds` on detailed models.

### Investigation

Measured on FreeCAD 1.1.1 with a 10 MB, 40-boolean model: cold-start ≈ 0.5s, `openDocument` (cached BREP, no re-recompute) ≈ 0.9s, and the `transformGeometry` scale itself ≈ 6s — i.e. the operation cost (O(geometry)) is the dominant term, not sandbox overhead. So the sandbox is only ~1.4s slower than live; both share the same 30s wall, and a fixed bump (30→60) alone would just relocate it for the heaviest models. The durable fix is to stop hardcoding it.

## Fix

- New `AppConfig.execution_timeout` (default **60**, was effectively 30).
- `execute_code(timeout=None)` resolves from config via `_configured_timeout()` when no explicit timeout is passed — single source of truth, applied to both the sandbox pre-check and live execution. Explicit-timeout callers (`validate_code`'s 15s Plan-mode check) are unchanged.
- Settings UI: **"Code execution timeout"** spinbox, range **5–600s**, so users can raise it for large models.

## Tests

- `test_config.py`: `execution_timeout` default is 60 + round-trips.
- `test_executor.py::TestConfigurableExecutionTimeout`: `execute_code()` honors the configured value and the new 60s default when no explicit timeout is given.
- Full unit suite: **899 passing** (the pre-existing `test_document_attach.py` Qt segfault remains deselected).

## Release

This PR also includes the **v0.16.1-alpha** version bump (`__init__.py`, `package.xml` date 2026-06-06) and CHANGELOG entry, so it is release-ready. Tag + GitHub release remain a separate manual step after merge. If an operation hangs *indefinitely* rather than being merely slow, that's a separate bug from this timeout budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)