### PR TITLE
fix(settings): give the reranker its own param namespace (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+A bug-fix for the temperature-persistence half of [issue #30](https://github.com/ghbalf/freecad-ai/issues/30) (@AVAVAVA1): a per-model sampling parameter set in Settings reverted to its default after Save.
+
+### Fixed
+
+- **Reranker params could overwrite the main model's params on save** (`freecad_ai/config.py`, `freecad_ai/ui/settings_dialog.py`, `freecad_ai/ui/chat_widget.py`). The reranker stored its sampling parameters in the *shared* `model_params` dict, keyed by model name. When the reranker inherited the main model (override field empty — including whenever reranking is off), its "effective model" *was* the main model, so the Save handler wrote the reranker's table — a stale snapshot taken when the dialog opened, before any edit — into the main model's slot, clobbering the value the user had just changed (e.g. `temperature` reverting to `0.3`). The reranker now keeps its parameters in a dedicated `rerank_params` field that can never collide with `model_params`: in override mode the reranker reads/writes its own slot; in inherit mode it reads the main model's params and persists nothing of its own. Existing configs are migrated on load (the legacy reranker-override slot seeds `rerank_params` once). ([issue #30](https://github.com/ghbalf/freecad-ai/issues/30); thanks @AVAVAVA1) ([#32](https://github.com/ghbalf/freecad-ai/pull/32))
+
+### Tests
+
+- Unit: `tests/unit/test_reranker_namespace.py` — the runtime read path (`_build_rerank_llm_client`) sources params from `rerank_params` when overriding and from the main model when inheriting, and the persistence rule (`SettingsDialog._resolve_rerank_params`) writes the table only in override mode. `tests/unit/test_config.py` gains the `rerank_params` default/round-trip and the migration-seed cases (override seeds, inherit no-ops, idempotent when already present).
+
 ## [0.16.4-alpha] - 2026-06-16
 
 A bug-fix patch for the vision half of [issue #30](https://github.com/ghbalf/freecad-ai/issues/30) (@AVAVAVA1): a model without vision support errored out on every follow-up turn once an image was anywhere in the conversation history.

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -452,6 +452,12 @@ class AppConfig:
     rerank_llm_base_url: str = ""
     rerank_llm_api_key: str = ""
     rerank_llm_model: str = ""
+    # Sampling params for the reranker's *override* model. Kept in their own
+    # namespace (never the shared model_params dict) so the reranker can never
+    # overwrite the main model's params — the bug behind issue #30. Only used
+    # when rerank_llm_model is set; in inherit mode the reranker reads the main
+    # model's params instead.
+    rerank_params: dict = field(default_factory=dict)
 
     # Chat dock layout persistence. FreeCAD's native mw.restoreState runs
     # before the workbench activates, so our dock misses the restore and
@@ -539,6 +545,12 @@ def load_config() -> AppConfig:
             cfg = AppConfig.from_dict(data)
         except (json.JSONDecodeError, TypeError, KeyError):
             pass
+    # Migrate pre-namespace configs: the reranker override model's params used
+    # to live in the shared model_params dict. Seed the new rerank_params slot
+    # from there so override users don't silently lose their params on upgrade.
+    # Idempotent — only fills an empty rerank_params (issue #30 follow-up).
+    if cfg.rerank_llm_model and not cfg.rerank_params:
+        cfg.rerank_params = dict(cfg.model_params.get(cfg.rerank_llm_model, {}))
     _apply_param_store_overrides(cfg)
     _write_to_param_store(cfg)
     return cfg

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -101,14 +101,14 @@ def _build_rerank_llm_client(cfg):
     too, for e.g. running reranking on a local Ollama model while the
     main chat uses a cloud provider.
 
-    Model params for the reranker's effective model are always sourced
-    from the shared ``cfg.model_params`` dict, keyed by model name.
-    This means:
-      - Inherited model → same params as main chat (handles provider
-        quirks like Moonshot's locked ``temperature=1``)
-      - Override model → params configured via the reranker's inline
-        params table in Settings (important for small Ollama models
-        that need ``num_predict`` / ``top_k`` / ``repeat_penalty`` etc.)
+    Model params come from one of two disjoint namespaces, so the reranker
+    can never overwrite the main model's params (issue #30):
+      - Inherited model (no override) → the main model's params from
+        ``cfg.model_params`` (handles provider quirks like Moonshot's locked
+        ``temperature=1``)
+      - Override model → the reranker's own ``cfg.rerank_params`` (important
+        for small Ollama models that need ``num_predict`` / ``top_k`` /
+        ``repeat_penalty`` etc.)
     """
     from ..llm.client import LLMClient
     provider_name = cfg.rerank_llm_provider_name or cfg.provider.name
@@ -116,9 +116,10 @@ def _build_rerank_llm_client(cfg):
     api_key = cfg.rerank_llm_api_key or cfg.provider.api_key
     model = cfg.rerank_llm_model or cfg.provider.model
 
-    # Always look up params for the effective model — sharing the main
-    # model_params dict keeps params coherent across main/reranker usage.
-    model_params = dict(cfg.model_params.get(model, {}))
+    if cfg.rerank_llm_model:  # override → reranker's own param namespace
+        model_params = dict(cfg.rerank_params)
+    else:  # inherit → use the main model's params
+        model_params = dict(cfg.model_params.get(model, {}))
 
     return LLMClient(
         provider_name=provider_name,

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -179,10 +179,6 @@ class SettingsDialog(QDialog):
         self.resize(540, 700)
         self._test_thread = None
         self._last_default_prompt = ""
-        # Unsaved reranker params, keyed by model name. Survives renaming
-        # the override model within one dialog session so the user doesn't
-        # lose typed-but-not-saved params.
-        self._rerank_pending_params: dict[str, dict] = {}
         self._rerank_last_model = ""
         self._build_ui()
         self._load_from_config()
@@ -856,8 +852,7 @@ class SettingsDialog(QDialog):
         self.rerank_llm_base_url_edit.setText(cfg.rerank_llm_base_url)
         self.rerank_llm_api_key_edit.setText(cfg.rerank_llm_api_key)
         self.rerank_llm_model_edit.setText(cfg.rerank_llm_model)
-        # Reset pending edits from any previous dialog open
-        self._rerank_pending_params = {}
+        # Force a fresh resolve (setText above may have fired the signal mid-load)
         self._rerank_last_model = ""
         self._on_rerank_model_changed()
         self._on_rerank_method_changed(self.rerank_method_combo.currentIndex())
@@ -1179,27 +1174,12 @@ class SettingsDialog(QDialog):
         rerank_model = self.rerank_llm_model_edit.text().strip()
         cfg.rerank_llm_model = rerank_model
 
-        # Save the reranker params table into cfg.model_params, keyed by
-        # the effective model name. When inheriting, that's the main model
-        # — edits in the reranker table propagate to the main model's
-        # entry (last-save-wins against the main table, which already
-        # wrote above). When overriding, it's the override model's slot.
-        effective_model = rerank_model or cfg.provider.model
-        rerank_params = self._read_rerank_params_table()
-        if rerank_params:
-            cfg.model_params[effective_model] = rerank_params
-
-        # Also persist any pending params for other override models that
-        # were edited earlier in this dialog session (before the user
-        # renamed the override field). Empty tables clear the slot, but
-        # never for the main model — the main table owns that.
-        for model_name, params in self._rerank_pending_params.items():
-            if model_name == effective_model:
-                continue  # already handled above
-            if params:
-                cfg.model_params[model_name] = params
-            elif model_name in cfg.model_params and model_name != cfg.provider.model:
-                del cfg.model_params[model_name]
+        # Save the reranker params into their own namespace (cfg.rerank_params),
+        # never the shared model_params dict. In inherit mode the reranker has
+        # no params of its own — the main Model Parameters table owns the main
+        # model's slot, so the reranker can't clobber it (issue #30).
+        cfg.rerank_params = self._resolve_rerank_params(
+            rerank_model, self._read_rerank_params_table())
 
         save_current_config()
         self.accept()
@@ -1208,45 +1188,52 @@ class SettingsDialog(QDialog):
         """Show the LLM provider subgroup only when 'LLM' is selected."""
         self.rerank_llm_group.setVisible(index == 2)
 
+    @staticmethod
+    def _resolve_rerank_params(rerank_model: str, table_params: dict) -> dict:
+        """Reranker params to persist into cfg.rerank_params.
+
+        Override mode (a distinct model is set) → persist the table. Inherit
+        mode (empty override) → persist nothing; the reranker reads the main
+        model's params at runtime and the main Model Parameters table owns
+        that slot, so the reranker can never overwrite it (issue #30).
+        """
+        return dict(table_params) if rerank_model.strip() else {}
+
     def _on_rerank_model_changed(self, *_args):
         """Refresh the reranker params table for the current model state.
 
-        - Empty override → prefill with the main Model Parameters table's
-          *live* values, lock the table read-only, and disable buttons.
-          Edits belong on the main table.
-        - Non-empty override → populate with pending/saved/default params
-          for that specific model, enable editing.
+        - Empty override → mirror the main Model Parameters table's live
+          values (edits belong on the main table; the reranker inherits them).
+        - Non-empty override → show the reranker's own params. Renaming the
+          override model keeps the current edits (params are a single set, not
+          keyed per model); entering override from inherit loads the saved
+          cfg.rerank_params, falling back to provider defaults.
         """
         cfg = get_config()
         prev_model = getattr(self, "_rerank_last_model", "") or ""
         model = self.rerank_llm_model_edit.text().strip()
-
-        # Persist unsaved edits under the previous (override) model name
-        # so typing a fresh override name doesn't drop them. We only stash
-        # when the previous state was editable (override mode).
-        if prev_model:
-            self._rerank_pending_params[prev_model] = self._read_rerank_params_table()
-
         self._rerank_last_model = model
-        inheriting = not model
 
-        if inheriting:
-            # Show live values from the main params table (not disk) —
-            # reflects in-dialog edits the user may have just made there.
-            # Stays editable: changes write to the main model's slot in
-            # cfg.model_params (shared with the main table).
-            params = self._read_model_params_table()
-            self._populate_rerank_params_table(params)
+        if not model:
+            # Inherit: show the main model's live params (reflects in-dialog
+            # edits there). These are not persisted under the reranker — the
+            # main table is authoritative.
+            self._populate_rerank_params_table(self._read_model_params_table())
             self._rerank_params_label.setText(translate(
                 "SettingsDialog",
-                "Model parameters (inheriting main model — edits also apply to main):"))
+                "Model parameters (inheriting main model — edit on the main table):"))
             return
 
-        # Override model: pending edits win, then saved, then provider defaults
-        if model in self._rerank_pending_params:
-            params = self._rerank_pending_params[model]
-        else:
-            params = dict(cfg.model_params.get(model, {}))
+        if prev_model:
+            # Was already overriding — the user just renamed the model.
+            # Keep the current edits (single param set, not per-model).
+            self._rerank_params_label.setText(translate(
+                "SettingsDialog", "Model parameters (reranker override):"))
+            return
+
+        # Entering override from inherit: load saved reranker params, else
+        # provider defaults.
+        params = dict(cfg.rerank_params)
         if not params:
             provider_name = (
                 self.rerank_llm_provider_combo.currentData()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -135,6 +135,24 @@ class TestAppConfig:
         assert c2.chat_dock_tabified_with == ["Tasks", "ModelView"]
         assert c2.chat_dock_mw_state == "aGVsbG8gd29ybGQ="
 
+    def test_rerank_params_default_empty(self):
+        """The reranker has its own param namespace, empty by default."""
+        c = AppConfig()
+        assert c.rerank_params == {}
+
+    def test_rerank_params_roundtrip(self):
+        """rerank_params survives a JSON round-trip independently of
+        model_params — it must never collide with the main model's slot
+        (issue #30: reranker save clobbered the main model's temperature)."""
+        c = AppConfig()
+        c.provider.model = "main-model"
+        c.model_params = {"main-model": {"temperature": 0.8}}
+        c.rerank_params = {"temperature": 0.0, "top_k": 20}
+        c2 = AppConfig.from_dict(c.to_dict())
+        assert c2.rerank_params == {"temperature": 0.0, "top_k": 20}
+        # The main model's params are untouched by the reranker namespace.
+        assert c2.model_params == {"main-model": {"temperature": 0.8}}
+
 
 class TestProviderPresets:
     def test_all_presets_have_required_keys(self):
@@ -189,6 +207,51 @@ class TestSaveLoad:
         c = load_config()
         assert c.mode == "plan"
         assert c.provider.name == "anthropic"
+
+    def test_load_seeds_rerank_params_from_legacy_override_slot(self, tmp_config_dir):
+        """Migration: pre-namespace configs stored the reranker override
+        model's params inside the shared model_params dict. On load, seed the
+        new rerank_params namespace from that slot so override users don't
+        silently lose their reranker params (issue #30 follow-up)."""
+        import freecad_ai.config as config_mod
+        os.makedirs(os.path.dirname(config_mod.CONFIG_FILE), exist_ok=True)
+        with open(config_mod.CONFIG_FILE, "w") as f:
+            json.dump({
+                "provider": {"name": "ollama", "model": "main-model"},
+                "rerank_llm_model": "rr-model",
+                "model_params": {"rr-model": {"temperature": 0.0, "top_k": 20}},
+            }, f)
+        c = load_config()
+        assert c.rerank_params == {"temperature": 0.0, "top_k": 20}
+
+    def test_load_does_not_seed_rerank_params_in_inherit_mode(self, tmp_config_dir):
+        """No reranker override model → nothing to migrate; rerank_params
+        stays empty (inherit mode reads the main model's params at runtime)."""
+        import freecad_ai.config as config_mod
+        os.makedirs(os.path.dirname(config_mod.CONFIG_FILE), exist_ok=True)
+        with open(config_mod.CONFIG_FILE, "w") as f:
+            json.dump({
+                "provider": {"name": "ollama", "model": "main-model"},
+                "rerank_llm_model": "",
+                "model_params": {"main-model": {"temperature": 0.7}},
+            }, f)
+        c = load_config()
+        assert c.rerank_params == {}
+
+    def test_load_keeps_existing_rerank_params_over_legacy_seed(self, tmp_config_dir):
+        """Idempotent: a config already carrying rerank_params is not
+        overwritten by the legacy model_params slot."""
+        import freecad_ai.config as config_mod
+        os.makedirs(os.path.dirname(config_mod.CONFIG_FILE), exist_ok=True)
+        with open(config_mod.CONFIG_FILE, "w") as f:
+            json.dump({
+                "provider": {"name": "ollama", "model": "main-model"},
+                "rerank_llm_model": "rr-model",
+                "rerank_params": {"temperature": 0.2},
+                "model_params": {"rr-model": {"temperature": 0.0, "top_k": 20}},
+            }, f)
+        c = load_config()
+        assert c.rerank_params == {"temperature": 0.2}
 
     def test_load_returns_defaults_on_corrupt_json(self, tmp_config_dir):
         import freecad_ai.config as config_mod

--- a/tests/unit/test_reranker_namespace.py
+++ b/tests/unit/test_reranker_namespace.py
@@ -1,0 +1,83 @@
+"""Reranker params get their own namespace, never the main model's slot.
+
+Issue #30 (AVAVAVA1): editing the main model's temperature and saving reverted
+it to 0.3. Root cause: the reranker save path wrote its table into the shared
+``cfg.model_params`` dict keyed by model name; in inherit mode that key *is* the
+main model, so the (stale) reranker snapshot clobbered the main model's params.
+
+The fix gives the reranker its own ``cfg.rerank_params`` field:
+  - override mode (a distinct reranker model is set) → reranker uses
+    ``cfg.rerank_params``;
+  - inherit mode (override field empty) → reranker uses the main model's
+    params (``cfg.model_params[provider.model]``), and saves nothing of its own.
+
+These tests pin both the runtime read path (``_build_rerank_llm_client``) and the
+persistence rule (``SettingsDialog._resolve_rerank_params``).
+"""
+
+import pytest
+
+# settings_dialog/chat_widget import through ui/compat.py which needs PySide.
+# In dev venvs without either, skip — the dialog can't be imported.
+try:
+    import PySide6  # noqa: F401
+except ImportError:
+    try:
+        import PySide2  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from freecad_ai.config import AppConfig  # noqa: E402
+from freecad_ai.ui.chat_widget import _build_rerank_llm_client  # noqa: E402
+from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
+
+
+def _cfg_with_params():
+    cfg = AppConfig()
+    cfg.provider.name = "ollama"
+    cfg.provider.base_url = "http://localhost:11434/v1"
+    cfg.provider.model = "main-model"
+    cfg.model_params = {"main-model": {"temperature": 0.8, "top_p": 0.9}}
+    cfg.rerank_params = {"temperature": 0.1, "top_k": 20}
+    return cfg
+
+
+class TestBuildRerankClientReadPath:
+    def test_override_uses_rerank_params(self):
+        """Distinct reranker model → params come from cfg.rerank_params,
+        NOT from cfg.model_params (which has nothing for this model)."""
+        cfg = _cfg_with_params()
+        cfg.rerank_llm_model = "rr-model"
+        client = _build_rerank_llm_client(cfg)
+        assert client.model == "rr-model"
+        assert client.model_params == {"temperature": 0.1, "top_k": 20}
+
+    def test_inherit_uses_main_model_params(self):
+        """Empty override → reranker inherits the main model and its params."""
+        cfg = _cfg_with_params()
+        cfg.rerank_llm_model = ""
+        client = _build_rerank_llm_client(cfg)
+        assert client.model == "main-model"
+        assert client.model_params == {"temperature": 0.8, "top_p": 0.9}
+
+
+class TestResolveRerankParamsWriteRule:
+    def test_override_persists_table(self):
+        """With an override model set, the reranker table is persisted."""
+        out = SettingsDialog._resolve_rerank_params(
+            "rr-model", {"temperature": 0.1, "top_k": 20})
+        assert out == {"temperature": 0.1, "top_k": 20}
+
+    def test_inherit_persists_nothing(self):
+        """Empty override → reranker stores nothing; the main Model
+        Parameters table is the sole owner of the main model's slot. This is
+        the exact guard that fixes the issue #30 clobber."""
+        out = SettingsDialog._resolve_rerank_params(
+            "", {"temperature": 0.1, "top_k": 20})
+        assert out == {}
+
+    def test_whitespace_override_treated_as_inherit(self):
+        """A blank-but-spaces override field is still inherit mode."""
+        out = SettingsDialog._resolve_rerank_params(
+            "   ", {"temperature": 0.1})
+        assert out == {}


### PR DESCRIPTION
## Summary

Fixes the temperature-persistence half of #30 (AVAVAVA1): editing the main model's temperature in Settings → Model Parameters and clicking Save reverted it to `0.3`.

**Root cause.** Reranker and main model shared `cfg.model_params`, keyed by model name. In *inherit* mode (reranker override field empty) the reranker's "effective model" **is** the main model, so the reranker save block wrote its table to the main model's exact slot — overwriting it with a stale snapshot taken at dialog-load time, before the user's edit. The block had no guard, so it fired even with reranking off (the reporter's case). The value showed `0.3` because the stale snapshot held the inherited default.

**Fix.** The reranker gets its own `cfg.rerank_params` field, structurally separate from `model_params`, so there is no shared key left to collide on.

- **Read** (`chat_widget._build_rerank_llm_client`): override → `cfg.rerank_params`; inherit → the main model's `cfg.model_params` (the reranker uses the main model's params).
- **Write** (`settings_dialog`): new pure `_resolve_rerank_params()` persists the table in override mode, nothing in inherit mode; `_save` never names `model_params`.
- **Migration** (`load_config`): seeds `rerank_params` once from the legacy `model_params[override]` slot so existing override users don't lose their params on upgrade (idempotent).
- Retires the per-model `_rerank_pending_params` dict — there's a single reranker param set now.

## Tests

TDD — 9 tests written first (RED), then implemented to green:

- `test_config.py`: field default, JSON round-trip (independent of `model_params`), migration seed + inherit/idempotent cases.
- `test_reranker_namespace.py`: runtime read path (override vs inherit) and the persistence rule.

```
full unit suite (minus the pre-existing Qt-segfault test_document_attach.py) … 920 passed
```

## Not yet verified

Driven by an AI coding assistant under the maintainer's direction and review. **Not yet run against a live FreeCAD GUI** (headless dev box) — the dialog round-trip (edit main temperature → Save → reopen) wants a manual smoke test before merge. The temperature value persisting and the reranker override path are the two things to spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)