### PR TITLE
release: v0.18.0-alpha — keep panel open (#34/#35), UA 403 fix (#33), tool-routing steering (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.18.0-alpha] - 2026-07-04
+
+A small feature-and-fix release bundling two community contributions from
+@3dyuval with a tool-routing steering improvement.
+
+### Added
+
+- **Keep the chat panel open across workbench switches** (`InitGui.py`, `freecad_ai/config.py`, `freecad_ai/ui/settings_dialog.py`). A new opt-in `keep_dock_on_workbench_switch` setting (off by default) stops the FreeCAD AI dock from hiding when you leave the workbench, so the panel stays usable everywhere. Exposed both as a Settings checkbox and a keybindable "Keep Chat Panel Open" menu command. ([#34](https://github.com/ghbalf/freecad-ai/issues/34), [#35](https://github.com/ghbalf/freecad-ai/pull/35); thanks @3dyuval)
+
+### Fixed
+
+- **Custom OpenAI-compatible endpoints no longer 403 on a missing User-Agent** (`freecad_ai/llm/client.py`). `urllib` defaults to a `Python-urllib/x.y` User-Agent that some WAFs and reverse proxies in front of self-hosted gateways reject; requests now send an explicit `User-Agent: FreeCAD-AI`. Applied to both the OpenAI and Anthropic header builders. ([#33](https://github.com/ghbalf/freecad-ai/pull/33); thanks @3dyuval)
+
+### Changed
+
+- **Improved Act-mode steering toward `create_sketch` for face attachment** (`freecad_ai/core/system_prompt.py`, `freecad_ai/tools/freecad_tools.py`). When asked to "sketch on the selected face", the model was hand-rolling a raw `AttachmentSupport`/`MapMode` macro via `execute_code` instead of calling `create_sketch(support=…, face=…)` — which already handles attachment, planar-face validation, and offset. The Act-mode strategy now calls out the face-sketch route explicitly, `create_sketch`'s face capability is lifted to the front of its description, and `execute_code`/`run_macro` are framed as last resorts. Steering-only (prompt + tool descriptions); guarded by text-assertion regression tests. ([#28](https://github.com/ghbalf/freecad-ai/issues/28))
+
 ## [0.17.0-alpha] - 2026-06-22
 
 A feature release adding the first non-STDIO MCP transport: the bundled MCP server can now be reached over HTTP with Server-Sent Events, alongside the existing newline-delimited STDIO transport. Contributed by @Shuenhoy ([#29](https://github.com/ghbalf/freecad-ai/pull/29)).

--- a/freecad_ai/__init__.py
+++ b/freecad_ai/__init__.py
@@ -1,3 +1,3 @@
 """FreeCAD AI — AI assistant workbench for FreeCAD."""
 
-__version__ = "0.17.0-alpha"
+__version__ = "0.18.0-alpha"

--- a/freecad_ai/core/system_prompt.py
+++ b/freecad_ai/core/system_prompt.py
@@ -51,6 +51,7 @@ that perform FreeCAD operations safely. Prefer using tools over generating raw c
 **Tool calling strategy:**
 - For solid shapes (box, cylinder, sphere, cone, torus): use `create_primitive` (auto-creates a Body; pass body_name to add to an existing Body, operation="subtractive" to cut)
 - For complex profiles or swept shapes: `create_body` → `create_sketch` → `pad_sketch` / `pocket_sketch` / `revolve_sketch`
+- To sketch on a SELECTED or named planar face of an existing solid (e.g. "sketch on the selected face"): use `create_sketch` with `support` + `face` (get the face name from `list_faces`). It handles the attachment, planar-face validation, and offset — do NOT hand-write a macro that sets `AttachmentSupport`/`MapMode`.
 - For lofting between two or more profiles: use `loft_sketches`
 - For sweeping a profile along a path: use `sweep_sketch`
 - To drill a hole / cut a feature into a SINGLE existing solid: add a subtractive feature INSIDE that Body — `create_primitive(operation="subtractive", body_name=...)` or `pocket_sketch`. Do NOT use `boolean_operation` for this; a Part boolean buries the original sketch/pad and makes the model history uneditable.
@@ -82,6 +83,8 @@ that perform FreeCAD operations safely. Prefer using tools over generating raw c
 **Important — preserve parametric history:** When MODIFYING an existing solid (drilling holes, adding/removing material), keep working inside its existing Body by appending features (subtractive/additive `create_primitive` with `body_name`, `pocket_sketch`, `pad_sketch`, `fillet_edges`, etc.). This leaves every original sketch and feature editable in the model tree. Avoid Part-workbench booleans on a parametric Body — they collapse its history.
 
 **Important:** Execute only what the user requests. Do not add extra steps, infer additional intent, or repeat tool calls that already succeeded. Once the requested operations are complete, report the result and stop.
+
+**Important — first-class tools over raw code:** `execute_code` and `run_macro` are a last resort. Before writing raw FreeCAD Python, scan the tool list; if a tool already covers the operation, call it. In particular, attaching a sketch to a selected or named face is `create_sketch(support=…, face=…)`, NOT a hand-written `AttachmentSupport`/`MapMode` macro. Raw code skips each tool's validation and parametric-history handling and is more error-prone.
 
 **Enclosure construction pattern** (base + snap-fit lid, T=wall thickness):
 1. Base: create_body → outer rectangle at (0,0) size L×W → pad H → pocket sketch at **offset=H**, inner rect at (T,T) size (L-2T)×(W-2T) → pocket **length=H-T**

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -590,6 +590,7 @@ class LLMClient:
     def _anthropic_headers(self) -> dict:
         headers = {
             "Content-Type": "application/json",
+            "User-Agent": "FreeCAD-AI",
             "x-api-key": self._resolve_api_key(),
             "anthropic-version": ANTHROPIC_API_VERSION,
         }

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -869,6 +869,11 @@ CREATE_SKETCH = ToolDefinition(
     name="create_sketch",
     description=(
         "Create a 2D sketch with geometry (lines, circles, arcs, rectangles) and constraints. "
+        "This is ALSO the correct tool to attach a sketch to a SELECTED or named planar "
+        "face of an existing solid (pass support='Obj', face='Face6' — get the name from "
+        "list_faces) or to a datum plane (support='PlaneName'); do NOT hand-write an "
+        "AttachmentSupport/MapMode macro for this. Without support it attaches to the origin "
+        "`plane` (XY/XZ/YZ). "
         "For PartDesign, specify body_name to add the sketch to a body. "
         "Rectangle dimensions can be expression strings for parametric models: "
         "width='Variables.length', height='Variables.width'. "
@@ -878,10 +883,6 @@ CREATE_SKETCH = ToolDefinition(
         "they are already constrained by the coordinates and dimensions you provide. "
         "COORDINATE SYSTEM: FreeCAD sketches use Y-up. When converting from SVG, images, "
         "or screen coordinates (which use Y-down), negate all Y values."
-        " To sketch on an existing solid's planar face, pass support='Obj' and "
-        "face='Face6' (use list_faces to find the name); to sketch on a datum "
-        "plane pass support='PlaneName'. Without support, attaches to the origin "
-        "`plane` (XY/XZ/YZ) as before."
     ),
     category="modeling",
     parameters=[
@@ -3544,7 +3545,7 @@ def _handle_execute_code(code: str) -> ToolResult:
 
 EXECUTE_CODE = ToolDefinition(
     name="execute_code",
-    description="Execute arbitrary Python code in FreeCAD's interpreter. Use this as a fallback when structured tools don't cover the needed operation. The code has access to FreeCAD, Part, PartDesign, Sketcher, Draft modules.",
+    description="Execute arbitrary Python code in FreeCAD's interpreter. LAST-RESORT fallback for operations no structured tool covers — check the tool list first. Do NOT use it to re-implement a covered operation (e.g. attaching a sketch to a face is `create_sketch`, not a hand-written AttachmentSupport macro). The code has access to FreeCAD, Part, PartDesign, Sketcher, Draft modules.",
     category="general",
     parameters=[
         ToolParam("code", "string", "Python code to execute"),

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1">
     <name>FreeCAD AI</name>
     <description>AI-powered assistant for 3D modeling in FreeCAD. Supports multiple LLM providers with Plan/Act modes, structured tool calling, skills, and MCP integration.</description>
-    <version>0.17.0-alpha</version>
-    <date>2026-06-22</date>
+    <version>0.18.0-alpha</version>
+    <date>2026-07-04</date>
     <maintainer email="alfred@mickautsch.de">Alfred Mickautsch</maintainer>
     <license file="LICENSE-CODE">LGPL-2.1-or-later</license>
     <license file="LICENSE-ICON">CC0-1.0</license>

--- a/tests/unit/test_api_key_resolution.py
+++ b/tests/unit/test_api_key_resolution.py
@@ -97,3 +97,21 @@ class TestResolveApiKey:
         client = _make_client(f"file:{token_file}")
         headers = client._openai_headers()
         assert headers["Authorization"] == "Bearer resolved-bearer-token"
+
+    def test_openai_headers_set_user_agent(self):
+        """OpenAI/custom requests send an explicit User-Agent (PR #33).
+
+        urllib otherwise defaults to ``Python-urllib/x.y``, which some WAFs
+        and proxies in front of self-hosted OpenAI-compatible endpoints
+        reject with a 403. An explicit UA avoids the denylisted default.
+        """
+        client = _make_client("sk-abc123")
+        assert client._openai_headers()["User-Agent"] == "FreeCAD-AI"
+
+    def test_anthropic_headers_set_user_agent(self):
+        """Anthropic requests send the same explicit User-Agent (PR #33
+        consistency): a proxied Anthropic-compatible endpoint has the same
+        denylisted-default gap as the OpenAI path.
+        """
+        client = _make_client("sk-abc123")
+        assert client._anthropic_headers()["User-Agent"] == "FreeCAD-AI"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -135,6 +135,25 @@ class TestAppConfig:
         assert c2.chat_dock_tabified_with == ["Tasks", "ModelView"]
         assert c2.chat_dock_mw_state == "aGVsbG8gd29ybGQ="
 
+    def test_keep_dock_on_workbench_switch_default(self):
+        """Opt-in feature (#34): the dock hides on workbench switch by default."""
+        assert AppConfig().keep_dock_on_workbench_switch is False
+
+    def test_keep_dock_on_workbench_switch_roundtrip(self):
+        """The keep-dock flag survives a JSON round-trip (#34/PR #35).
+
+        A brand-new defaulted bool needs no migration seeding: from_dict
+        falls back to the dataclass default when an older config JSON omits
+        the key, and preserves it when present.
+        """
+        c = AppConfig()
+        c.keep_dock_on_workbench_switch = True
+        c2 = AppConfig.from_dict(c.to_dict())
+        assert c2.keep_dock_on_workbench_switch is True
+        # An older config missing the key deserializes to the default.
+        legacy = AppConfig.from_dict({})
+        assert legacy.keep_dock_on_workbench_switch is False
+
     def test_rerank_params_default_empty(self):
         """The reranker has its own param namespace, empty by default."""
         c = AppConfig()

--- a/tests/unit/test_tool_routing.py
+++ b/tests/unit/test_tool_routing.py
@@ -1,0 +1,61 @@
+"""Regression guards for the #28 tool-routing steering.
+
+These are text-assertion guards, not behavioural tests: they lock in the
+prompt/description cues that steer the model toward `create_sketch` for
+"sketch on the selected face" instead of hand-rolling a raw
+`AttachmentSupport`/`MapMode` macro via `execute_code`/`run_macro`.
+
+They cannot prove the LLM routes correctly (that needs a live eval); they
+prevent the steering text from silently regressing.
+"""
+
+from freecad_ai.core.system_prompt import build_system_prompt
+from freecad_ai.tools.freecad_tools import CREATE_SKETCH, EXECUTE_CODE
+
+
+def _act_tools_prompt():
+    return build_system_prompt(mode="act", tools_enabled=True)
+
+
+class TestActModeSteering:
+    def test_has_sketch_on_face_routing_rule(self):
+        """Act-mode prompt explicitly routes face-sketching to create_sketch."""
+        prompt = _act_tools_prompt()
+        assert "create_sketch" in prompt
+        # The selected/named-face case must be called out with support+face.
+        lower = prompt.lower()
+        assert "selected" in lower and "face" in lower
+        assert "support" in prompt and "list_faces" in prompt
+
+    def test_warns_against_handwritten_attachment_macro(self):
+        """The prompt tells the model NOT to hand-write AttachmentSupport/MapMode."""
+        prompt = _act_tools_prompt()
+        assert "AttachmentSupport" in prompt
+        assert "MapMode" in prompt
+
+    def test_escape_hatches_marked_last_resort(self):
+        """execute_code/run_macro are framed as last resorts, not peers."""
+        prompt = _act_tools_prompt().lower()
+        assert "last resort" in prompt
+        assert "execute_code" in prompt and "run_macro" in prompt
+
+
+class TestCreateSketchDescription:
+    def test_face_capability_is_prominent(self):
+        """The face/support capability appears BEFORE the constraint/coordinate
+        boilerplate, not buried as the trailing sentence (the #28 root cause)."""
+        desc = CREATE_SKETCH.description
+        assert "list_faces" in desc and "support" in desc and "face" in desc
+        # Prominence guard: face attachment is introduced before COORDINATE SYSTEM.
+        assert desc.index("list_faces") < desc.index("COORDINATE SYSTEM")
+
+    def test_discourages_raw_attachment_macro(self):
+        desc = CREATE_SKETCH.description
+        assert "AttachmentSupport" in desc
+
+
+class TestExecuteCodeDescription:
+    def test_marked_last_resort_and_points_at_create_sketch(self):
+        desc = EXECUTE_CODE.description.lower()
+        assert "last-resort" in desc or "last resort" in desc
+        assert "create_sketch" in desc


### PR DESCRIPTION
Minor release bundling two community contributions from @3dyuval with a tool-routing steering improvement.

## What's included

- **#35 / #34 — Keep chat panel open across workbenches** (@3dyuval). Opt-in `keep_dock_on_workbench_switch` (off by default): the dock no longer hides when leaving the FreeCAD AI workbench. Settings checkbox + keybindable menu command.
- **#33 — User-Agent 403 fix** (@3dyuval). `urllib`'s default `Python-urllib/x.y` UA is rejected by some WAFs/proxies in front of self-hosted OpenAI-compatible gateways; requests now send `User-Agent: FreeCAD-AI`. Applied to **both** the OpenAI and Anthropic header builders (the Anthropic line is a maintainer consistency add-on).
- **#28 — Act-mode steering toward `create_sketch` for face attachment.** Steering-only (prompt + tool descriptions): routes "sketch on the selected face" to `create_sketch(support=…, face=…)` instead of a hand-rolled `AttachmentSupport`/`MapMode` macro. Cannot be proven without a live-model eval; guarded by text-assertion regression tests.

## Tests

- +4 regression guards for #33/#35 (header assertions for both providers; config round-trip incl. legacy key-absent path).
- +6 text-assertion guards for #28 steering (folded in from `fix/tool-routing-28`).
- **943 unit tests pass** (`test_document_attach.py` excluded — pre-existing Qt segfault on clean master).

## Release checklist

- [x] Version bumped in `package.xml` + `freecad_ai/__init__.py` (pyproject stays 0.1.0, untracked)
- [x] CHANGELOG entry
- [ ] Tag `v0.18.0-alpha` + GitHub release (Latest)
- [ ] Wiki Home banner bump
- [ ] Issue comments (#33/#35 shipped, close #34, note on #28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)