### PR TITLE
feat(#46): route recovery snapshots to a managed BACKUPS_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Recovery snapshots now live in a managed backups dir** (#46) — before each
+  `execute_code`, `_auto_save` writes the pre-execution snapshot to
+  `CONFIG_DIR/backups/<name>.<hash>.ai-backup.FCStd` instead of dropping an
+  `.ai-backup.FCStd` file beside the user's document. The project folder stays
+  clean; each source path maps to one stable, hash-tagged file that is
+  overwritten in place (collision-safe across same-named documents in different
+  folders). Builds on the #44 filename-accretion fix.
+
+### Added
+
+- **`max_backups` config knob** (#46, JSON-only) — count cap for the recovery
+  snapshots in `CONFIG_DIR/backups`, pruned via the shared `prune_oldest_files`
+  helper (also honours the existing `max_retention_age_days`). Defaults to `0`
+  (keep all) to preserve prior behavior on upgrade; growth is naturally bounded
+  since each document reuses one file. Recommended value if you want a hard cap:
+  `50`.
+
 ## [0.20.0-alpha] - 2026-07-22
 
 A feature release: the workbench can now connect *to* MCP servers by URL — the

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -305,6 +305,7 @@ SKILLS_DIR = os.path.join(CONFIG_DIR, "skills")
 USER_TOOLS_DIR = os.path.join(CONFIG_DIR, "tools")
 HOOKS_DIR = os.path.join(CONFIG_DIR, "hooks")
 LOGS_DIR = os.path.join(CONFIG_DIR, "logs")
+BACKUPS_DIR = os.path.join(CONFIG_DIR, "backups")
 
 
 def prune_oldest_files(
@@ -483,6 +484,10 @@ class AppConfig:
     max_saved_conversations: int = 0
     max_session_logs: int = 0
     max_retention_age_days: int = 0
+    # Pre-execution recovery snapshots kept in BACKUPS_DIR (#46). 0 = keep all;
+    # each source document reuses one hash-tagged file (overwritten), so growth
+    # is naturally bounded by the number of distinct documents ever edited.
+    max_backups: int = 0
 
     @property
     def supports_vision(self) -> bool:
@@ -522,7 +527,7 @@ class AppConfig:
 
 def _ensure_dirs():
     """Create config directories if they don't exist."""
-    for d in (CONFIG_DIR, CONVERSATIONS_DIR, SKILLS_DIR, USER_TOOLS_DIR, HOOKS_DIR, LOGS_DIR):
+    for d in (CONFIG_DIR, CONVERSATIONS_DIR, SKILLS_DIR, USER_TOOLS_DIR, HOOKS_DIR, LOGS_DIR, BACKUPS_DIR):
         os.makedirs(d, exist_ok=True)
 
 

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -328,20 +328,37 @@ finally:
 
 
 def _auto_save(namespace: dict):
-    """Save a recovery copy of the active document before executing code."""
+    """Save a recovery copy of the active document before executing code.
+
+    Snapshots live in the managed ``BACKUPS_DIR`` under the extension's config
+    tree (#46), not beside the user's document — the project folder stays clean
+    and disk use is bounded. Each source path maps to one stable, hash-tagged
+    file that is overwritten in place, so same-named documents in different
+    folders never collide and no snapshot accretes across executions.
+    """
     try:
+        import hashlib
+        from ..config import BACKUPS_DIR, get_config, prune_oldest_files
         from .active_document import resolve_active_document
         doc = resolve_active_document()
         if not doc or not doc.FileName:
             return  # Unsaved document, nothing to back up
         original = doc.FileName
-        doc.saveAs(original + ".ai-backup")
-        # saveAs writes the snapshot and repoints FileName at it, and FreeCAD
-        # appends ".FCStd" when the name lacks it (".ai-backup" -> ".ai-backup.FCStd").
-        # Restore the exact original path so the extension can't compound across
-        # calls; a plain .replace(".ai-backup", "") leaves that trailing ".FCStd"
-        # behind and grows the filename by one extension every execution.
+        os.makedirs(BACKUPS_DIR, exist_ok=True)
+        stem = os.path.splitext(os.path.basename(original))[0]
+        tag = hashlib.sha1(original.encode("utf-8")).hexdigest()[:8]
+        backup = os.path.join(BACKUPS_DIR, f"{stem}.{tag}.ai-backup.FCStd")
+        doc.saveAs(backup)
+        # saveAs repoints FileName at the snapshot; restore the exact original
+        # so the path can't compound across calls (the #45 accretion).
         doc.FileName = original
+        cfg = get_config()
+        prune_oldest_files(
+            BACKUPS_DIR,
+            lambda n: n.endswith(".ai-backup.FCStd"),
+            cfg.max_backups,
+            cfg.max_retention_age_days,
+        )
     except Exception:
         pass  # Best-effort
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,5 +1,7 @@
 """Tests for code execution engine — extract, validate, and safety checks."""
 
+import os
+
 import pytest
 
 from unittest.mock import patch
@@ -492,40 +494,76 @@ class _FakeDoc:
 
 
 class TestAutoSave:
-    """Regression tests for issue #45 / PR #44 — the recovery snapshot must
-    not compound ``.FCStd`` onto the document filename on each execution."""
+    """Tests for ``_auto_save`` — issue #46 (managed backups dir) and the #45 /
+    PR #44 regression (the snapshot must not compound ``.FCStd`` onto the
+    document filename, and must overwrite one stable file rather than accrete)."""
 
-    def test_preserves_document_filename(self):
+    def _run(self, doc, backups_dir):
+        with patch("freecad_ai.config.BACKUPS_DIR", backups_dir), patch(
+            "freecad_ai.core.active_document.resolve_active_document",
+            return_value=doc,
+        ):
+            executor._auto_save({})
+
+    def test_preserves_document_filename(self, tmp_path):
         # After a backup the document must point at exactly the original path.
         # The old code rebuilt it with ``.replace(".ai-backup", "")``, which
         # left the ``.FCStd`` that saveAs appended, growing the name by one
-        # extension every call.
+        # extension every call (#45).
         doc = _FakeDoc("/tmp/part.FCStd")
-        with patch(
-            "freecad_ai.core.active_document.resolve_active_document",
-            return_value=doc,
-        ):
-            executor._auto_save({})
+        self._run(doc, str(tmp_path))
         assert doc.FileName == "/tmp/part.FCStd"
 
-    def test_backup_path_is_stable_across_calls(self):
-        # Two executions must overwrite one stable snapshot, not accrete a new
-        # ``…ai-backup.FCStd`` file each time (the litter reported in #45).
+    def test_backup_written_to_managed_dir(self, tmp_path):
+        # #46: the snapshot lands in the managed BACKUPS_DIR, not beside the
+        # user's document, and keeps the ``.ai-backup.FCStd`` suffix.
+        doc = _FakeDoc("/home/user/project/part.FCStd")
+        self._run(doc, str(tmp_path))
+        assert len(doc.saved_paths) == 1
+        saved = doc.saved_paths[0]
+        assert os.path.dirname(saved) == str(tmp_path)
+        assert saved.endswith(".ai-backup.FCStd")
+        # never written next to the source document
+        assert not saved.startswith("/home/user/project/")
+
+    def test_backup_path_is_stable_across_calls(self, tmp_path):
+        # Two executions overwrite one stable snapshot, never accrete (#45).
         doc = _FakeDoc("/tmp/part.FCStd")
-        with patch(
+        self._run(doc, str(tmp_path))
+        self._run(doc, str(tmp_path))
+        assert len(set(doc.saved_paths)) == 1
+
+    def test_collision_safe_for_same_basename(self, tmp_path):
+        # Two documents sharing a basename in different folders must map to
+        # distinct snapshot files (the hash tag prevents collisions).
+        doc_a = _FakeDoc("/projects/a/part.FCStd")
+        doc_b = _FakeDoc("/projects/b/part.FCStd")
+        self._run(doc_a, str(tmp_path))
+        self._run(doc_b, str(tmp_path))
+        assert doc_a.saved_paths[0] != doc_b.saved_paths[0]
+        for p in doc_a.saved_paths + doc_b.saved_paths:
+            assert os.path.dirname(p) == str(tmp_path)
+
+    def test_prunes_managed_dir(self, tmp_path):
+        # #46: bounded disk use — _auto_save prunes the managed dir with the
+        # shared helper, matching only .ai-backup.FCStd snapshots.
+        doc = _FakeDoc("/tmp/part.FCStd")
+        with patch("freecad_ai.config.BACKUPS_DIR", str(tmp_path)), patch(
+            "freecad_ai.config.prune_oldest_files"
+        ) as mock_prune, patch(
             "freecad_ai.core.active_document.resolve_active_document",
             return_value=doc,
         ):
             executor._auto_save({})
-            executor._auto_save({})
-        assert doc.saved_paths == ["/tmp/part.FCStd.ai-backup.FCStd"] * 2
+        assert mock_prune.called
+        assert mock_prune.call_args[0][0] == str(tmp_path)
+        # the pattern predicate must accept our snapshots and reject foreign files
+        pattern_fn = mock_prune.call_args[0][1]
+        assert pattern_fn("part.abc12345.ai-backup.FCStd") is True
+        assert pattern_fn("something-else.json") is False
 
-    def test_no_backup_for_unsaved_document(self):
+    def test_no_backup_for_unsaved_document(self, tmp_path):
         # An unsaved document (empty FileName) has nothing to snapshot.
         doc = _FakeDoc("")
-        with patch(
-            "freecad_ai.core.active_document.resolve_active_document",
-            return_value=doc,
-        ):
-            executor._auto_save({})
+        self._run(doc, str(tmp_path))
         assert doc.saved_paths == []


### PR DESCRIPTION
Addresses #46. Builds on the #44 filename-accretion fix (merged).

## What

Routes pre-execution recovery snapshots to a managed directory instead of dropping them beside the user's document.

- **New `BACKUPS_DIR = CONFIG_DIR/backups`** (added to `_ensure_dirs`), consistent with `LOGS_DIR` / `CONVERSATIONS_DIR`.
- **`_auto_save` now writes** `CONFIG_DIR/backups/<stem>.<sha1(path)[:8]>.ai-backup.FCStd`. The hash tag keeps same-named documents in different folders from colliding, and each source path maps to one stable file that is overwritten in place (no accretion). `doc.FileName` is still restored verbatim.
- **New `max_backups` config knob** (JSON-only), pruned via the existing `prune_oldest_files` helper (which also honours `max_retention_age_days`).

## Why

`_auto_save` was writing `.ai-backup.FCStd` right next to the model on every `execute_code`, cluttering the folder the user actually works in — the visible symptom behind #45. #44 stopped the filename from compounding; this moves the snapshot out of the project folder entirely and bounds disk use.

## Design decisions

- **Location — `CONFIG_DIR/backups` over `getUserCachePath`:** a cache dir is semantically "safe to wipe" (OS cleaners, FreeCAD itself), which is wrong for a recovery snapshot. See the discussion in #46.
- **`max_backups` defaults to `0` (keep all):** per the project's convention that new config defaults preserve prior behavior on upgrade — no snapshot is silently deleted. Growth is naturally bounded anyway since each document reuses one file. The CHANGELOG notes `50` as a recommended hard cap for those who want one.
- **Out of scope:** restore-from-backup UI. Now that snapshots live in one known managed place, that's a clean follow-up — worth its own issue rather than bundling here.

## Testing

`tests/unit/test_executor.py::TestAutoSave` extended to 6 cases: filename preservation, written-to-managed-dir, stable-path-across-calls (no accretion), collision-safety for same-basename docs, pruning wiring, and the unsaved-document guard. Uses a `_FakeDoc` mimicking FreeCAD's `saveAs`, so it runs in the unit lane with no live FreeCAD.

- Confirmed the managed-dir assertions **fail before this change and pass after** (RED → GREEN).
- Full unit suite green: **1021 passed** (`test_document_attach.py` ignored — pre-existing Qt segfault on clean master).
- Verified `max_backups` round-trips through `config.json` and `BACKUPS_DIR` is created by `_ensure_dirs`.

> Opened as a **draft** — the managed-dir direction was proposed in #46 but not yet green-lit for merge. Happy to adjust scope (e.g. add the retention knob to the Settings UI, or wire restore-on-crash) based on your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
