### PR TITLE
fix(executor): don't flag empty sketches/bodies as null-shape in sandbox

### DIFF
--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -96,13 +96,26 @@ def _collect_object_issues(objects_state, baseline_bad):
     newly broke are reported. The shape source of truth lives here so the
     subprocess harness and the unit tests exercise identical logic.
     """
+    # Object types whose Shape is legitimately null in a valid, complete state.
+    # An empty sketch ("create a sketch on the selected face" — geometry is
+    # drawn later in the editor) and an empty body (a container before its
+    # first feature) both report Shape.isNull() == True while State stays
+    # "Up-to-date". Flagging their null shape produced a false positive that
+    # failed the sketch-on-a-face workflow; the model then injected junk
+    # placeholder geometry to defeat the check (issue #18). A genuinely failed
+    # object of these types (e.g. a sketch whose attachment didn't resolve)
+    # still lands in an Invalid state and is caught by the invalid_state report
+    # below. Kept local so it ships with the function source into the sandbox
+    # harness (inspect.getsource doesn't carry module globals).
+    null_shape_ok_types = {"Sketcher::SketchObject", "PartDesign::Body"}
     issues = []
     for st in objects_state:
         name = st["name"]
         if name in baseline_bad:
             continue
         if st.get("null"):
-            issues.append("Object '" + name + "' has null shape")
+            if st.get("type") not in null_shape_ok_types:
+                issues.append("Object '" + name + "' has null shape")
         elif st.get("invalid"):
             issues.append("Object '" + name + "' has invalid shape")
         if st.get("invalid_state"):
@@ -190,8 +203,8 @@ try:
                 pass
         _state = getattr(_obj, "State", None)
         _bad_state = bool(_state and "Invalid" in _state)
-        return {{"name": _obj.Name, "null": _null,
-                 "invalid": _invalid, "invalid_state": _bad_state}}
+        return {{"name": _obj.Name, "type": getattr(_obj, "TypeId", ""),
+                 "null": _null, "invalid": _invalid, "invalid_state": _bad_state}}
 
     # Baseline: objects already broken in the opened document BEFORE user code
     # runs. The sandbox dry-runs against a copy of the saved document, so an

--- a/tests/integration/test_sandbox_validation.py
+++ b/tests/integration/test_sandbox_validation.py
@@ -129,6 +129,46 @@ class TestSandboxIgnoresPreexistingInvalidity:
         assert "invalid shape" in err, "failure must name the invalid shape"
 
 
+class TestEmptySketchNullShapeNotReported:
+    """Regression for issue #18 follow-up: "create a sketch on the selected
+    face" produces an EMPTY sketch (geometry is drawn later in the editor).
+    On FreeCAD 1.1 an empty Sketcher::SketchObject has Shape.isNull() == True
+    while its State stays "Up-to-date" — a valid intermediate state, not a
+    defect. The post-execution validator reported it as "has null shape",
+    failing the exact "sketch on a selected face" workflow #20 was meant to
+    enable; the model then injected a junk placeholder circle to defeat the
+    check, which is what the user saw ("a random circular sketch somewhere
+    instead of the selected rectangular face").
+    """
+
+    def test_empty_sketch_on_valid_face_passes(self, freecad_available):
+        # Mirror the user's case: an empty sketch attached to a real planar
+        # face of an imported-like solid. The attachment is valid, so the only
+        # thing that can fail is the empty sketch's (benign) null shape.
+        code = (
+            "import Part\n"
+            "f = doc.addObject('Part::Feature', 'ImportedSolid')\n"
+            "f.Shape = Part.makeBox(40, 40, 40)\n"
+            "doc.recompute()\n"
+            "sk = doc.addObject('Sketcher::SketchObject', 'Sketch_Face1')\n"
+            "sk.AttachmentSupport = [(f, 'Face1')]\n"
+            "sk.MapMode = 'FlatFace'\n"
+            "doc.recompute()\n"
+        )
+        ok, err = _sandbox_test(code, timeout=60)
+        assert ok is True, (
+            "an empty sketch validly attached to a face must pass the sandbox; "
+            "got err=" + err
+        )
+
+    def test_empty_body_passes(self, freecad_available):
+        # A PartDesign::Body before its first feature also has a benign null
+        # shape while Up-to-date.
+        code = "doc.addObject('PartDesign::Body', 'Body')\n"
+        ok, err = _sandbox_test(code, timeout=60)
+        assert ok is True, "an empty body must pass the sandbox; got err=" + err
+
+
 @pytest.fixture
 def simple_saved_doc(freecad_available):
     """Path to a trivial saved .FCStd (one box) — exercises the openDocument

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -420,3 +420,53 @@ class TestCollectObjectIssues:
         ]
         issues = executor._collect_object_issues(objects_state, set())
         assert issues == []
