### PR TITLE
feat(skills): references/ tier-3 progressive disclosure (#37)

### DIFF
--- a/docs/superpowers/plans/2026-07-21-skill-references.md
+++ b/docs/superpowers/plans/2026-07-21-skill-references.md
@@ -1,0 +1,523 @@
+# Skill `references/` Resource Loading — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add tier-3 progressive disclosure to skills — a `references/` subdirectory whose markdown files the model loads on demand via `use_skill(name, resource=...)`.
+
+**Architecture:** Extend the existing skill loader to scan `references/` into a per-skill `{key -> absolute_path}` allowlist. Extend the `use_skill` tool with an optional `resource` argument that indexes that allowlist (the model passes a key, never a path — traversal is impossible by construction). When a skill with references is loaded, append an auto-generated "Available references" manifest to its `SKILL.md` result so the model knows what it can pull in and the exact call to do so.
+
+**Tech Stack:** Python 3.11, stdlib only (`os`, `dataclasses`). Tests via pytest, headless (no FreeCAD).
+
+**Design doc:** `docs/superpowers/specs/2026-07-21-skill-references-design.md`. Issue [#37](https://github.com/ghbalf/freecad-ai/issues/37).
+
+## Global Constraints
+
+- No external dependencies — stdlib only.
+- Fully backward-compatible: a skill with no `references/` directory must behave exactly as today (empty `references` dict, no manifest, no error).
+- Model input is **never** joined into a filesystem path. The `resource` argument is looked up as a key in a pre-scanned dict; unknown keys return an error.
+- Follow the repo test gotcha: run pytest as `env PYTHONPATH= .venv/bin/pytest ...` (a leaked `PYTHONPATH` shadows the venv's pluggy and crashes pytest).
+- `references/` scan is top-level files only (no recursion) — the Agent Skills spec recommends keeping references one level deep.
+- Text files read as UTF-8; undecodable/unreadable files are skipped at scan and error cleanly at read (same posture as the existing `SKILL.md` loader).
+
+---
+
+## File Structure
+
+- `freecad_ai/extensions/skills.py` — loader + registry. Add `Skill.references` field, scan logic in `_scan_skills_dir`, `get_skill_resource()` method, `render_references_manifest()` method, `_reference_summary()` module helper, and manifest append in `execute_skill()`.
+- `freecad_ai/tools/freecad_tools.py` — `_handle_use_skill` gains a `resource` branch; `USE_SKILL` gains a `resource` parameter and an updated description.
+- `tests/unit/test_skills.py` — all new tests (loader, resource resolution, traversal-safety, manifest).
+- `tests/unit/test_tool_routing.py` — one text-assertion guard for the `use_skill` description advertising the two-step read.
+
+---
+
+### Task 1: Loader scans `references/` into `Skill.references`
+
+**Files:**
+- Modify: `freecad_ai/extensions/skills.py` (`Skill` dataclass ~lines 27-36; `_scan_skills_dir` ~lines 57-109)
+- Test: `tests/unit/test_skills.py`
+
+**Interfaces:**
+- Produces: `Skill.references: dict[str, str]` mapping a normalized key (filename stem, lowercased) to the reference file's absolute path. Empty dict when the skill has no `references/` dir.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/test_skills.py`:
+
+```python
+class TestSkillReferences:
+    def _make_skill_with_refs(self, tmp_path, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        sd = skills_dir / "debug-model"
+        sd.mkdir()
+        (sd / "SKILL.md").write_text("# Debug Model\n\nDiagnose broken models.\n")
+        refs = sd / "references"
+        refs.mkdir()
+        (refs / "freecad-gotchas.md").write_text(
+            "# FreeCAD gotchas\n\ngetObjectsByLabel vs getObject, AttachmentSupport.\n"
+        )
+        (refs / "fix-attachment.md").write_text(
+            "# Fix attachment\n\nRe-attach a face or datum plane.\n"
+        )
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(tmp_path / "nonexistent"))
+        return skills_dir
+
+    def test_scans_reference_files_into_dict(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        skill = reg.get_skill("debug-model")
+        assert set(skill.references) == {"freecad-gotchas", "fix-attachment"}
+        assert skill.references["freecad-gotchas"].endswith(
+            os.path.join("references", "freecad-gotchas.md")
+        )
+
+    def test_skill_without_references_has_empty_dict(self, mock_skills_dir, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(mock_skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(mock_skills_dir))
+        reg = SkillsRegistry()
+        assert reg.get_skill("test-skill").references == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_skills.py::TestSkillReferences -v`
+Expected: FAIL — `Skill` has no attribute `references` (both tests error/fail).
+
+- [ ] **Step 3: Add the `references` field to the dataclass**
+
+In `freecad_ai/extensions/skills.py`, in the `Skill` dataclass, add after `validation_path`:
+
+```python
+    references: dict = field(default_factory=dict)  # key (lowercased stem) -> abspath
+```
+
+(`field` is already imported: `from dataclasses import dataclass, field`.)
+
+- [ ] **Step 4: Scan `references/` in `_scan_skills_dir`**
+
+In `_scan_skills_dir`, immediately before the `self._skills[entry] = Skill(...)` construction, add:
+
+```python
+            references = {}
+            refs_dir = os.path.join(skill_dir, "references")
+            if os.path.isdir(refs_dir):
+                for ref_entry in sorted(os.listdir(refs_dir)):
+                    ref_path = os.path.join(refs_dir, ref_entry)
+                    if not os.path.isfile(ref_path):
+                        continue
+                    key = os.path.splitext(ref_entry)[0].lower()
+                    references[key] = ref_path
+```
+
+Then add `references=references,` to the `Skill(...)` call.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_skills.py::TestSkillReferences -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add freecad_ai/extensions/skills.py tests/unit/test_skills.py
+git commit -m "feat(skills): scan references/ subdirectory into Skill.references"
+```
+
+---
+
+### Task 2: `get_skill_resource` resolves a key to file contents (traversal-safe)
+
+**Files:**
+- Modify: `freecad_ai/extensions/skills.py` (add method to `SkillsRegistry`)
+- Test: `tests/unit/test_skills.py`
+
+**Interfaces:**
+- Consumes: `Skill.references` from Task 1.
+- Produces: `SkillsRegistry.get_skill_resource(name: str, resource: str) -> dict` returning `{"output": <file contents>}` on success or `{"error": <message>}` on unknown skill / no references / unknown key / unreadable file. Accepts the key with or without an extension (`"foo"` or `"foo.md"`), case-insensitively.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TestSkillReferences` in `tests/unit/test_skills.py`:
+
+```python
+    def test_get_resource_returns_file_contents(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("debug-model", "freecad-gotchas")
+        assert "output" in result
+        assert "AttachmentSupport" in result["output"]
+
+    def test_get_resource_accepts_md_extension(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("debug-model", "fix-attachment.md")
+        assert "output" in result
+        assert "datum plane" in result["output"]
+
+    def test_get_resource_unknown_key_lists_available(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("debug-model", "nope")
+        assert "error" in result
+        assert "freecad-gotchas" in result["error"]
+        assert "fix-attachment" in result["error"]
+
+    def test_get_resource_skill_without_references(self, mock_skills_dir, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(mock_skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(mock_skills_dir))
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("test-skill", "anything")
+        assert "error" in result
+        assert "no references" in result["error"].lower()
+
+    def test_get_resource_unknown_skill(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("no-such-skill", "freecad-gotchas")
+        assert "error" in result
+
+    def test_get_resource_traversal_is_not_found(self, tmp_path, monkeypatch):
+        """Model input is a key, never a path — traversal keys just miss."""
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        for evil in ["../SKILL", "../../conftest", "/etc/passwd", "..\\SKILL"]:
+            result = reg.get_skill_resource("debug-model", evil)
+            assert "error" in result, f"{evil!r} should not resolve"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_skills.py::TestSkillReferences -v`
+Expected: the 6 new tests FAIL — `SkillsRegistry` has no attribute `get_skill_resource`.
+
+- [ ] **Step 3: Implement `get_skill_resource`**
+
+In `freecad_ai/extensions/skills.py`, add this method to `SkillsRegistry` (e.g. after `execute_skill`):
+
+```python
+    def get_skill_resource(self, name: str, resource: str) -> dict:
+        """Return the contents of a skill's reference file.
+
+        `resource` is a KEY into the pre-scanned Skill.references allowlist —
+        it is never treated as a filesystem path, so directory traversal is
+        impossible. The key may be given with or without an extension and is
+        matched case-insensitively.
+
+        Returns {"output": contents} or {"error": message}.
+        """
+        skill = self._skills.get(name)
+        if not skill:
+            return {"error": f"Unknown skill: {name}"}
+        if not skill.references:
+            return {"error": f"Skill '{name}' has no references."}
+
+        key = os.path.splitext(resource.strip())[0].lower()
+        path = skill.references.get(key)
+        if not path:
+            available = ", ".join(sorted(skill.references))
+            return {
+                "error": (
+                    f"Reference '{resource}' not found in skill '{name}'. "
+                    f"Available: {available}"
+                )
+            }
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return {"output": f.read()}
+        except (OSError, UnicodeDecodeError) as e:
+            return {"error": f"Could not read reference '{resource}': {e}"}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_skills.py::TestSkillReferences -v`
+Expected: PASS (all TestSkillReferences tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add freecad_ai/extensions/skills.py tests/unit/test_skills.py
+git commit -m "feat(skills): add get_skill_resource with allowlist-key lookup"
+```
+
+---
+
+### Task 3: Append an "Available references" manifest to the `use_skill` result
+
+**Files:**
+- Modify: `freecad_ai/extensions/skills.py` (add `_reference_summary` module helper, `render_references_manifest` method, append in `execute_skill`)
+- Test: `tests/unit/test_skills.py`
+
+**Interfaces:**
+- Consumes: `Skill.references` (Task 1).
+- Produces: `SkillsRegistry.render_references_manifest(skill: Skill) -> str` — returns a markdown block (leading with two newlines) listing each reference key, a one-line summary, and the exact `use_skill(..., resource=...)` call; returns `""` when the skill has no references. `execute_skill` appends this to the `inject_prompt` content on the SKILL.md path only.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `TestSkillReferences`:
+
+```python
+    def test_execute_skill_appends_references_manifest(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.execute_skill("debug-model")
+        content = result["inject_prompt"]
+        assert "Diagnose broken models." in content            # original SKILL.md
+        assert "Available references" in content                # manifest heading
+        assert "freecad-gotchas" in content and "fix-attachment" in content
+        # advertises the exact invocation syntax
+        assert "resource='freecad-gotchas'" in content
+        # includes a one-line summary drawn from the file
+        assert "getObjectsByLabel" in content
+
+    def test_execute_skill_no_manifest_without_references(self, mock_skills_dir, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(mock_skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(mock_skills_dir))
+        reg = SkillsRegistry()
+        result = reg.execute_skill("test-skill")
+        assert "Available references" not in result["inject_prompt"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_skills.py::TestSkillReferences::test_execute_skill_appends_references_manifest tests/unit/test_skills.py::TestSkillReferences::test_execute_skill_no_manifest_without_references -v`
+Expected: the append test FAILS ("Available references" not in content); the no-manifest test PASSES already.
+
+- [ ] **Step 3: Add the summary helper and manifest renderer**
+
+In `freecad_ai/extensions/skills.py`, add a module-level helper near `_file_hash`:
+
+```python
+def _reference_summary(path: str) -> str:
+    """First non-empty content line of a reference file, heading marks stripped."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip().lstrip("#").strip()
+                if line:
+                    return line[:100]
+    except (OSError, UnicodeDecodeError):
+        pass
+    return ""
+```
+
+Add this method to `SkillsRegistry`:
+
+```python
+    def render_references_manifest(self, skill: Skill) -> str:
+        """Markdown block advertising a skill's on-demand reference files."""
+        if not skill.references:
+            return ""
+        lines = [
+            "\n\n## Available references",
+            f"Load one when needed with "
+            f"use_skill(name='{skill.name}', resource='<key>'):",
+        ]
+        for key in sorted(skill.references):
+            summary = _reference_summary(skill.references[key])
+            bullet = f"- `{key}` (resource='{key}')"
+            if summary:
+                bullet += f" — {summary}"
+            lines.append(bullet)
+        return "\n".join(lines)
+```
+
+- [ ] **Step 4: Append the manifest in `execute_skill`**
+
+In `execute_skill`, replace the final return:
+
+```python
+        # Default: inject SKILL.md content into the prompt
+        return {"inject_prompt": skill.content}
+```
+
+with:
+
+```python
+        # Default: inject SKILL.md content into the prompt, plus a manifest of
+        # any on-demand reference files the skill bundles (tier-3 disclosure).
+        content = skill.content + self.render_references_manifest(skill)
+        return {"inject_prompt": content}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_skills.py::TestSkillReferences -v`
+Expected: PASS (all green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add freecad_ai/extensions/skills.py tests/unit/test_skills.py
+git commit -m "feat(skills): advertise references via an auto-generated manifest"
+```
+
+---
+
+### Task 4: `use_skill` tool gains a `resource` parameter
+
+**Files:**
+- Modify: `freecad_ai/tools/freecad_tools.py` (`_handle_use_skill` ~lines 5305-5347; `USE_SKILL` ~lines 5350-5367)
+- Test: `tests/unit/test_skills.py` (end-to-end through the handler), `tests/unit/test_tool_routing.py` (description guard)
+
+**Interfaces:**
+- Consumes: `SkillsRegistry.get_skill_resource` (Task 2).
+- Produces: `use_skill(name, args="", resource="")` — when `resource` is non-empty, returns the reference file contents (or an error `ToolResult`); when empty, unchanged behavior (loads `SKILL.md` + manifest).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/test_skills.py` (imports the handler directly):
+
+```python
+class TestUseSkillResource:
+    def _refs_skill(self, tmp_path, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        sd = skills_dir / "debug-model"
+        sd.mkdir()
+        (sd / "SKILL.md").write_text("# Debug Model\n\nDiagnose broken models.\n")
+        refs = sd / "references"
+        refs.mkdir()
+        (refs / "freecad-gotchas.md").write_text("# Gotchas\n\nAttachmentSupport not Support.\n")
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(tmp_path / "none"))
+
+    def test_use_skill_resource_returns_file(self, tmp_path, monkeypatch):
+        from freecad_ai.tools.freecad_tools import _handle_use_skill
+        self._refs_skill(tmp_path, monkeypatch)
+        result = _handle_use_skill("debug-model", resource="freecad-gotchas")
+        assert result.success is True
+        assert "AttachmentSupport" in result.output
+
+    def test_use_skill_resource_unknown_errors(self, tmp_path, monkeypatch):
+        from freecad_ai.tools.freecad_tools import _handle_use_skill
+        self._refs_skill(tmp_path, monkeypatch)
+        result = _handle_use_skill("debug-model", resource="missing")
+        assert result.success is False
+        assert "freecad-gotchas" in result.error
+
+    def test_use_skill_without_resource_still_loads_skill(self, tmp_path, monkeypatch):
+        from freecad_ai.tools.freecad_tools import _handle_use_skill
+        self._refs_skill(tmp_path, monkeypatch)
+        result = _handle_use_skill("debug-model")
+        assert result.success is True
+        assert "Diagnose broken models." in result.output
+```
+
+Add to `tests/unit/test_tool_routing.py` (import `USE_SKILL`):
+
+```python
+class TestUseSkillDescription:
+    def test_advertises_resource_two_step(self):
+        from freecad_ai.tools.freecad_tools import USE_SKILL
+        desc = USE_SKILL.description.lower()
+        assert "resource" in desc
+        assert "reference" in desc
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_skills.py::TestUseSkillResource tests/unit/test_tool_routing.py::TestUseSkillDescription -v`
+Expected: FAIL — `_handle_use_skill` takes no `resource` kwarg; description lacks "resource".
+
+- [ ] **Step 3: Add the `resource` branch to the handler**
+
+In `freecad_ai/tools/freecad_tools.py`, change the `_handle_use_skill` signature and add the branch right after the registry is built:
+
+```python
+def _handle_use_skill(name: str, args: str = "", resource: str = "") -> ToolResult:
+    """Load a skill's instructions (or one of its reference files) for the model.
+
+    With `resource` set, returns the contents of that reference file (tier-3
+    progressive disclosure). Otherwise returns SKILL.md plus a manifest of any
+    references the skill bundles.
+    """
+    from ..extensions.skills import SkillsRegistry
+    registry = SkillsRegistry()
+
+    if resource:
+        res = registry.get_skill_resource(name, resource)
+        if "error" in res:
+            return ToolResult(success=False, output="", error=res["error"])
+        return ToolResult(success=True, output=res["output"])
+
+    result = registry.execute_skill(name, args)
+    # ... existing body unchanged ...
+```
+
+(Leave the rest of the existing function body exactly as-is below the new branch.)
+
+- [ ] **Step 4: Add the `resource` parameter and update the description**
+
+Replace the `USE_SKILL` definition's `description` and `parameters`:
+
+```python
+USE_SKILL = ToolDefinition(
+    name="use_skill",
+    description=(
+        "Load a skill's detailed instructions for a complex task. "
+        "Skills provide step-by-step construction guides (e.g. enclosure, gear). "
+        "Call this when the user's request matches a skill, then follow the "
+        "returned instructions using your tools. If the skill lists 'Available "
+        "references', pull one into context on demand by calling use_skill again "
+        "with the same name and the reference's `resource` key."
+    ),
+    parameters=[
+        ToolParam("name", "string",
+                  "Skill name (e.g. 'enclosure', 'gear', 'fastener-hole')"),
+        ToolParam("args", "string",
+                  "User's parameters for the skill (e.g. '120x80x60mm, screw lid')",
+                  required=False, default=""),
+        ToolParam("resource", "string",
+                  "Optional reference key from the skill's 'Available references' "
+                  "list, to load that reference file instead of the skill itself",
+                  required=False, default=""),
+    ],
+    handler=_handle_use_skill,
+    category="query",
+)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_skills.py::TestUseSkillResource tests/unit/test_tool_routing.py::TestUseSkillDescription -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full unit suite (regression)**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q`
+Expected: all green (baseline 946 + new tests). `test_document_attach.py` is excluded because it Qt-segfaults on clean master.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add freecad_ai/tools/freecad_tools.py tests/unit/test_skills.py tests/unit/test_tool_routing.py
+git commit -m "feat(skills): use_skill resource param loads reference files (closes #37)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Tier-3 `references/` loading → Tasks 1–4. ✓
+- Extend `use_skill` (not a new tool) → Task 4. ✓
+- Auto-generated manifest with exact invocation syntax → Task 3 (`render_references_manifest`, asserted in test). ✓
+- Security-by-construction (key lookup, no path handling) → Task 2 (`get_skill_resource`) + traversal test. ✓
+- Unknown-key error lists available → Task 2. ✓
+- Top-level scan only → Task 1 (`os.listdir`, `isfile` filter, no recursion). ✓
+- Backward compatibility (no references → unchanged) → Task 1 empty-dict test + Task 3 no-manifest test. ✓
+- All headless-unit-testable → every task's tests avoid FreeCAD. ✓
+- `scripts/`/`assets/`/nesting out of scope → not implemented. ✓
+
+**Placeholder scan:** none — every code and test step shows complete content.
+
+**Type consistency:** `Skill.references: dict[str,str]` (Task 1) is consumed unchanged by `get_skill_resource` (Task 2), `render_references_manifest` (Task 3), and via the handler in Task 4. `get_skill_resource` returns `{"output"|"error"}` (Task 2), consumed as such by the handler (Task 4). `render_references_manifest(skill)` name/signature consistent between Task 3 definition and its call in `execute_skill`. Handler signature `_handle_use_skill(name, args="", resource="")` matches the `USE_SKILL` parameter list.
+
+**Note on commits:** the per-task commit steps follow the repo's TDD convention; run them during execution, when the maintainer has authorized committing.

--- a/docs/superpowers/specs/2026-07-21-skill-references-design.md
+++ b/docs/superpowers/specs/2026-07-21-skill-references-design.md
@@ -1,0 +1,215 @@
+# Design: skill `references/` resource loading (progressive disclosure, tier 3)
+
+- **Date:** 2026-07-21
+- **Status:** Approved design, pending implementation plan
+- **Issue:** [#37](https://github.com/ghbalf/freecad-ai/issues/37) (@3dyuval)
+- **Scope:** `references/` subdirectory only. `scripts/` is **explicitly out of
+  scope** for v1 — see "Why not `scripts/` (yet)".
+- **Base:** branch `feature/skill-references` off `master`. Self-contained; no
+  dependency on the #38/#39 fixes.
+
+## Background
+
+Skills today have exactly two tiers of context loading, and no third:
+
+1. **Tier 1 — metadata.** `SkillsRegistry.get_descriptions()`
+   (`freecad_ai/extensions/skills.py:127`) injects every skill's name +
+   description into the system prompt. Always present, cheap.
+2. **Tier 2 — instructions.** `use_skill` (`freecad_tools.py:5350`) returns the
+   whole `SKILL.md` as a tool result via `execute_skill` →
+   `{"inject_prompt": skill.content}` (`skills.py:183`). Loaded on demand when
+   the skill is invoked.
+
+The [Agent Skills specification](https://agentskills.io/specification) and
+[Claude's own Skills docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+define a **third tier**: bundled resource files (`references/`, `scripts/`,
+`assets/`) loaded only when a task actually needs them, at *zero* context cost
+until read. This workbench implements tiers 1 and 2 but not tier 3, so there is
+no way to keep `SKILL.md` lean while shipping deep reference material — the exact
+gap #37 describes.
+
+**Why this matters more here than in a general agent:** issue #10 showed this
+workbench already hits hard per-request context caps on some providers (GitHub
+Models), which is why the tool reranker exists. A fat `SKILL.md` competes for
+that same scarce budget on every invocation. Tier-3 references let a skill carry
+extensive gotcha docs / fix procedures that cost nothing until the model chooses
+to read one.
+
+### The mechanism mismatch we have to design around
+
+In every reference harness, tier 3 works because **the agent has a filesystem
+and bash** and simply reads/runs the files (`cat references/FORMS.md`,
+`python scripts/fill_form.py`). There is *no dedicated resource-loading API* —
+the general-purpose Read/Bash tools are the mechanism.
+
+This workbench **deliberately does not give the model a filesystem or bash
+tool.** It exposes a curated ~50 domain tools, `use_skill`, and a sandboxed
+last-resort `execute_code`. So the mechanism that makes tier 3 "free" elsewhere
+does not exist here — we must synthesize a narrow equivalent.
+
+## Approach
+
+Extend the existing `use_skill` tool with an optional `resource` argument, rather
+than adding a new tool.
+
+- **Why extend, not add:** a new tool schema competes for the per-request budget
+  that #10 already showed is scarce on some providers. Extending `use_skill`
+  costs one parameter, and the model already reaches for `use_skill`.
+- **Alternative considered — a dedicated `read_skill_file` tool.** Closer to how
+  real harnesses model it, but adds tool surface and (if it took a path) a
+  traversal boundary to police. Rejected on budget + safety grounds.
+
+### Flow
+
+1. `use_skill("debug-model")` → returns `SKILL.md` **plus an auto-generated
+   "Available references" block** enumerating each reference file, a one-line
+   summary, and the exact call to load it.
+2. `use_skill("debug-model", resource="freecad-gotchas")` → returns the contents
+   of `references/freecad-gotchas.md` as the tool result.
+
+The auto-generated manifest is important: because the model can't list a
+directory itself, the loader advertises the available references explicitly, with
+the precise invocation syntax, so the model never has to guess a filename.
+
+### Security by construction (no path handling of model input)
+
+The loader scans `references/` **once** at registry-build time into a dict
+`Skill.references: {key -> absolute_path}`. At load time the model passes a
+**key**, which we look up in that dict. **Model input is never joined into a
+filesystem path**, so `../` traversal, absolute paths, and symlink escapes are
+structurally impossible — the model can only name a key that was pre-scanned from
+inside the skill's own `references/` directory. An unknown key returns an error
+listing the valid keys (mirroring the existing fuzzy skill-not-found UX in
+`_handle_use_skill`).
+
+This is a stronger guarantee than "validate the path" — there is no path to
+validate.
+
+### Trust boundary (why references are safe additively)
+
+A reference file's contents are injected into the model's context, exactly like
+`SKILL.md` already is. It is the **same trust boundary as tier 2** — the user
+installed the skill; its markdown was already going to be trusted. `references/`
+adds *more of the same kind of content*, not a new kind of capability. This is
+the key contrast with `scripts/` (below), which would add an *execution* surface.
+
+## Components
+
+All changes are in `freecad_ai/extensions/skills.py` and the `use_skill` tool in
+`freecad_ai/tools/freecad_tools.py`. No change to the agentic loop, config, or
+system prompt.
+
+1. **`Skill` dataclass** — add `references: dict = field(default_factory=dict)`
+   mapping a normalized key → absolute file path.
+
+2. **`SkillsRegistry._scan_skills_dir`** — after locating `SKILL.md`, scan a
+   sibling `references/` directory (top level only). For each readable file,
+   compute a key (the filename stem, lowercased) and store `key -> abspath`.
+   Extract a one-line summary per file (first heading or first non-empty line —
+   reuse the existing description-extraction logic) for the manifest. Undecodable
+   files are skipped, matching the existing `SKILL.md` read behavior.
+
+3. **`SkillsRegistry.get_skill_resource(name, key) -> dict`** — new method:
+   look up the key in `skill.references`; on hit read the file (UTF-8) and return
+   `{"output": content}`; on miss return
+   `{"error": "..."}` listing available keys. Never touches model-supplied paths.
+
+4. **References manifest helper** — render an "Available references" markdown
+   block from `skill.references` + summaries, appended to the `inject_prompt`
+   content in `execute_skill`/`_handle_use_skill` when the skill has any
+   references. Absent entirely when it has none (no behavior change for existing
+   skills).
+
+5. **`use_skill` tool** — add an optional `resource` string parameter. When
+   present, the handler routes to `get_skill_resource` instead of loading
+   `SKILL.md`. Description updated to explain the two-step read pattern.
+
+## Data flow
+
+```
+model: use_skill(name="debug-model")
+  -> _handle_use_skill -> execute_skill -> inject_prompt = SKILL.md
+     + "\n\n## Available references\n- freecad-gotchas — getObjectsByLabel,
+        AttachmentSupport, isNull... (load: use_skill name='debug-model'
+        resource='freecad-gotchas'))\n- fix-attachment — ..."
+  <- tool result
+
+model: use_skill(name="debug-model", resource="freecad-gotchas")
+  -> _handle_use_skill (resource branch) -> get_skill_resource("debug-model",
+        "freecad-gotchas") -> read references/freecad-gotchas.md
+  <- tool result = file contents
+```
+
+## Error handling
+
+- **Unknown resource key** → `ToolResult(success=False, error="Reference
+  'X' not found in skill 'debug-model'. Available: freecad-gotchas,
+  fix-attachment")`. Same shape/spirit as the existing unknown-skill error.
+- **`resource` given for a skill with no `references/`** → error stating the
+  skill has no references.
+- **Undecodable / unreadable file at read time** → error; such files are also
+  omitted from the manifest so this should be unreachable in practice.
+- **Skill not found** with a `resource` set → the existing fuzzy-match path runs
+  first (unchanged); resource resolution only happens once a skill is resolved.
+
+## Backward compatibility
+
+Fully additive. Skills without a `references/` directory get an empty
+`references` dict, no manifest block, and behave exactly as today. No config
+field, no migration, no system-prompt change.
+
+## Testing (all headless-unit-testable, no FreeCAD needed)
+
+New tests in `tests/unit/test_skills.py`:
+
+1. Loader discovers files in `references/` and populates `Skill.references`.
+2. A skill with no `references/` dir has an empty `references` dict (regression /
+   backward-compat guard).
+3. `get_skill_resource` returns file contents for a valid key.
+4. `get_skill_resource` with an unknown key returns an error listing valid keys.
+5. **Traversal is impossible:** a key like `"../SKILL"` or `"../../secret"` is
+   simply "not found" (proves model input never reaches the filesystem as a path).
+6. The "Available references" manifest is appended to the `use_skill` result when
+   references exist, and *absent* when they don't.
+7. `use_skill(resource=...)` routes through the tool handler and returns the file
+   contents (end-to-end through `_handle_use_skill`).
+8. Manifest advertises the exact invocation syntax (a text-assertion guard, like
+   the #28 routing guards, so the steering can't silently regress).
+
+Follow TDD: each behavior gets a failing test first.
+
+## Why not `scripts/` (yet)
+
+`references/` is a **read** feature; `scripts/` is an **execute** feature, and
+that difference collides with the workbench's deliberately-controlled execution
+model (Plan/Dangerous mode, the #14/#18 sandbox validator, `execute_code` framed
+last-resort). Concretely:
+
+- **No invocation path exists.** With no bash/filesystem tool, `scripts/` is
+  inert unless we add a tool that lets the *model* run a skill's script file —
+  i.e. move the trust boundary from "harness invokes one fixed entrypoint" to
+  "model chooses which of N files to execute."
+- **It forces a trust decision with no free answer.** A skill script run
+  in-process like `handler.py` (`skills.py:185`, `importlib.exec_module`, no
+  sandbox, full FreeCAD access) would **bypass every safety layer** the sandbox
+  work built — now triggered by the model. Run through the `execute_code`
+  sandbox instead and `scripts/` becomes *almost exactly `execute_code` with a
+  file as its source* — largely duplicating an existing tool.
+- **`handler.py` already occupies this niche**, narrowly: one `execute(args)`
+  entrypoint, harness-invoked, not model-chosen. `scripts/` widens that to N
+  model-invokable entrypoints, dragging in per-script interface contracts,
+  Dangerous-mode consistency questions, and a larger segfault blast radius
+  (in-process scripts share the FreeCAD process).
+
+So `scripts/` is not a folder — it is an execution-model change. It should be its
+own scoped proposal *if and when* a concrete need appears that `handler.py`
+cannot serve, and ideally with a proposed answer to the trust question above.
+`references/` delivers the progressive-disclosure value #37 actually argues for,
+at zero new execution surface.
+
+## Out of scope for v1
+
+- `scripts/` and `assets/` subdirectories.
+- Recursive/nested reference directories (spec recommends keeping references one
+  level deep; v1 scans top-level files only).
+- Any UI surface for browsing references (they are a model-facing mechanism).

--- a/freecad_ai/extensions/skills.py
+++ b/freecad_ai/extensions/skills.py
@@ -197,6 +197,38 @@ class SkillsRegistry:
         # Default: inject SKILL.md content into the prompt
         return {"inject_prompt": skill.content}
 
+    def get_skill_resource(self, name: str, resource: str) -> dict:
+        """Return the contents of a skill's reference file.
+
+        `resource` is a KEY into the pre-scanned Skill.references allowlist —
+        it is never treated as a filesystem path, so directory traversal is
+        impossible. The key may be given with or without an extension and is
+        matched case-insensitively.
+
+        Returns {"output": contents} or {"error": message}.
+        """
+        skill = self._skills.get(name)
+        if not skill:
+            return {"error": f"Unknown skill: {name}"}
+        if not skill.references:
+            return {"error": f"Skill '{name}' has no references."}
+
+        key = os.path.splitext(resource.strip())[0].lower()
+        path = skill.references.get(key)
+        if not path:
+            available = ", ".join(sorted(skill.references))
+            return {
+                "error": (
+                    f"Reference '{resource}' not found in skill '{name}'. "
+                    f"Available: {available}"
+                )
+            }
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return {"output": f.read()}
+        except (OSError, UnicodeDecodeError) as e:
+            return {"error": f"Could not read reference '{resource}': {e}"}
+
     def _run_handler(self, skill: Skill, args: str) -> dict | None:
         """Try to load and run a skill's handler.py.
 

--- a/freecad_ai/extensions/skills.py
+++ b/freecad_ai/extensions/skills.py
@@ -194,8 +194,27 @@ class SkillsRegistry:
             if handler_result is not None:
                 return handler_result
 
-        # Default: inject SKILL.md content into the prompt
-        return {"inject_prompt": skill.content}
+        # Default: inject SKILL.md content into the prompt, plus a manifest of
+        # any on-demand reference files the skill bundles (tier-3 disclosure).
+        content = skill.content + self.render_references_manifest(skill)
+        return {"inject_prompt": content}
+
+    def render_references_manifest(self, skill: Skill) -> str:
+        """Markdown block advertising a skill's on-demand reference files."""
+        if not skill.references:
+            return ""
+        lines = [
+            "\n\n## Available references",
+            f"Load one when needed with "
+            f"use_skill(name='{skill.name}', resource='<key>'):",
+        ]
+        for key in sorted(skill.references):
+            summary = _reference_summary(skill.references[key])
+            bullet = f"- `{key}` (resource='{key}')"
+            if summary:
+                bullet += f" — {summary}"
+            lines.append(bullet)
+        return "\n".join(lines)
 
     def get_skill_resource(self, name: str, resource: str) -> dict:
         """Return the contents of a skill's reference file.
@@ -349,6 +368,30 @@ class SkillsRegistry:
             shutil.rmtree(user_skill_dir)
             return True
         return False
+
+
+def _reference_summary(path: str) -> str:
+    """One-line summary of a reference file for the manifest.
+
+    Prefer the first non-empty, non-heading line (matching how skill
+    descriptions are extracted in _scan_skills_dir); fall back to the first
+    heading's text if the file is heading-only.
+    """
+    heading = ""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if stripped.startswith("#"):
+                    if not heading:
+                        heading = stripped.lstrip("#").strip()
+                    continue
+                return stripped[:100]
+    except (OSError, UnicodeDecodeError):
+        pass
+    return heading[:100]
 
 
 def _file_hash(path: str) -> str:

--- a/freecad_ai/extensions/skills.py
+++ b/freecad_ai/extensions/skills.py
@@ -34,6 +34,7 @@ class Skill:
     trigger: str = ""  # Slash command, e.g. "/thread-insert"
     has_handler: bool = False
     validation_path: str = ""
+    references: dict = field(default_factory=dict)  # key (lowercased stem) -> abspath
 
 
 class SkillsRegistry:
@@ -98,6 +99,19 @@ class SkillsRegistry:
             if os.path.isfile(val_file):
                 validation_path = val_file
 
+            # Tier-3 progressive disclosure: scan a sibling references/ dir
+            # (top level only) into a {key -> abspath} allowlist. The model
+            # later names a key, never a path, so traversal is impossible.
+            references = {}
+            refs_dir = os.path.join(skill_dir, "references")
+            if os.path.isdir(refs_dir):
+                for ref_entry in sorted(os.listdir(refs_dir)):
+                    ref_path = os.path.join(refs_dir, ref_entry)
+                    if not os.path.isfile(ref_path):
+                        continue
+                    key = os.path.splitext(ref_entry)[0].lower()
+                    references[key] = ref_path
+
             self._skills[entry] = Skill(
                 name=entry,
                 description=description,
@@ -106,6 +120,7 @@ class SkillsRegistry:
                 trigger=f"/{entry}",
                 has_handler=os.path.isfile(handler_path),
                 validation_path=validation_path,
+                references=references,
             )
 
     def register(self, name: str, content: str, trigger: str = ""):

--- a/freecad_ai/llm/providers.py
+++ b/freecad_ai/llm/providers.py
@@ -148,7 +148,14 @@ PROVIDERS = {
         "base_url": "",
         "default_model": "",
         "api_style": "openai",
-        "supports_tools": False,
+        # Custom endpoints are OpenAI-compatible and there is no per-model
+        # tool probe for them (the /api/show capability check is Ollama-only),
+        # so this static flag is the sole source of truth. Default True: most
+        # custom servers (vLLM, llama.cpp --jinja, SGLang) support tool calling,
+        # and a False default silently strips the tools array from every
+        # request (issue #38). A genuinely tool-less endpoint opts out via
+        # tools_detected=false in config.json.
+        "supports_tools": True,
     },
 }
 

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -5302,16 +5302,24 @@ REPORT_SKILL_PARAMS = ToolDefinition(
 
 # ── use_skill ──────────────────────────────────────────────
 
-def _handle_use_skill(name: str, args: str = "") -> ToolResult:
-    """Load a skill's instructions and return them for the model to follow.
+def _handle_use_skill(name: str, args: str = "", resource: str = "") -> ToolResult:
+    """Load a skill's instructions (or one of its reference files) for the model.
 
-    The skill content (SKILL.md) is returned as the tool result. The model
-    should read these instructions and follow them step by step using its
-    available tools.  If the exact name isn't found, a fuzzy search on skill
-    names and descriptions is attempted.
+    With `resource` set, returns the contents of that reference file (tier-3
+    progressive disclosure — the key indexes a pre-scanned allowlist, never a
+    filesystem path). Otherwise returns SKILL.md plus a manifest of any
+    references the skill bundles. If the exact name isn't found, a fuzzy search
+    on skill names and descriptions is attempted.
     """
     from ..extensions.skills import SkillsRegistry
     registry = SkillsRegistry()
+
+    if resource:
+        res = registry.get_skill_resource(name, resource)
+        if "error" in res:
+            return ToolResult(success=False, output="", error=res["error"])
+        return ToolResult(success=True, output=res["output"])
+
     result = registry.execute_skill(name, args)
 
     if "error" in result:
@@ -5353,13 +5361,19 @@ USE_SKILL = ToolDefinition(
         "Load a skill's detailed instructions for a complex task. "
         "Skills provide step-by-step construction guides (e.g. enclosure, gear). "
         "Call this when the user's request matches a skill, then follow the "
-        "returned instructions using your tools."
+        "returned instructions using your tools. If the skill lists 'Available "
+        "references', pull one into context on demand by calling use_skill again "
+        "with the same name and the reference's `resource` key."
     ),
     parameters=[
         ToolParam("name", "string",
                   "Skill name (e.g. 'enclosure', 'gear', 'fastener-hole')"),
         ToolParam("args", "string",
                   "User's parameters for the skill (e.g. '120x80x60mm, screw lid')",
+                  required=False, default=""),
+        ToolParam("resource", "string",
+                  "Optional reference key from the skill's 'Available references' "
+                  "list, to load that reference file instead of the skill itself",
                   required=False, default=""),
     ],
     handler=_handle_use_skill,

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -3545,7 +3545,7 @@ def _handle_execute_code(code: str) -> ToolResult:
 
 EXECUTE_CODE = ToolDefinition(
     name="execute_code",
-    description="Execute arbitrary Python code in FreeCAD's interpreter. LAST-RESORT fallback for operations no structured tool covers — check the tool list first. Do NOT use it to re-implement a covered operation (e.g. attaching a sketch to a face is `create_sketch`, not a hand-written AttachmentSupport macro). The code has access to FreeCAD, Part, PartDesign, Sketcher, Draft modules.",
+    description="Execute arbitrary Python code in FreeCAD's interpreter. LAST-RESORT fallback for operations no structured tool covers — check the tool list first. Do NOT use it to re-implement a covered operation (e.g. attaching a sketch to a face is `create_sketch`, not a hand-written AttachmentSupport macro). The code has access to FreeCAD, Part, PartDesign, Sketcher, Draft modules. Each call runs in a fresh namespace — variables, imports, and objects do NOT persist between calls, so make every call fully self-contained (re-fetch objects with getObject/getObjectsByLabel each time; a NameError means you referenced a name from an earlier call, not that your query was wrong).",
     category="general",
     parameters=[
         ToolParam("code", "string", "Python code to execute"),

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -239,3 +239,40 @@ class TestGetDescriptions:
 
         reg = SkillsRegistry()
         assert reg.get_descriptions() == ""
+
+
+class TestSkillReferences:
+    def _make_skill_with_refs(self, tmp_path, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        sd = skills_dir / "debug-model"
+        sd.mkdir()
+        (sd / "SKILL.md").write_text("# Debug Model\n\nDiagnose broken models.\n")
+        refs = sd / "references"
+        refs.mkdir()
+        (refs / "freecad-gotchas.md").write_text(
+            "# FreeCAD gotchas\n\ngetObjectsByLabel vs getObject, AttachmentSupport.\n"
+        )
+        (refs / "fix-attachment.md").write_text(
+            "# Fix attachment\n\nRe-attach a face or datum plane.\n"
+        )
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(tmp_path / "nonexistent"))
+        return skills_dir
+
+    def test_scans_reference_files_into_dict(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        skill = reg.get_skill("debug-model")
+        assert set(skill.references) == {"freecad-gotchas", "fix-attachment"}
+        assert skill.references["freecad-gotchas"].endswith(
+            os.path.join("references", "freecad-gotchas.md")
+        )
+
+    def test_skill_without_references_has_empty_dict(self, mock_skills_dir, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(mock_skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(mock_skills_dir))
+        reg = SkillsRegistry()
+        assert reg.get_skill("test-skill").references == {}

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -321,3 +321,24 @@ class TestSkillReferences:
         for evil in ["../SKILL", "../../conftest", "/etc/passwd", "..\\SKILL"]:
             result = reg.get_skill_resource("debug-model", evil)
             assert "error" in result, f"{evil!r} should not resolve"
+
+    def test_execute_skill_appends_references_manifest(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.execute_skill("debug-model")
+        content = result["inject_prompt"]
+        assert "Diagnose broken models." in content            # original SKILL.md
+        assert "Available references" in content                # manifest heading
+        assert "freecad-gotchas" in content and "fix-attachment" in content
+        # advertises the exact invocation syntax
+        assert "resource='freecad-gotchas'" in content
+        # includes a one-line summary drawn from the file
+        assert "getObjectsByLabel" in content
+
+    def test_execute_skill_no_manifest_without_references(self, mock_skills_dir, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(mock_skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(mock_skills_dir))
+        reg = SkillsRegistry()
+        result = reg.execute_skill("test-skill")
+        assert "Available references" not in result["inject_prompt"]

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -342,3 +342,39 @@ class TestSkillReferences:
         reg = SkillsRegistry()
         result = reg.execute_skill("test-skill")
         assert "Available references" not in result["inject_prompt"]
+
+
+class TestUseSkillResource:
+    def _refs_skill(self, tmp_path, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        sd = skills_dir / "debug-model"
+        sd.mkdir()
+        (sd / "SKILL.md").write_text("# Debug Model\n\nDiagnose broken models.\n")
+        refs = sd / "references"
+        refs.mkdir()
+        (refs / "freecad-gotchas.md").write_text("# Gotchas\n\nAttachmentSupport not Support.\n")
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(tmp_path / "none"))
+
+    def test_use_skill_resource_returns_file(self, tmp_path, monkeypatch):
+        from freecad_ai.tools.freecad_tools import _handle_use_skill
+        self._refs_skill(tmp_path, monkeypatch)
+        result = _handle_use_skill("debug-model", resource="freecad-gotchas")
+        assert result.success is True
+        assert "AttachmentSupport" in result.output
+
+    def test_use_skill_resource_unknown_errors(self, tmp_path, monkeypatch):
+        from freecad_ai.tools.freecad_tools import _handle_use_skill
+        self._refs_skill(tmp_path, monkeypatch)
+        result = _handle_use_skill("debug-model", resource="missing")
+        assert result.success is False
+        assert "freecad-gotchas" in result.error
+
+    def test_use_skill_without_resource_still_loads_skill(self, tmp_path, monkeypatch):
+        from freecad_ai.tools.freecad_tools import _handle_use_skill
+        self._refs_skill(tmp_path, monkeypatch)
+        result = _handle_use_skill("debug-model")
+        assert result.success is True
+        assert "Diagnose broken models." in result.output

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -276,3 +276,48 @@ class TestSkillReferences:
         monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(mock_skills_dir))
         reg = SkillsRegistry()
         assert reg.get_skill("test-skill").references == {}
+
+    def test_get_resource_returns_file_contents(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("debug-model", "freecad-gotchas")
+        assert "output" in result
+        assert "AttachmentSupport" in result["output"]
+
+    def test_get_resource_accepts_md_extension(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("debug-model", "fix-attachment.md")
+        assert "output" in result
+        assert "datum plane" in result["output"]
+
+    def test_get_resource_unknown_key_lists_available(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("debug-model", "nope")
+        assert "error" in result
+        assert "freecad-gotchas" in result["error"]
+        assert "fix-attachment" in result["error"]
+
+    def test_get_resource_skill_without_references(self, mock_skills_dir, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(mock_skills_dir))
+        monkeypatch.setattr(skills_mod, "BUILTIN_SKILLS_DIR", str(mock_skills_dir))
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("test-skill", "anything")
+        assert "error" in result
+        assert "no references" in result["error"].lower()
+
+    def test_get_resource_unknown_skill(self, tmp_path, monkeypatch):
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        result = reg.get_skill_resource("no-such-skill", "freecad-gotchas")
+        assert "error" in result
+
+    def test_get_resource_traversal_is_not_found(self, tmp_path, monkeypatch):
+        """Model input is a key, never a path — traversal keys just miss."""
+        self._make_skill_with_refs(tmp_path, monkeypatch)
+        reg = SkillsRegistry()
+        for evil in ["../SKILL", "../../conftest", "/etc/passwd", "..\\SKILL"]:
+            result = reg.get_skill_resource("debug-model", evil)
+            assert "error" in result, f"{evil!r} should not resolve"

--- a/tests/unit/test_tool_routing.py
+++ b/tests/unit/test_tool_routing.py
@@ -73,3 +73,11 @@ class TestExecuteCodeDescription:
             or "do not persist" in desc
         # …and the actionable consequence spelled out.
         assert "self-contained" in desc
+
+
+class TestUseSkillDescription:
+    def test_advertises_resource_two_step(self):
+        from freecad_ai.tools.freecad_tools import USE_SKILL
+        desc = USE_SKILL.description.lower()
+        assert "resource" in desc
+        assert "reference" in desc

--- a/tests/unit/test_tool_routing.py
+++ b/tests/unit/test_tool_routing.py
@@ -59,3 +59,17 @@ class TestExecuteCodeDescription:
         desc = EXECUTE_CODE.description.lower()
         assert "last-resort" in desc or "last resort" in desc
         assert "create_sketch" in desc
+
+    def test_warns_state_does_not_persist_between_calls(self):
+        """Issue #39: each execute_code call runs in a fresh namespace.
+
+        Nothing signalled this, so models chained `x = ...` across calls,
+        hit NameError, misread it as a wrong query, and looped until the
+        turn budget was exhausted. The description must tell the model each
+        call is self-contained so it stops chaining state."""
+        desc = EXECUTE_CODE.description.lower()
+        # The statelessness must be stated…
+        assert "fresh namespace" in desc or "does not persist" in desc \
+            or "do not persist" in desc
+        # …and the actionable consequence spelled out.
+        assert "self-contained" in desc

--- a/tests/unit/test_vision_routing.py
+++ b/tests/unit/test_vision_routing.py
@@ -278,6 +278,34 @@ class TestSupportsToolsConfig:
         assert cfg2.tools_detected is True
         assert cfg2.thinking_detected is False
 
+    def test_custom_provider_supports_tools_by_default(self):
+        """Issue #38: a custom OpenAI-compatible endpoint must get tools.
+
+        There is no per-model tool probe for the custom provider (the
+        /api/show capability check is Ollama-only), so tools_detected stays
+        None and the static provider flag is the sole source of truth. It
+        must therefore default to True — most custom servers (vLLM,
+        llama.cpp --jinja, SGLang) support tool calling, and a False default
+        silently strips the tools array from every request.
+        """
+        from freecad_ai.config import AppConfig
+        cfg = AppConfig()
+        cfg.provider.name = "custom"
+        cfg.tools_detected = None  # no Ollama probe runs for custom
+        assert cfg.supports_tools is True
+
+    def test_custom_provider_tools_opt_out_still_honored(self):
+        """A genuinely tool-less custom endpoint can still opt out.
+
+        Setting tools_detected=False (via config.json) must override the
+        now-True static default, so the escape hatch keeps working.
+        """
+        from freecad_ai.config import AppConfig
+        cfg = AppConfig()
+        cfg.provider.name = "custom"
+        cfg.tools_detected = False
+        assert cfg.supports_tools is False
+
 
 class TestFallbackDiscovery:
     """MCP fallback tool search."""


### PR DESCRIPTION
I'm an AI assistant handling this on Alfred's behalf.

Closes #37.

## What

Adds **tier-3 progressive disclosure** to skills: a skill may now ship a `references/` subdirectory of markdown files that the model loads **on demand**, at zero context cost until it actually pulls one in.

Skills previously had only two tiers of context loading:

1. **Tier 1 — metadata**: every skill's name + description, always in the system prompt.
2. **Tier 2 — instructions**: the whole `SKILL.md`, loaded when `use_skill` is invoked.

There was no way to keep `SKILL.md` lean while shipping deep reference material — the gap #37 describes. This PR adds the missing third tier.

## How

- The skill loader scans a sibling `references/` directory (top level only) into a per-skill `{key → absolute_path}` allowlist (`Skill.references`).
- `use_skill` gains an optional `resource` argument. `use_skill(name, resource="freecad-gotchas")` returns that reference file's contents.
- When a skill with references is loaded, an auto-generated **"Available references"** manifest is appended to its `SKILL.md` result — listing each key, a one-line summary, and the exact call to load it (the model can't list a directory itself, so we advertise them explicitly).

### Security by construction

The model passes a **key**, which is looked up in the pre-scanned allowlist. **Model input is never joined into a filesystem path**, so `../` traversal, absolute paths, and symlink escapes are structurally impossible — there is no path to validate. An unknown key returns an error listing the valid keys.

## Why `references/` only (no `scripts/` yet)

`references/` is a **read** feature and shares tier 2's existing trust boundary (skill markdown the user installed was already trusted). `scripts/` would be an **execute** feature — a new capability surface that collides with the workbench's deliberately-controlled execution model (Plan/Dangerous mode, the sandbox validator, `execute_code` framed last-resort). It's an execution-model change, not a folder, and deserves its own scoped proposal. Full reasoning is in the design doc and in the discussion on #37. Invitation still stands for a concrete `scripts/` trust model.

## Tests

- +14 headless unit tests (loader, key resolution, traversal-safety, manifest, end-to-end through the tool handler, description guard).
- Full unit suite: **960 green** (`env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py`).

## Backward compatibility

Fully additive. A skill with no `references/` directory gets an empty dict, no manifest, and behaves exactly as before. No config field, no migration, no system-prompt change.

## Docs

- Design: `docs/superpowers/specs/2026-07-21-skill-references-design.md`
- Plan: `docs/superpowers/plans/2026-07-21-skill-references.md`

---

I'm an AI assistant and can't run FreeCAD's GUI to smoke-test this myself; the change is covered by headless unit tests. If anything misbehaves in a live session, please reopen and I'll take another look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
