### PR TITLE
feat: http mcp server

### DIFF
--- a/freecad_ai/mcp/server.py
+++ b/freecad_ai/mcp/server.py
@@ -1,7 +1,7 @@
 """MCP Server — exposes FreeCAD tools to external MCP clients.
 
-Runs over StdioServerTransport, handling initialize, tools/list,
-tools/call, and ping requests.
+Handles initialize, tools/list, tools/call, and ping requests over
+transport (STDIO or HTTP/SSE).
 """
 
 import logging
@@ -17,14 +17,16 @@ PROTOCOL_VERSION = "2025-03-26"
 
 
 class MCPServer:
-    """Exposes a ToolRegistry as an MCP server over STDIO."""
+    """Exposes a ToolRegistry as an MCP server."""
 
-    def __init__(self, registry: ToolRegistry):
+    def __init__(self, registry: ToolRegistry, transport=None, executor=None):
         self._registry = registry
+        self._transport = transport
+        self._executor = executor
 
     def run(self):
         """Start the server (blocking)."""
-        transport = StdioServerTransport()
+        transport = self._transport or StdioServerTransport()
         logger.info("MCP server starting with %d tools", len(self._registry.list_tools()))
         transport.run(self._handle)
 
@@ -68,7 +70,10 @@ class MCPServer:
         tool_name = params.get("name", "")
         arguments = params.get("arguments", {})
 
-        result = self._registry.execute(tool_name, arguments)
+        if self._executor:
+            result = self._executor.execute(tool_name, arguments)
+        else:
+            result = self._registry.execute(tool_name, arguments)
 
         if result.success:
             content = [{"type": "text", "text": result.output}]

--- a/freecad_ai/mcp/transport.py
+++ b/freecad_ai/mcp/transport.py
@@ -200,6 +200,9 @@ class StdioServerTransport:
         sys.stdout.flush()
 
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
 class SSEServerTransport:
     """Server-side transport: serves MCP over HTTP + Server-Sent Events.
 
@@ -209,18 +212,55 @@ class SSEServerTransport:
 
     Designed for a single connected client at a time (typical for a
     desktop-app MCP server like FreeCAD).
+
+    Because ``POST /messages`` executes arbitrary tools (including run_macro),
+    every request is gated: the ``Host`` header must be loopback (a
+    DNS-rebinding guard) and any cross-origin ``Origin`` is rejected. Native
+    MCP clients send no ``Origin``; a malicious web page's ``fetch()`` always
+    does, so this blocks browser drive-by tool invocation without breaking the
+    documented local client. ``allowed_hosts``/``allowed_origins`` widen the
+    policy for advanced (e.g. deliberately LAN-exposed) deployments.
     """
 
-    def __init__(self, host: str = "127.0.0.1", port: int = 3000):
+    def __init__(self, host: str = "127.0.0.1", port: int = 3000,
+                 allowed_hosts=None, allowed_origins=()):
         self._host = host
         self._port = port
         self._handler: Callable[[dict], dict | None] | None = None
         self._sse_wfile: Any = None
         self._sse_lock = threading.Lock()
+        if allowed_hosts is None:
+            allowed_hosts = _LOOPBACK_HOSTS | {host.lower()}
+        self._allowed_hosts = frozenset(h.lower() for h in allowed_hosts)
+        self._allowed_origins = frozenset(allowed_origins)
+
+    @staticmethod
+    def _hostname_of(host_header) -> str:
+        """Extract the bare hostname (no port) from a Host header value."""
+        if not host_header:
+            return ""
+        value = host_header.strip()
+        if value.startswith("["):  # IPv6 literal, e.g. [::1]:3000
+            return value[1:].split("]", 1)[0].lower()
+        return value.split(":", 1)[0].lower()
+
+    def _request_allowed(self, host_header, origin_header) -> bool:
+        """Authorize a request by its Host (DNS-rebinding) and Origin (CSRF)."""
+        if self._hostname_of(host_header) not in self._allowed_hosts:
+            return False
+        if origin_header is not None and origin_header not in self._allowed_origins:
+            return False
+        return True
 
     def run(self, handler: Callable[[dict], dict | None]):
         """Start the HTTP server (blocking)."""
         self._handler = handler
