### PR TITLE
fix: prevent auto-save from compounding .FCStd onto document filename

### DIFF
--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -334,10 +334,14 @@ def _auto_save(namespace: dict):
         doc = resolve_active_document()
         if not doc or not doc.FileName:
             return  # Unsaved document, nothing to back up
-        backup = doc.FileName + ".ai-backup"
-        doc.saveAs(backup)
-        # Restore the original filename so the user doesn't notice
-        doc.FileName = doc.FileName.replace(".ai-backup", "")
+        original = doc.FileName
+        doc.saveAs(original + ".ai-backup")
+        # saveAs writes the snapshot and repoints FileName at it, and FreeCAD
+        # appends ".FCStd" when the name lacks it (".ai-backup" -> ".ai-backup.FCStd").
+        # Restore the exact original path so the extension can't compound across
+        # calls; a plain .replace(".ai-backup", "") leaves that trailing ".FCStd"
+        # behind and grows the filename by one extension every execution.
+        doc.FileName = original
     except Exception:
         pass  # Best-effort
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -470,3 +470,62 @@ class TestCollectObjectIssues:
         ]
         issues = executor._collect_object_issues(objects_state, set())
         assert issues == ["Object 'Pad' has null shape"]
+
+
+class _FakeDoc:
+    """Minimal stand-in for the App::Document slice ``_auto_save`` touches.
+
+    Mirrors the surprising part of FreeCAD's ``saveAs``: it writes the file
+    *and* repoints ``FileName`` at the saved path, appending ``.FCStd`` when
+    the target lacks that extension (``.ai-backup`` -> ``.ai-backup.FCStd``).
+    """
+
+    def __init__(self, filename):
+        self.FileName = filename
+        self.saved_paths = []
+
+    def saveAs(self, path):
+        if not path.endswith(".FCStd"):
+            path += ".FCStd"
+        self.saved_paths.append(path)
+        self.FileName = path
+
+
+class TestAutoSave:
+    """Regression tests for issue #45 / PR #44 — the recovery snapshot must
+    not compound ``.FCStd`` onto the document filename on each execution."""
+
+    def test_preserves_document_filename(self):
+        # After a backup the document must point at exactly the original path.
+        # The old code rebuilt it with ``.replace(".ai-backup", "")``, which
+        # left the ``.FCStd`` that saveAs appended, growing the name by one
+        # extension every call.
+        doc = _FakeDoc("/tmp/part.FCStd")
+        with patch(
+            "freecad_ai.core.active_document.resolve_active_document",
+            return_value=doc,
+        ):
+            executor._auto_save({})
+        assert doc.FileName == "/tmp/part.FCStd"
+
+    def test_backup_path_is_stable_across_calls(self):
+        # Two executions must overwrite one stable snapshot, not accrete a new
+        # ``…ai-backup.FCStd`` file each time (the litter reported in #45).
+        doc = _FakeDoc("/tmp/part.FCStd")
+        with patch(
+            "freecad_ai.core.active_document.resolve_active_document",
+            return_value=doc,
+        ):
+            executor._auto_save({})
+            executor._auto_save({})
+        assert doc.saved_paths == ["/tmp/part.FCStd.ai-backup.FCStd"] * 2
+
+    def test_no_backup_for_unsaved_document(self):
+        # An unsaved document (empty FileName) has nothing to snapshot.
+        doc = _FakeDoc("")
+        with patch(
+            "freecad_ai.core.active_document.resolve_active_document",
+            return_value=doc,
+        ):
+            executor._auto_save({})
+        assert doc.saved_paths == []


### PR DESCRIPTION
_auto_save() snapshotted via `doc.saveAs(FileName + ".ai-backup")` then restored the name with `.replace(".ai-backup", "")`. FreeCAD's saveAs appends ".FCStd" when the target lacks it (".ai-backup" -> ".ai-backup.FCStd"), so the restore left a trailing ".FCStd" behind — growing the document FileName by one extension on every execute_code call and littering the directory with never-reused `…ai-backup.FCStd` snapshots.

Capture the original FileName and restore it verbatim after the backup, so the path stays stable and the single ".ai-backup.FCStd" snapshot is overwritten in place instead of accumulating.