### PR TITLE
fix: add User-Agent header to fix 403 errors

### DIFF
--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -365,6 +365,7 @@ class LLMClient:
     def _openai_headers(self) -> dict:
         headers = {
             "Content-Type": "application/json",
+            "User-Agent": "FreeCAD-AI",
         }
         resolved_key = self._resolve_api_key()
         if resolved_key:


### PR DESCRIPTION
I was having trouble using 'custom' api calls to my OpenAI api.

It seemed that when using `curl` it worked because it adds user-agent by default.
I.E
```HTTP
User-Agent: curl/8.20.0
```

This PR adds `User-Agent: Freecad-AI` for all custom agent calls.