+        server = self._make_server()
+        logger.info("MCP SSE server listening on http://%s:%d", self._host, self._port)
+        server.serve_forever()
+
+    def _make_server(self):
+        """Build the threaded HTTP server (split out for testability)."""
         transport = self
 
         class RequestHandler(BaseHTTPRequestHandler):
@@ -230,13 +270,25 @@ class SSEServerTransport:
             def _base_path(self):
                 return self.path.split("?")[0].rstrip("/")
 
+            def _authorized(self):
+                if transport._request_allowed(
+                    self.headers.get("Host"), self.headers.get("Origin")
+                ):
+                    return True
+                self.send_error(403)
+                return False
+
             def do_GET(self):
+                if not self._authorized():
+                    return
                 if self._base_path() == "/sse":
                     self._handle_sse()
                 else:
                     self.send_error(404)
 
             def do_POST(self):
+                if not self._authorized():
+                    return
                 if self._base_path() == "/messages":
                     self._handle_messages()
                 else:
@@ -247,7 +299,6 @@ class SSEServerTransport:
                 self.send_header("Content-Type", "text/event-stream")
                 self.send_header("Cache-Control", "no-cache")
                 self.send_header("Connection", "keep-alive")
-                self.send_header("Access-Control-Allow-Origin", "*")
                 self.end_headers()
 
                 session_id = uuid.uuid4().hex
@@ -291,7 +342,6 @@ class SSEServerTransport:
 
                 self.send_response(202)
                 self.send_header("Content-Type", "application/json")
-                self.send_header("Access-Control-Allow-Origin", "*")
                 self.end_headers()
                 self.wfile.write(b'{"accepted":true}')
                 self.wfile.flush()
@@ -308,18 +358,16 @@ class SSEServerTransport:
                 self.wfile.write(data)
 
             def do_OPTIONS(self):
+                # No permissive CORS: a cross-origin preflight gets no
+                # Access-Control-Allow-Origin, so the browser blocks the
+                # follow-up request (do_POST also rejects it server-side).
                 self.send_response(204)
-                self.send_header("Access-Control-Allow-Origin", "*")
-                self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-                self.send_header("Access-Control-Allow-Headers", "Content-Type")
                 self.end_headers()
 
         class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
             daemon_threads = True
 
-        server = ThreadedHTTPServer((self._host, self._port), RequestHandler)
-        logger.info("MCP SSE server listening on http://%s:%d", self._host, self._port)
-        server.serve_forever()
+        return ThreadedHTTPServer((self._host, self._port), RequestHandler)
 
     def _send_sse(self, msg: dict):
         """Send a JSON-RPC message to the connected SSE client."""

--- a/freecad_ai/mcp/transport.py
+++ b/freecad_ai/mcp/transport.py
@@ -215,7 +215,7 @@ class SSEServerTransport:
         self._host = host
         self._port = port
         self._handler: Callable[[dict], dict | None] | None = None
-        self._sse_wfile = None
+        self._sse_wfile: Any = None
         self._sse_lock = threading.Lock()
 
     def run(self, handler: Callable[[dict], dict | None]):
@@ -256,17 +256,13 @@ class SSEServerTransport:
 
                 try:
                     endpoint_data = f"/messages?sessionId={session_id}"