+
+    def test_empty_sketch_null_shape_is_not_reported(self):
+        # Issue #18 follow-up: "create a sketch on the selected face" makes an
+        # empty sketch (geometry is added later in the editor). On FreeCAD 1.1
+        # an empty Sketcher::SketchObject reports Shape.isNull() == True while
+        # State stays "Up-to-date" — a valid, complete intermediate state. The
+        # validator must not flag it; otherwise the model injects junk
+        # placeholder geometry to defeat the false positive.
+        objects_state = [
+            {"name": "Sketch_Face1996", "type": "Sketcher::SketchObject",
+             "null": True, "invalid": False, "invalid_state": False},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == [], (
+            "an empty but valid sketch (null shape, Up-to-date) must not be "
+            "reported as broken"
+        )
+
+    def test_empty_body_null_shape_is_not_reported(self):
+        # A PartDesign::Body before its first feature also has a null shape
+        # while Up-to-date — same benign null as an empty sketch.
+        objects_state = [
+            {"name": "Body", "type": "PartDesign::Body",
+             "null": True, "invalid": False, "invalid_state": False},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == []
+
+    def test_failed_sketch_attachment_still_reported(self):
+        # Safety net: a sketch whose attachment did not resolve lands in an
+        # Invalid state (null shape AND invalid_state). The null-shape
+        # exemption for sketches must NOT swallow this — the separate
+        # invalid_state report still catches the genuine failure.
+        objects_state = [
+            {"name": "Sketch", "type": "Sketcher::SketchObject",
+             "null": True, "invalid": False, "invalid_state": True},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == ["Object 'Sketch' is in Invalid state"]
+
+    def test_null_shape_on_non_exempt_new_object_still_reported(self):
+        # A solid-producing feature (e.g. a Pad) that silently builds nothing
+        # is a real defect and must still be reported — the exemption is
+        # narrow, keyed on object type.
+        objects_state = [
+            {"name": "Pad", "type": "PartDesign::Pad",
+             "null": True, "invalid": False, "invalid_state": False},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == ["Object 'Pad' has null shape"]


### PR DESCRIPTION
## Problem

Reported on #18 by @0xrushi: "create a sketch on the selected face" still fails in v0.16.0-alpha. His session log shows three sandbox retries all rejected with `Object 'Sketch_Face1996' has null shape`, after which the model added a 1 mm placeholder circle to satisfy the validator — which the user saw as *"a random circular sketch somewhere instead of the selected rectangular face."*

## Root cause

"Create a sketch on the selected face" produces an **empty** sketch (geometry is drawn later). On FreeCAD 1.1 an empty `Sketcher::SketchObject` reports `Shape.isNull() == True` while its `State` stays `Up-to-date` — a valid, complete intermediate state, **not** a defect. The post-execution validator (`_collect_object_issues`) flagged it as `has null shape`.

This is the same "null shape ⇒ broken" assumption behind #18/#19, in a new guise: #19 suppressed *pre-existing* invalid imports via the baseline snapshot; this is a *legitimately-empty new* object the baseline can't suppress.

Evidence gathered on FreeCAD 1.1.1:

| Object | `Shape` | `State` | old verdict |
|---|---|---|---|
| Empty sketch, **valid** face attach | null | `Up-to-date` | ❌ false positive |
| Empty sketch, **failed** attach | null | `Invalid` | ✅ correctly caught (two signals) |
| Empty `PartDesign::Body` | null | `Up-to-date` | ❌ same false positive |
| Datum plane / line | **non-null** | `Up-to-date` | ✅ unaffected |
| Sketch **with** geometry | non-null | `Up-to-date` | ✅ passes |

The discriminator is **`State`**, not the null shape: a validly-attached empty sketch is `Up-to-date`; a failed attachment is `Invalid`.

## Fix

- `_snap` now records each object's `TypeId`.
- `_collect_object_issues` skips the **null-shape** report for `Sketcher::SketchObject` and `PartDesign::Body` (types whose empty/null shape is a valid state). The exempt set is kept **local** to the function so it ships into the sandbox harness via `inspect.getsource` (which doesn't carry module globals).
- The separate **`invalid_state`** report is untouched, so a sketch whose attachment fails (null shape **and** `Invalid` state) is still caught. Datum geometry carries non-null shapes and is unaffected.

## Tests

Reproduced live, then pinned RED→GREEN:
- **Unit** (`TestCollectObjectIssues`): empty sketch not reported, empty body not reported, failed-attachment still reported via Invalid state, non-exempt feature (Pad) null still reported.
- **Integration** (`TestEmptySketchNullShapeNotReported`): empty sketch on a real planar face passes; empty body passes.

Verification: 904 unit passed (pre-existing `test_document_attach.py` Qt-segfault excluded as usual); full `test_sandbox_validation.py` integration file green, including the existing bad-attachment and newly-created-invalid negative controls.

## Not addressed here

The session log also shows the model hand-rolling a raw `run_macro` instead of calling the `create_sketch(support=…/face=…)` tool from #20 — a separate prompt-level routing issue tracked in its own follow-up.

Refs #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)