### PR TITLE
fix(chat): strip history images for non-vision models (#30)

### DIFF
--- a/freecad_ai/core/conversation.py
+++ b/freecad_ai/core/conversation.py
@@ -94,6 +94,7 @@ class Conversation:
     def get_messages_for_api(self, max_chars: int = 100000,
                              api_style: str = "openai",
                              describe_fn=None,
+                             strip_images: bool = False,
                              strip_thinking: bool = False) -> list[dict]:
         """Get messages formatted for the LLM API.
 
@@ -102,6 +103,12 @@ class Conversation:
         Never splits a tool_call/tool_result pair during truncation.
 
         Args:
+            describe_fn: If given, image blocks in history are replaced with
+                text descriptions produced by this callable (vision fallback).
+            strip_images: If True (and no describe_fn), image blocks in history
+                are replaced with a text placeholder. Use for non-vision models
+                so a stale image from earlier in the conversation isn't sent to
+                a model that would reject it (issue #30).
             strip_thinking: If True, remove reasoning_content from assistant
                 messages in the history.  Required by models like Gemma that
                 reject thinking content in multi-turn conversations.
@@ -152,9 +159,12 @@ class Conversation:
         while result and result[0]["role"] not in ("user",):
             result.pop(0)
 
-        # Replace image blocks with text descriptions if describe_fn is provided
+        # Replace image blocks with text descriptions if describe_fn is
+        # provided, else drop them to a placeholder when strip_images is set.
         if describe_fn:
             result = self._replace_images_with_descriptions(result, describe_fn)
+        elif strip_images:
+            result = self._strip_images(result)
 
         # Convert to provider format
         if api_style == "anthropic":
@@ -289,6 +299,30 @@ class Conversation:
                             "type": "text",
                             "text": f"[Image: description unavailable — MCP error: {e}]",
                         })
+                else:
+                    new_blocks.append(block)
+            result.append({**msg, "content": new_blocks})
+        return result
+
+    @staticmethod
+    def _strip_images(messages: list[dict]) -> list[dict]:
+        """Replace image content blocks with a placeholder text block.
+
+        For models without vision support and no describe_image fallback, so
+        history images aren't sent raw to a provider that would reject them.
+        """
+        result = []
+        for msg in messages:
+            if not isinstance(msg.get("content"), list):
+                result.append(msg)
+                continue
+            new_blocks = []
+            for block in msg["content"]:
+                if block.get("type") == "image":
+                    new_blocks.append({
+                        "type": "text",
+                        "text": "[Image omitted — the current model has no vision support]",
+                    })
                 else:
                     new_blocks.append(block)
             result.append({**msg, "content": new_blocks})

--- a/freecad_ai/extensions/skill_evaluator.py
+++ b/freecad_ai/extensions/skill_evaluator.py
@@ -383,10 +383,14 @@ class SkillEvaluator:
                         _turn + 1, budget, elapsed, tool_calls)
             from ..llm.client import should_strip_thinking
             from ..config import get_config as _get_cfg
+            _cfg = _get_cfg()
             strip = should_strip_thinking(
-                client.model, _get_cfg().strip_thinking_history)
+                client.model, _cfg.strip_thinking_history)
+            # Defensive: keep history image-free for non-vision models, matching
+            # the chat path (the eval conversation is text-only today).
             messages = conv.get_messages_for_api(
-                api_style=api_style, strip_thinking=strip)
+                api_style=api_style, strip_images=not _cfg.supports_vision,
+                strip_thinking=strip)
             try:
                 response = client.send_with_tools(
                     messages, system=system_prompt, tools=tools_schema

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -2510,7 +2510,10 @@ class ChatDockWidget(QDockWidget):
         cfg = get_config()
         strip = should_strip_thinking(
             cfg.provider.model, cfg.strip_thinking_history)
-        messages = self.conversation.get_messages_for_api(strip_thinking=strip)
+        # This retry attached a viewport snapshot above; drop history images
+        # for non-vision models so they aren't sent raw (issue #30).
+        messages = self.conversation.get_messages_for_api(
+            strip_images=not cfg.supports_vision, strip_thinking=strip)
 
         self._set_loading(True)
         self._streaming_html = ""

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -2002,8 +2002,13 @@ class ChatDockWidget(QDockWidget):
         from ..llm.client import should_strip_thinking
         strip = should_strip_thinking(
             cfg.provider.model, cfg.strip_thinking_history)
+        # When the model has no vision and no describe_image fallback is
+        # available, drop history image blocks to a placeholder so they aren't
+        # sent raw to a provider that would reject them (issue #30). When a
+        # describe_fn exists, the worker rebuilds messages with descriptions.
+        strip_images = not cfg.supports_vision and describe_fn is None
         messages = self.conversation.get_messages_for_api(
-            api_style=api_style, strip_thinking=strip)
+            api_style=api_style, strip_images=strip_images, strip_thinking=strip)
 
         # Start streaming
         self._set_loading(True)

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -566,3 +566,53 @@ class TestShouldStripThinking:
         from freecad_ai.llm.client import should_strip_thinking
         assert should_strip_thinking("") is False
         assert should_strip_thinking(None) is False
+
+
+class TestStripImagesForNonVisionModels:
+    """Issue #30: a non-vision model must not receive image blocks from history.
+
+    When the current model has no vision support and no describe_image
+    fallback is configured, image blocks in history must be replaced with a
+    text placeholder instead of being sent raw (which the provider rejects).
+    """
+
+    IMAGE = {"type": "image", "media_type": "image/png", "data": "aWdub3Jl"}
+
+    def _conv_with_image(self):
+        c = Conversation()
+        c.add_user_message("look at this", images=[self.IMAGE])
+        return c
+
+    def test_strip_images_removes_image_block_openai(self):
+        c = self._conv_with_image()
+        msgs = c.get_messages_for_api(api_style="openai", strip_images=True)
+        blocks = msgs[0]["content"]
+        assert all(b.get("type") != "image_url" for b in blocks)
+        assert any(b["type"] == "text" for b in blocks)
+
+    def test_strip_images_removes_image_block_anthropic(self):
+        c = self._conv_with_image()
+        msgs = c.get_messages_for_api(api_style="anthropic", strip_images=True)
+        blocks = msgs[0]["content"]
+        assert all(b.get("type") != "image" for b in blocks)
+
+    def test_strip_images_keeps_text(self):
+        c = self._conv_with_image()
+        msgs = c.get_messages_for_api(api_style="openai", strip_images=True)
+        text = " ".join(b.get("text", "") for b in msgs[0]["content"])
+        assert "look at this" in text
+
+    def test_default_keeps_images(self):
+        # Behavior preserved when strip_images is not requested.
+        c = self._conv_with_image()
+        msgs = c.get_messages_for_api(api_style="openai")
+        assert any(b.get("type") == "image_url" for b in msgs[0]["content"])
+
+    def test_describe_fn_takes_precedence_over_strip(self):
+        c = self._conv_with_image()
+        msgs = c.get_messages_for_api(
+            api_style="openai", strip_images=True,
+            describe_fn=lambda data_url: "a red cube",
+        )
+        text = " ".join(b.get("text", "") for b in msgs[0]["content"])
+        assert "a red cube" in text

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -608,6 +608,15 @@ class TestStripImagesForNonVisionModels:
         msgs = c.get_messages_for_api(api_style="openai")
         assert any(b.get("type") == "image_url" for b in msgs[0]["content"])
 
+    def test_strip_images_on_system_message_with_viewport(self):
+        # The auto-retry-on-error path attaches a viewport snapshot via
+        # add_system_message(images=[...]); that image must also be stripped.
+        c = Conversation()
+        c.add_system_message("code failed", images=[self.IMAGE])
+        msgs = c.get_messages_for_api(api_style="openai", strip_images=True)
+        blocks = msgs[0]["content"]
+        assert all(b.get("type") != "image_url" for b in blocks)
+
     def test_describe_fn_takes_precedence_over_strip(self):
         c = self._conv_with_image()
         msgs = c.get_messages_for_api(


### PR DESCRIPTION
## Summary

Fixes the vision half of #30: a model **without** vision support errors out on every follow-up turn once an image is anywhere in the conversation history.

### Root cause
`get_messages_for_api()` was called from several send paths without stripping or converting image blocks. The only mitigation — replacing images with text descriptions — runs in the worker and only when a `describe_image` vision-fallback MCP tool is configured. So for the common case (non-vision model, no fallback tool), an image left in history was sent raw to the provider, which rejects it; the conversation stays broken until history is cleared.

### Fix
- `conversation.py`: `get_messages_for_api()` gains a `strip_images` option and a `_strip_images()` helper that replaces image blocks with a `[Image omitted — the current model has no vision support]` text placeholder (OpenAI + Anthropic formats).
- `chat_widget.py`, **main send path**: passes `strip_images=True` when `not cfg.supports_vision and describe_fn is None`. When a `describe_image` fallback exists, the existing describe-and-substitute path is unchanged.
- `chat_widget.py`, **auto-retry-on-error path**: this path attaches a viewport snapshot via `add_system_message(images=[...])` and re-sent history with no vision gating — a real, reproducible variant. Now strips images for non-vision models.
- `skill_evaluator.py`: same gate applied for consistency (its eval conversation is text-only today, so this is defensive).

### Tests
+6 regression tests in `test_conversation.py::TestStripImagesForNonVisionModels` (OpenAI + Anthropic stripping, text preserved, default-keeps-images guard, `describe_fn` precedence, system-message/viewport-image shape). Full unit suite green (910 passed; only the pre-existing `test_document_attach.py` Qt-segfault excluded).

### Notes
- The **temperature-persistence** bug also reported in #30 is a separate issue in the settings save path and is **not** addressed here — awaiting a reproduction detail from the reporter.

Refs #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