-                    self.wfile.write(
+                    endpoint_event = (
                         f"event: endpoint\ndata: {endpoint_data}\n\n".encode()
                     )
-                    self.wfile.flush()
-
-                    while True:
-                        self.wfile.write(b": keepalive\n\n")
-                        self.wfile.flush()
+                    if not transport._write_locked(endpoint_event):
+                        return
+                    while transport._write_locked(b": keepalive\n\n"):
                         time.sleep(15)
-                except (BrokenPipeError, ConnectionResetError, OSError):
-                    pass
                 finally:
                     with transport._sse_lock:
                         if transport._sse_wfile is self.wfile:
@@ -329,13 +325,25 @@ class SSEServerTransport:
         """Send a JSON-RPC message to the connected SSE client."""
         data = json.dumps(msg, separators=(",", ":"))
         payload = f"event: message\ndata: {data}\n\n".encode()
+        self._write_locked(payload)
+
+    def _write_locked(self, payload: bytes) -> bool:
+        """Write raw bytes to the SSE client, serialized by ``_sse_lock``.
+
+        The lock is held across the write *and* flush (not just the pointer
+        read), so the keepalive loop and tool responses — which run on
+        separate ThreadingMixIn request threads — cannot interleave bytes and
+        corrupt the event stream. Returns False if there is no connected
+        client or the connection has dropped (the client is then cleared).
+        """
         with self._sse_lock:
             wfile = self._sse_wfile
-        if wfile is None:
-            return
-        try:
-            wfile.write(payload)
-            wfile.flush()
-        except (BrokenPipeError, ConnectionResetError, OSError):
-            with self._sse_lock:
+            if wfile is None:
+                return False
+            try:
+                wfile.write(payload)
+                wfile.flush()
+                return True
+            except (BrokenPipeError, ConnectionResetError, OSError):
                 self._sse_wfile = None
+                return False

--- a/freecad_ai/mcp/transport.py
+++ b/freecad_ai/mcp/transport.py
@@ -1,16 +1,24 @@
-"""STDIO transports for MCP communication.
+"""Transports for MCP communication.
 
 StdioClientTransport — manages a subprocess MCP server (client side).
 StdioServerTransport — reads stdin / writes stdout (server side).
+SSEServerTransport  — serves MCP over HTTP with Server-Sent Events.
 """
 
 import json
+import logging
 import subprocess
 import sys
 import threading
+import time
+import uuid
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from socketserver import ThreadingMixIn
 from typing import Any, Callable
 
 from . import protocol
+
+logger = logging.getLogger(__name__)
 
 
 class StdioClientTransport:
@@ -190,3 +198,144 @@ class StdioServerTransport:
         data = json.dumps(msg, separators=(",", ":")) + "\n"
         sys.stdout.write(data)
         sys.stdout.flush()
+
+
+class SSEServerTransport:
+    """Server-side transport: serves MCP over HTTP + Server-Sent Events.
+
+    Endpoints:
+        GET  /sse       — SSE event stream (client subscribes here)
+        POST /messages  — JSON-RPC requests (responses arrive via SSE)
+
+    Designed for a single connected client at a time (typical for a
+    desktop-app MCP server like FreeCAD).
+    """
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 3000):
+        self._host = host
+        self._port = port
+        self._handler: Callable[[dict], dict | None] | None = None
+        self._sse_wfile = None
+        self._sse_lock = threading.Lock()
+
+    def run(self, handler: Callable[[dict], dict | None]):
+        """Start the HTTP server (blocking)."""
+        self._handler = handler
+        transport = self
+
+        class RequestHandler(BaseHTTPRequestHandler):
+            def log_message(self, fmt, *args):
+                logger.debug(fmt, *args)
+
+            def _base_path(self):
+                return self.path.split("?")[0].rstrip("/")
+
+            def do_GET(self):
+                if self._base_path() == "/sse":
+                    self._handle_sse()
+                else:
+                    self.send_error(404)
+
+            def do_POST(self):
+                if self._base_path() == "/messages":
+                    self._handle_messages()
+                else:
+                    self.send_error(404)
+
+            def _handle_sse(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Cache-Control", "no-cache")
+                self.send_header("Connection", "keep-alive")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+
+                session_id = uuid.uuid4().hex
+                with transport._sse_lock:
+                    transport._sse_wfile = self.wfile
+
+                try:
+                    endpoint_data = f"/messages?sessionId={session_id}"
+                    self.wfile.write(
+                        f"event: endpoint\ndata: {endpoint_data}\n\n".encode()
+                    )
+                    self.wfile.flush()
+
+                    while True:
+                        self.wfile.write(b": keepalive\n\n")
+                        self.wfile.flush()
+                        time.sleep(15)
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    pass
+                finally:
+                    with transport._sse_lock:
+                        if transport._sse_wfile is self.wfile:
+                            transport._sse_wfile = None
+
+            def _handle_messages(self):
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length).decode("utf-8")
+
+                try:
+                    msg = json.loads(body)
+                except json.JSONDecodeError:
+                    err = protocol.make_error(
+                        None, protocol.PARSE_ERROR, "Parse error"
+                    )
+                    self._send_json(400, err)
+                    return
+
+                try:
+                    response = transport._handler(msg) if transport._handler else None
+                except Exception as e:
+                    msg_id = msg.get("id")
+                    response = protocol.make_error(
+                        msg_id, protocol.INTERNAL_ERROR, str(e)
+                    ) if msg_id is not None else None
+
+                self.send_response(202)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.end_headers()
+                self.wfile.write(b'{"accepted":true}')
+                self.wfile.flush()
+
+                if response is not None:
+                    transport._send_sse(response)
+
+            def _send_json(self, code: int, msg: dict):
+                data = json.dumps(msg, separators=(",", ":")).encode()
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def do_OPTIONS(self):
+                self.send_response(204)
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+                self.send_header("Access-Control-Allow-Headers", "Content-Type")
+                self.end_headers()
+
+        class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+            daemon_threads = True
+
+        server = ThreadedHTTPServer((self._host, self._port), RequestHandler)
+        logger.info("MCP SSE server listening on http://%s:%d", self._host, self._port)
+        server.serve_forever()
+
+    def _send_sse(self, msg: dict):
+        """Send a JSON-RPC message to the connected SSE client."""
+        data = json.dumps(msg, separators=(",", ":"))
+        payload = f"event: message\ndata: {data}\n\n".encode()
+        with self._sse_lock:
+            wfile = self._sse_wfile
+        if wfile is None:
+            return
+        try:
+            wfile.write(payload)
+            wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            with self._sse_lock:
+                self._sse_wfile = None

--- a/mcp_server_http.py
+++ b/mcp_server_http.py
@@ -32,9 +32,14 @@ import threading
 
 logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-if script_dir not in sys.path:
-    sys.path.insert(0, script_dir)
+# __file__ is undefined when this script is run via exec(open(...).read())
+# (a documented usage); guard so that path raises no NameError. In that mode
+# the freecad-ai package is already importable from FreeCAD's Mod directory.
+_script_path = globals().get("__file__")
+if _script_path:
+    script_dir = os.path.dirname(os.path.abspath(_script_path))
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
 
 import FreeCAD
 

--- a/mcp_server_http.py
+++ b/mcp_server_http.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""MCP server entry point for FreeCAD AI (HTTP/SSE mode).
+
+Starts FreeCAD with GUI and exposes all built-in tools via the MCP
+protocol over HTTP + Server-Sent Events, so you can watch FreeCAD
+update in real-time while an AI client calls tools.
+
+Usage:
+    # Start FreeCAD with this script as an argument:
+    /path/to/FreeCAD.AppImage /path/to/freecad-ai/mcp_server_http.py
+
+    # Or from inside a running FreeCAD via macro / exec:
+    exec(open("/path/to/freecad-ai/mcp_server_http.py").read())
+
+MCP configuration:
+{
+    "freecad": {
+      "type": "remote",
+      "url": "http://127.0.0.1:3000/sse"
+    }
+}
+
+Environment variables:
+    MCP_HOST  — listen address  (default: 127.0.0.1)
+    MCP_PORT  — listen port     (default: 3000)
+"""
+
+import os
+import sys
+import logging
+import threading
+
+logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+if script_dir not in sys.path:
+    sys.path.insert(0, script_dir)
+
+import FreeCAD
+
+if not FreeCAD.ActiveDocument:
+    FreeCAD.newDocument("Unnamed")
+
+from freecad_ai.tools.setup import create_default_registry
+from freecad_ai.tools.executor_utils import QtMainThreadToolExecutor
+from freecad_ai.mcp.server import MCPServer
+from freecad_ai.mcp.transport import SSEServerTransport
+
+registry = create_default_registry(include_mcp=False)
+
+executor = QtMainThreadToolExecutor()
+executor.set_registry(registry)
+
+host = os.environ.get("MCP_HOST", "127.0.0.1")
+port = int(os.environ.get("MCP_PORT", "3000"))
+
+transport = SSEServerTransport(host=host, port=port)
+server = MCPServer(registry, transport=transport, executor=executor)
+
+server_thread = threading.Thread(target=server.run, daemon=True)
+server_thread.start()
+
+print(f"MCP SSE server running on http://{host}:{port}/sse", flush=True)

--- a/tests/unit/test_mcp_sse_transport.py
+++ b/tests/unit/test_mcp_sse_transport.py
@@ -9,6 +9,9 @@ Covers two issues found in code review:
 """
 
 import pathlib
+import threading
+import urllib.error
+import urllib.request
 
 import pytest
 
@@ -97,6 +100,82 @@ def test_write_locked_clears_client_on_broken_pipe():
 
     assert transport._write_locked(b"data") is False
     assert transport._sse_wfile is None
+
+
+# ---------------------------------------------------------------------------
+# Security — CORS / cross-origin tool invocation (drive-by RCE) guard
+# ---------------------------------------------------------------------------
+
+def test_request_allowed_for_loopback_native_client():
+    transport = SSEServerTransport()
+    # Native MCP clients connect over loopback and send no Origin header.
+    assert transport._request_allowed("127.0.0.1:3000", None) is True
+    assert transport._request_allowed("localhost:3000", None) is True
+
+
+def test_request_allowed_for_ipv6_loopback():
+    transport = SSEServerTransport()
+    assert transport._request_allowed("[::1]:3000", None) is True
+
+
+def test_request_rejected_for_cross_origin_browser_request():
+    transport = SSEServerTransport()
+    # A malicious web page's fetch() to localhost always carries an Origin.
+    assert transport._request_allowed("127.0.0.1:3000", "https://evil.example") is False
+
+
+def test_request_rejected_for_non_loopback_host_dns_rebinding():
+    transport = SSEServerTransport()
+    assert transport._request_allowed("evil.example", None) is False
+
+
+def test_request_rejected_for_missing_host():
+    transport = SSEServerTransport()
+    assert transport._request_allowed(None, None) is False
+    assert transport._request_allowed("", None) is False
+
+
+def test_request_allows_explicitly_configured_bind_host():
+    transport = SSEServerTransport(host="192.168.1.5")
+    assert transport._request_allowed("192.168.1.5:3000", None) is True
+
+
+def test_cross_origin_post_rejected_and_no_wildcard_cors_header():
+    transport = SSEServerTransport(host="127.0.0.1", port=0)
+    transport._handler = lambda msg: {
+        "jsonrpc": "2.0", "id": msg.get("id"), "result": {}
+    }
+    server = transport._make_server()
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        # A cross-origin browser POST is rejected server-side.
+        cross = urllib.request.Request(
+            f"http://127.0.0.1:{port}/messages",
+            data=b'{"jsonrpc":"2.0","id":1,"method":"ping"}',
+            headers={"Content-Type": "application/json",
+                     "Origin": "https://evil.example"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(cross, timeout=5)
+        assert exc.value.code == 403
+
+        # A native client POST (no Origin) is accepted and exposes no
+        # permissive CORS header.
+        native = urllib.request.Request(
+            f"http://127.0.0.1:{port}/messages",
+            data=b'{"jsonrpc":"2.0","id":1,"method":"ping"}',
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        resp = urllib.request.urlopen(native, timeout=5)
+        assert resp.status == 202
+        assert resp.headers.get("Access-Control-Allow-Origin") is None
+    finally:
+        server.shutdown()
+        server.server_close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_sse_transport.py
+++ b/tests/unit/test_mcp_sse_transport.py
@@ -1,0 +1,129 @@
+"""Regression tests for the SSE MCP server transport (PR #29 review fixes).
+
+Covers two issues found in code review:
+  - SSE socket writes must be serialized under ``_sse_lock`` so the keepalive
+    loop and a tool response (running on different ThreadingMixIn threads)
+    cannot interleave bytes and corrupt the event stream.
+  - The HTTP entry-point script must not reference ``__file__`` unguarded,
+    because its documented ``exec(open(...).read())`` usage has no ``__file__``.
+"""
+
+import pathlib
+
+import pytest
+
+from freecad_ai.mcp.transport import SSEServerTransport
+
+
+# ---------------------------------------------------------------------------
+# Issue A — concurrent SSE writes must hold the lock
+# ---------------------------------------------------------------------------
+
+class _LockProbe:
+    """Fake wfile that records whether ``_sse_lock`` is held during write().
+
+    A plain ``threading.Lock`` returns ``False`` from ``acquire(blocking=False)``
+    whenever it is already held, so this deterministically detects whether the
+    transport serializes the actual write (not merely the pointer read).
+    """
+
+    def __init__(self, lock):
+        self._lock = lock
+        self.lock_held_during_write = None
+        self.written = b""
+
+    def write(self, data):
+        acquired = self._lock.acquire(blocking=False)
+        self.lock_held_during_write = not acquired
+        if acquired:
+            self._lock.release()
+        self.written += data
+
+    def flush(self):
+        pass
+
+
+def test_send_sse_holds_lock_during_write():
+    transport = SSEServerTransport()
+    probe = _LockProbe(transport._sse_lock)
+    transport._sse_wfile = probe
+
+    transport._send_sse({"jsonrpc": "2.0", "id": 1, "result": {}})
+
+    assert probe.lock_held_during_write is True
+
+
+def test_send_sse_frames_message_as_sse_event():
+    transport = SSEServerTransport()
+    probe = _LockProbe(transport._sse_lock)
+    transport._sse_wfile = probe
+
+    transport._send_sse({"jsonrpc": "2.0", "id": 7, "result": {"ok": True}})
+
+    text = probe.written.decode()
+    assert text.startswith("event: message\ndata: ")
+    assert text.endswith("\n\n")
+    assert '"id":7' in text
+
+
+def test_write_locked_holds_lock_during_write():
+    transport = SSEServerTransport()
+    probe = _LockProbe(transport._sse_lock)
+    transport._sse_wfile = probe
+
+    assert transport._write_locked(b": keepalive\n\n") is True
+    assert probe.lock_held_during_write is True
+    assert probe.written == b": keepalive\n\n"
+
+
+def test_write_locked_returns_false_without_client():
+    transport = SSEServerTransport()
+    transport._sse_wfile = None
+
+    assert transport._write_locked(b"data") is False
+
+
+def test_write_locked_clears_client_on_broken_pipe():
+    transport = SSEServerTransport()
+
+    class _Broken:
+        def write(self, data):
+            raise BrokenPipeError()
+
+        def flush(self):
+            pass
+
+    transport._sse_wfile = _Broken()
+
+    assert transport._write_locked(b"data") is False
+    assert transport._sse_wfile is None
+
+
+# ---------------------------------------------------------------------------
+# Issue D — entry-point script must be safe under exec() (no __file__)
+# ---------------------------------------------------------------------------
+
+def test_http_entry_point_safe_under_exec():
+    """exec(open('mcp_server_http.py').read()) must not raise NameError on __file__.
+
+    The script's docstring documents this exact usage. ``exec`` of source text
+    defines no ``__file__``; the script must guard the reference. Running it in
+    a unit env can't import the FreeCAD C++ module, so reaching ``import
+    FreeCAD`` (ImportError) proves we got past the ``__file__`` handling.
+    """
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    source = (repo_root / "mcp_server_http.py").read_text()
+    code = compile(source, "mcp_server_http.py", "exec")
+
+    namespace = {}  # mimics exec(open(...).read()): no __file__ defined
+    try:
+        exec(code, namespace)
+    except (ImportError, ModuleNotFoundError):
+        pass  # reached `import FreeCAD` — past the __file__ guard, as intended
+    except NameError as exc:
+        if "__file__" in str(exc):
+            pytest.fail(
+                "mcp_server_http.py references __file__ unguarded — "
+                "breaks the documented exec(open(...).read()) usage"
+            )
+        raise


### PR DESCRIPTION
This allows the users to operate in an external harness with the GUI visualization available.

Usage:

Start FreeCAD with `/path/to/FreeCAD.AppImage /path/to/freecad-ai/mcp_server_http.py`

MCP configuration:
```json
{
    "freecad": {
      "type": "remote",
      "url": "http://127.0.0.1:3000/sse"
    }
}
```