### PR TITLE
fix(executor): force sandbox harness to exit; fixes spurious timeout (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.16.2-alpha] - 2026-06-06
+
+A bug-fix patch for [issue #14](https://github.com/ghbalf/freecad-ai/issues/14): the headless sandbox pre-check could time out on *any* operation — even a trivial one — whenever a saved document was open, making Act mode unusable on affected setups. This supersedes the v0.16.1-alpha timeout change, which addressed the wrong cause.
+
+### Fixed
+
+- **Sandbox dry-run hung against an open document** (`freecad_ai/core/executor.py`). The harness script wrote its result file but never forced the interpreter to exit. On FreeCAD builds where running a script via `-c` against an opened document leaves the process in interactive mode (the Qt/console event loop never returns), the subprocess never terminated, so the pre-check blocked until its timeout and reported a spurious "code timed out after N seconds" — regardless of what the code did (even, e.g., "render a cube"). The harness now calls `os._exit(0)` after writing its result, so the subprocess always terminates promptly. Diagnosed and first patched by @galberding; also reported by @JohnMcLear and @trougnouf. ([issue #14](https://github.com/ghbalf/freecad-ai/issues/14))
+
+### Changed
+
+- **`execution_timeout` default reverted to 30s** (from the 60s introduced in v0.16.1-alpha). With the hang fixed, the higher default only lengthened the wait before a genuinely-stuck operation was cancelled; the setting remains user-tunable (range 5--600s) for heavy operations on large models.
+
+### Tests
+
+- Unit: `tests/unit/test_executor.py::TestSandboxHarnessForcesExit` (the generated harness must force a process exit). Integration: `tests/integration/test_sandbox_validation.py::TestSandboxExitsAgainstOpenedDocument` (trivial code on an opened document returns instead of timing out).
+
 ## [0.16.1-alpha] - 2026-06-06
 
 A bug-fix patch for [issue #14](https://github.com/ghbalf/freecad-ai/issues/14): generated code could time out on large or detailed models regardless of the operation, with no way to extend the limit.

--- a/freecad_ai/__init__.py
+++ b/freecad_ai/__init__.py
@@ -1,3 +1,3 @@
 """FreeCAD AI — AI assistant workbench for FreeCAD."""
 
-__version__ = "0.16.1-alpha"
+__version__ = "0.16.2-alpha"

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -400,12 +400,11 @@ class AppConfig:
     # button is then the only brake). Default 30 preserves prior behavior.
     max_tool_turns: int = 30
     # Wall-clock budget (seconds) for executing a single generated code block —
-    # applied to BOTH the headless sandbox dry-run and the live SIGALRM. Heavy
-    # but valid geometry ops (e.g. scaling a detailed model via
-    # Shape.transformGeometry, whose cost grows with face count) can exceed the
-    # old hardcoded 30s; the default was bumped to 60 and made user-tunable so
-    # large models are not falsely killed (issue #14).
-    execution_timeout: int = 60
+    # applied to BOTH the headless sandbox dry-run and the live SIGALRM. Kept
+    # user-tunable so heavy but valid geometry ops (e.g. scaling a detailed
+    # model via Shape.transformGeometry, whose cost grows with face count) can
+    # be given more time on large models (issue #14).
+    execution_timeout: int = 30
     enable_tools: bool = True
     thinking: str = "off"  # "off", "on", "extended"
     strip_thinking_history: bool | None = None  # None=auto-detect, True/False=override

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -237,6 +237,14 @@ finally:
         pass
     with open({result_path!r}, "w") as f:
         json.dump(result, f)
+    # Force the interpreter to exit. On some FreeCAD builds, running a script
+    # via `-c` against an OPENED document leaves the process in interactive
+    # mode (Qt/console event loop never returns), so subprocess.run() would
+    # block until its timeout and the sandbox always reported a spurious
+    # "timed out" — even for trivial code (issue #14). os._exit skips atexit
+    # handlers / lingering non-daemon threads that a plain sys.exit can wait on.
+    import os as _os
+    _os._exit(0)
 '''.format(
         collect_fn_src=inspect.getsource(_collect_object_issues),
         open_block=open_block,
@@ -308,7 +316,7 @@ def _auto_save(namespace: dict):
         pass  # Best-effort
 
 
-_DEFAULT_EXECUTION_TIMEOUT = 60
+_DEFAULT_EXECUTION_TIMEOUT = 30
 
 
 def _configured_timeout(default: int = _DEFAULT_EXECUTION_TIMEOUT) -> int:

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -283,14 +283,14 @@ class SettingsDialog(QDialog):
         self.execution_timeout_spin = QSpinBox()
         self.execution_timeout_spin.setRange(5, 600)
         self.execution_timeout_spin.setSingleStep(5)
-        self.execution_timeout_spin.setValue(60)
+        self.execution_timeout_spin.setValue(30)
         self.execution_timeout_spin.setSuffix(translate("SettingsDialog", " s"))
         self.execution_timeout_spin.setToolTip(
             translate("SettingsDialog",
                       "Time budget for executing one generated code block "
                       "(sandbox dry-run and live run).\n"
                       "Raise it for heavy operations on large/detailed models "
-                      "(e.g. scaling). Default: 60.")
+                      "(e.g. scaling). Default: 30.")
         )
         fixed_layout.addRow(
             translate("SettingsDialog", "Code execution timeout:"),

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1">
     <name>FreeCAD AI</name>
     <description>AI-powered assistant for 3D modeling in FreeCAD. Supports multiple LLM providers with Plan/Act modes, structured tool calling, skills, and MCP integration.</description>
-    <version>0.16.1-alpha</version>
+    <version>0.16.2-alpha</version>
     <date>2026-06-06</date>
     <maintainer email="alfred@mickautsch.de">Alfred Mickautsch</maintainer>
     <license file="LICENSE-CODE">LGPL-2.1-or-later</license>

--- a/tests/integration/test_sandbox_validation.py
+++ b/tests/integration/test_sandbox_validation.py
@@ -127,3 +127,69 @@ class TestSandboxIgnoresPreexistingInvalidity:
         ok, err = _sandbox_test(_INVALID_SOLID, timeout=90)
         assert ok is False, "a newly-created invalid shape must still fail"
         assert "invalid shape" in err, "failure must name the invalid shape"
+
+
+@pytest.fixture
+def simple_saved_doc(freecad_available):
+    """Path to a trivial saved .FCStd (one box) — exercises the openDocument
+    branch of the sandbox harness."""
+    fd, doc_path = tempfile.mkstemp(suffix=".FCStd")
+    os.close(fd)
+    os.unlink(doc_path)
+    builder = (
+        "import FreeCAD as App, Part\n"
+        "doc = App.newDocument('Simple')\n"
+        "f = doc.addObject('Part::Feature', 'Box')\n"
+        "f.Shape = Part.makeBox(10, 10, 10)\n"
+        "doc.recompute()\n"
+        "doc.saveAs(" + repr(doc_path) + ")\n"
+        "exit(0)\n"
+    )
+    script = tempfile.mktemp(suffix=".py")
+    with open(script, "w") as fh:
+        fh.write(builder)
+    subprocess.run(
+        [_find_freecad_cmd(), "-c", script],
+        capture_output=True,
+        env={**os.environ, "QT_QPA_PLATFORM": "offscreen"},
+        timeout=120,
+    )
+    assert os.path.isfile(doc_path), "fixture failed to save the document"
+    yield doc_path
+    for p in (doc_path, script):
+        try:
+            os.unlink(p)
+        except OSError:
+            pass
+
+
+class TestSandboxExitsAgainstOpenedDocument:
+    """Regression for issue #14: the harness script wrote its result file but
+    never forced the interpreter to exit. On FreeCAD builds where running a
+    script via `-c` against an OPENED document leaves the process in
+    interactive mode (the Qt/console event loop never returns), the subprocess
+    never terminated, so subprocess.run() blocked until its timeout and the
+    sandbox reported a spurious "code timed out" — even for trivial code like
+    creating a box. The harness now calls os._exit(0) after writing the result.
+
+    Diagnosed and first patched by @galberding on the issue thread.
+    """
+
+    def test_trivial_code_against_opened_document_does_not_hang(
+        self, simple_saved_doc
+    ):
+        # Without the os._exit(0) fix this blocks for the full timeout and
+        # returns ("Sandbox: code timed out after N seconds"); with it, the
+        # subprocess exits as soon as the result file is written.
+        code = (
+            "f = doc.addObject('Part::Feature', 'Box2')\n"
+            "import Part\n"
+            "f.Shape = Part.makeBox(5, 5, 5)\n"
+            "doc.recompute()\n"
+        )
+        ok, err = _sandbox_test(code, timeout=30, document_path=simple_saved_doc)
+        assert "timed out" not in err, (
+            "sandbox hung on the openDocument path — the harness must force "
+            "the interpreter to exit after writing its result (issue #14)"
+        )
+        assert ok is True, "trivial valid code on an opened document must pass; got err=" + err

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -99,11 +99,12 @@ class TestAppConfig:
         assert restored.thinking == "on"
 
     def test_execution_timeout_default(self):
-        # Issue #14 (reopened): the execution timeout was hardcoded at 30s and
-        # too short for heavy-geometry ops (e.g. scaling a detailed model). It
-        # is now a configurable field; the default was bumped 30 -> 60.
+        # Issue #14: the execution timeout was hardcoded with no override. It is
+        # now a configurable field (kept at the long-standing 30s default; the
+        # real #14 fix was the sandbox no longer hanging — raising the budget
+        # only helps genuinely-slow ops on large models).
         c = AppConfig()
-        assert c.execution_timeout == 60
+        assert c.execution_timeout == 30
 
     def test_execution_timeout_roundtrip(self):
         c = AppConfig()

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -256,6 +256,54 @@ class TestSandboxTimeout:
         )
 
 
+class TestSandboxHarnessForcesExit:
+    """Issue #14: the sandbox harness wrote its result file but never forced the
+    interpreter to exit. On FreeCAD builds where running a script via `-c`
+    against an OPENED document leaves the process in interactive mode (the
+    Qt/console event loop never returns), the subprocess never terminated, so
+    `subprocess.run()` blocked until its timeout and the sandbox reported a
+    spurious "code timed out" — even for trivial code.
+
+    The hang itself is build-/timing-dependent and not reliably reproducible in
+    CI, so this guards the invariant instead: the generated harness must force a
+    process exit after writing its result. Diagnosed and first patched by
+    @galberding on the issue thread.
+    """
+
+    def test_generated_harness_forces_process_exit(self):
+        captured = {}
+
+        class _FakeProc:
+            returncode = 0
+
+        def _fake_run(cmd, **kwargs):
+            # cmd == [freecad_bin, "-c", script_file]; capture the harness the
+            # sandbox wrote before it would have run FreeCAD.
+            with open(cmd[2]) as fh:
+                captured["harness"] = fh.read()
+            return _FakeProc()
+
+        with patch(
+            "freecad_ai.core.executor._find_freecad_cmd",
+            return_value="/usr/bin/freecadcmd",
+        ):
+            with patch(
+                "freecad_ai.core.executor.subprocess.run", side_effect=_fake_run
+            ):
+                executor._sandbox_test("x = 1", timeout=5)
+
+        harness = captured.get("harness", "")
+        assert harness, "sandbox did not generate a harness script"
+        forces_exit = any(
+            tok in harness for tok in ("os._exit(", "sys.exit(")
+        )
+        assert forces_exit, (
+            "sandbox harness must force the interpreter to exit after writing "
+            "its result, or the FreeCAD subprocess can hang until timeout "
+            "(issue #14)"
+        )
+
+
 class TestConfigurableExecutionTimeout:
     """Issue #14 (reopened): the execution timeout was hardcoded at 30s with no
     user override, so heavy-but-valid operations — scaling a detailed model via
@@ -289,10 +337,9 @@ class TestConfigurableExecutionTimeout:
                     executor.execute_code("x = 1")  # no explicit timeout
         return seen["timeout"]
 
-    def test_default_execution_timeout_is_60(self):
-        assert self._captured_timeout(None) == 60, (
-            "execute_code() with no explicit timeout must use the bumped "
-            "60s default, not the old hardcoded 30s"
+    def test_default_execution_timeout_is_30(self):
+        assert self._captured_timeout(None) == 30, (
+            "execute_code() with no explicit timeout must use the 30s default"
         )
 
     def test_configured_execution_timeout_is_honored(self):


### PR DESCRIPTION
## The real root cause of #14

Refs #14. The sandbox harness script writes its result file but **never forces the interpreter to exit**. On FreeCAD builds where running a script via `-c` against an **opened document** leaves the process in interactive mode (the Qt/console event loop never returns), the subprocess never terminates — so `subprocess.run(timeout=…)` blocks until its timeout and the pre-check reports a spurious `code timed out after N seconds`, **regardless of what the code does** (even "render a cube").

This explains the reports that survived v0.16.1-alpha:
- @JohnMcLear's trivial "render a cube" timing out.
- The intermittency: only the `openDocument` branch hangs; with no/unsaved document the `newDocument` branch exits fine.
- Why the v0.16.1 `30→60` default bump made it *worse* — it just lengthened the hang.

**Credit:** diagnosed and first patched by **@galberding** on the issue thread; also reported by @JohnMcLear and @trougnouf.

### Reproduction (verified)

Driving the real `_sandbox_test` harness against a saved document with trivial code (`addObject('Part::Box')`) hung the full timeout and returned `Sandbox: code timed out`. Adding the exit call → returns in ~0.9s, `safe=True`. The `newDocument` path and error-reporting path are unaffected.

> Note on testing: the hang is build-/timing-dependent and was **not reliably reproducible locally** (it fired once, then ran clean). So the deterministic regression test guards the *invariant* — the harness must force a process exit — rather than the flaky symptom.

## Fix

- Harness calls **`os._exit(0)`** after writing its result. `os._exit` is used rather than `sys.exit` because `sys.exit` raises `SystemExit` and runs cleanup that can still block on a lingering Qt event loop / non-daemon thread. The result file is written and closed beforehand, and a real `SIGSEGV` still happens before the exit call, so crash-detection is unaffected.
- **Revert `execution_timeout` default 60 → 30** (the configurable setting from v0.16.1 stays, range 5–600s). With the hang gone, the higher default only lengthened the wait before genuinely-stuck code is cancelled.

## Tests

- Unit `tests/unit/test_executor.py::TestSandboxHarnessForcesExit` — the generated harness must force an exit (deterministic red→green; verified it fails without the fix).
- Integration `tests/integration/test_sandbox_validation.py::TestSandboxExitsAgainstOpenedDocument` — trivial code on an opened document returns instead of timing out (positive control).
- Full unit suite **900 passing**; sandbox integration **5 passing**.

## Release

Includes the **v0.16.2-alpha** bump (`__init__.py`, `package.xml`) and CHANGELOG entry — release-ready. Supersedes the v0.16.1-alpha approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)