### PR TITLE
fix(executor): stub Gui.ActiveDocument in headless sandbox (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.16.3-alpha] - 2026-06-07
+
+A bug-fix patch for two headless-sandbox false positives: the pre-check rejected valid code that runs fine in the real FreeCAD GUI, blocking common workflows. Reported on [issue #18](https://github.com/ghbalf/freecad-ai/issues/18) (@0xrushi) and [issue #14](https://github.com/ghbalf/freecad-ai/issues/14) (@JohnMcLear).
+
+### Fixed
+
+- **Empty sketches were flagged as broken** (`freecad_ai/core/executor.py`). "Create a sketch on the selected face" produces an empty sketch (geometry is drawn later in the editor). On FreeCAD 1.1 an empty `Sketcher::SketchObject` reports `Shape.isNull() == True` while its `State` stays `Up-to-date` — a valid intermediate state, not a defect — but the post-execution validator reported `has null shape` and failed every retry, after which the model injected a placeholder circle to satisfy the check (the stray sketch users saw instead of one on the selected face). The validator now skips the null-shape report for object types whose empty shape is valid (`Sketcher::SketchObject`, `PartDesign::Body`); the separate Invalid-state check still catches a sketch whose attachment genuinely fails. ([issue #18](https://github.com/ghbalf/freecad-ai/issues/18); thanks @0xrushi)
+- **Headless view-framing calls failed the pre-check** (`freecad_ai/core/executor.py`). LLM-generated code routinely ends with view cosmetics — `Gui.ActiveDocument.ActiveView.viewIsometric()`, `fitAll()`, `SendMsgToActiveView("ViewFit")`. Headlessly `FreeCADGui` has no `ActiveDocument`, so these raised `AttributeError: module 'FreeCADGui' has no attribute 'ActiveDocument'` and the sandbox rejected otherwise-valid geometry — e.g. "generate a cube", which surfaced once the v0.16.2-alpha hang fix removed the timeout that had been masking it. The sandbox harness now stubs the whole `Gui.ActiveDocument.*` surface with a recursive no-op, so view chains are harmless while the geometry is still validated. ([issue #14](https://github.com/ghbalf/freecad-ai/issues/14); thanks @JohnMcLear)
+
+### Tests
+
+- Integration: `tests/integration/test_sandbox_validation.py::TestEmptySketchNullShapeNotReported` (empty sketch on a real face, and empty body, pass) and `::TestHeadlessGuiCallsAreStubbed` (verbatim "generate a cube" with view framing passes). Unit: `tests/unit/test_executor.py::TestCollectObjectIssues` gains empty-sketch/empty-body exemption and the matching safety-net cases. Existing bad-attachment and newly-invalid negative controls remain green.
+
 ## [0.16.2-alpha] - 2026-06-06
 
 A bug-fix patch for [issue #14](https://github.com/ghbalf/freecad-ai/issues/14): the headless sandbox pre-check could time out on *any* operation — even a trivial one — whenever a saved document was open, making Act mode unusable on affected setups. This supersedes the v0.16.1-alpha timeout change, which addressed the wrong cause.

--- a/freecad_ai/__init__.py
+++ b/freecad_ai/__init__.py
@@ -1,3 +1,3 @@
 """FreeCAD AI — AI assistant workbench for FreeCAD."""
 
-__version__ = "0.16.2-alpha"
+__version__ = "0.16.3-alpha"

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -180,9 +180,22 @@ try:
 
     try:
         import FreeCADGui as Gui
-        # Console mode: Gui module exists but has no active view.
-        # Stub methods that LLM code commonly calls so they become no-ops.
+        # Console mode: Gui module exists but has no active document/view.
+        # LLM-generated code routinely ends with view-framing cosmetics
+        # (Gui.ActiveDocument.ActiveView.viewIsometric(), fitAll(),
+        # SendMsgToActiveView("ViewFit")). Headlessly FreeCADGui has no
+        # ActiveDocument, so these raise AttributeError and fail the pre-check
+        # for geometry that runs fine in the user's real GUI. Neutralize the
+        # whole Gui.ActiveDocument.* surface with a recursive no-op — any
+        # attribute access or call returns the same stub, so arbitrary view
+        # chains become harmless while the geometry is still validated (#14).
         if not hasattr(Gui, "ActiveDocument") or Gui.ActiveDocument is None:
+            class _NoOpGui:
+                def __getattr__(self, _name):
+                    return self
+                def __call__(self, *a, **kw):
+                    return self
+            Gui.ActiveDocument = _NoOpGui()
             Gui.SendMsgToActiveView = lambda *a, **kw: None
             Gui.updateGui = lambda *a, **kw: None
     except ImportError:

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1">
     <name>FreeCAD AI</name>
     <description>AI-powered assistant for 3D modeling in FreeCAD. Supports multiple LLM providers with Plan/Act modes, structured tool calling, skills, and MCP integration.</description>
-    <version>0.16.2-alpha</version>
-    <date>2026-06-06</date>
+    <version>0.16.3-alpha</version>
+    <date>2026-06-07</date>
     <maintainer email="alfred@mickautsch.de">Alfred Mickautsch</maintainer>
     <license file="LICENSE-CODE">LGPL-2.1-or-later</license>
     <license file="LICENSE-ICON">CC0-1.0</license>

--- a/tests/integration/test_sandbox_validation.py
+++ b/tests/integration/test_sandbox_validation.py
@@ -169,6 +169,39 @@ class TestEmptySketchNullShapeNotReported:
         assert ok is True, "an empty body must pass the sandbox; got err=" + err
 
 
+class TestHeadlessGuiCallsAreStubbed:
+    """Regression for issue #14 (follow-up): LLM-generated code routinely ends
+    with view-framing boilerplate — Gui.ActiveDocument.ActiveView.viewIsometric(),
+    fitAll(), SendMsgToActiveView("ViewFit"). In the headless sandbox FreeCADGui
+    has no ActiveDocument / ActiveView, so these raise AttributeError and the
+    pre-check rejects otherwise-valid geometry that runs fine in the user's real
+    GUI. @JohnMcLear's "generate a cube" failed this way across three releases.
+    The harness stubs these GUI-only calls to no-ops so validation sees the
+    geometry, not the cosmetics.
+    """
+
+    def test_generate_a_cube_with_view_framing_passes(self, freecad_available):
+        # Verbatim shape of @JohnMcLear's reported code (#14).
+        code = (
+            "import FreeCAD as App\n"
+            "import Part\n"
+            "doc = App.ActiveDocument\n"
+            "cube = doc.addObject('Part::Box', 'Cube')\n"
+            "cube.Length = 50.0\n"
+            "cube.Width = 50.0\n"
+            "cube.Height = 50.0\n"
+            "doc.recompute()\n"
+            "import FreeCADGui as Gui\n"
+            "Gui.ActiveDocument.ActiveView.viewIsometric()\n"
+            "Gui.SendMsgToActiveView('ViewFit')\n"
+        )
+        ok, err = _sandbox_test(code, timeout=60)
+        assert ok is True, (
+            "valid geometry followed by headless-only GUI view calls must pass "
+            "the sandbox; got err=" + err
+        )
+
+
 @pytest.fixture
 def simple_saved_doc(freecad_available):
     """Path to a trivial saved .FCStd (one box) — exercises the openDocument


### PR DESCRIPTION
## Problem

Reported on #14 by @JohnMcLear. After v0.16.2-alpha fixed the sandbox hang (the timeout is gone), "generate a cube" now fails the pre-check with:

```
Sandbox: AttributeError: module 'FreeCADGui' has no attribute 'ActiveDocument'
```

from the model's view-framing tail:

```python
import FreeCADGui as Gui
Gui.ActiveDocument.ActiveView.viewIsometric()
Gui.SendMsgToActiveView('ViewFit')
```

## Root cause

The harness GUI stub block (`executor.py`) neutralizes `Gui.SendMsgToActiveView` and `Gui.updateGui` for console mode but **not `Gui.ActiveDocument`** — which is absent headlessly. So purely cosmetic view-framing calls (that work fine in the user's real GUI) raise `AttributeError` and the sandbox rejects valid geometry. The v0.16.2 hang fix removed the timeout that had been masking this.

Same false-positive family as #18/#19/#26: the headless dry-run rejecting code that's valid in the real environment.

## Fix

Extend the existing stub: assign `Gui.ActiveDocument` to a **recursive no-op** (every attribute access or call returns the same stub), so any `Gui.ActiveDocument.*` view chain becomes harmless while the geometry is still validated. Verified empirically that the C++ `Gui` module accepts the assignment headlessly.

## Tests

- Integration `TestHeadlessGuiCallsAreStubbed` — @JohnMcLear's verbatim "generate a cube" code passes (RED→GREEN).
- Full `test_sandbox_validation.py` green, including the existing bad-attachment and newly-invalid negative controls. Full unit suite: 904 passed.

## Release

This branch also carries the **v0.16.3-alpha** release prep (version bump + CHANGELOG), bundling this fix with the empty-sketch/empty-body validator fix already merged via #26.

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)