### PR TITLE
fix(#50): Plan-mode Execute button missing on truncated long plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Plan-mode Execute button missing on long plans** (#50, reported by
+  @MusaAkyuz) — a plan that hit the `max_tokens` output limit was cut off
+  mid-code-block, so the closing ``` fence never arrived. Both fence regexes
+  require it, so the script rendered as unformatted prose and no Execute/Copy
+  buttons were emitted. The button was never generated — nothing was scrolled
+  off-screen. A truncated block now renders as a proper code block and gets a
+  **Copy** button; **Execute is withheld**, since running a script cut off
+  mid-expression raises a `SyntaxError` or leaves half-built geometry.
+- **Truncated responses are now flagged** (#50) — `finish_reason="length"`
+  (OpenAI-style) and `stop_reason="max_tokens"` (Anthropic) were both discarded,
+  so a plan simply stopped mid-line with no explanation. The chat now shows a
+  warning naming the current Max Tokens value and pointing at Settings.
+- **`` ```py `` and untagged code blocks now get an Execute button** (#50) — the
+  executor matched only `` ```python `` while the renderer styled any fence, so
+  models that tag fences differently produced a code block with no way to run it.
+  Non-Python fences (`` ```bash ``, `` ```json ``) remain non-executable.
+
 ## [0.21.0-alpha] - 2026-07-27
 
 A fix-and-cleanup release for the pre-execution recovery snapshots that

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -32,13 +32,48 @@ class ExecutionResult:
     code: str
 
 
-# Regex to extract ```python ... ``` code blocks
-CODE_BLOCK_RE = re.compile(r"```python\s*\n(.*?)```", re.DOTALL)
+# Fence tags we treat as executable Python. Deliberately narrow: this text is
+# handed to exec(), so ```bash / ```json must never match. A bare ``` counts,
+# since models routinely omit the tag (issue #50).
+PYTHON_FENCE_TAGS = ("python", "py", "python3", "")
+
+# Regex to extract ```<tag> ... ``` code blocks. Tag is filtered afterwards.
+CODE_BLOCK_RE = re.compile(r"```(\w*)[ \t]*\n(.*?)```", re.DOTALL)
+
+# A fence opened but never closed — the response was cut off mid-block
+# (typically at max_tokens). Anchored to the end of the text.
+TRUNCATED_BLOCK_RE = re.compile(r"```(\w*)[ \t]*\n((?:(?!```).)*)\Z", re.DOTALL)
+
+
+def _is_python_fence(tag: str) -> bool:
+    return tag.lower() in PYTHON_FENCE_TAGS
 
 
 def extract_code_blocks(text: str) -> list[str]:
-    """Extract all Python code blocks from markdown-formatted text."""
-    return CODE_BLOCK_RE.findall(text)
+    """Extract all complete Python code blocks from markdown-formatted text.
+
+    Only closed blocks are returned — a block cut off mid-expression must never
+    reach exec(). Use :func:`extract_truncated_block` to recover those for display.
+    """
+    return [code for tag, code in CODE_BLOCK_RE.findall(text) if _is_python_fence(tag)]
+
+
+def extract_truncated_block(text: str) -> str | None:
+    """Return the body of a trailing unterminated code fence, if any.
+
+    A plan that hits ``max_tokens`` ends mid-code-block with no closing fence, so
+    the normal extractor finds nothing and the user is left with an unusable wall
+    of text (issue #50). This recovers the partial script so it can still be
+    rendered and copied — never executed.
+    """
+    # Strip complete blocks first so their content can't be mistaken for an
+    # unterminated one, then look for a fence opening in what remains.
+    remainder = CODE_BLOCK_RE.sub("", text)
+    match = TRUNCATED_BLOCK_RE.search(remainder)
+    if not match or not _is_python_fence(match.group(1)):
+        return None
+    code = match.group(2)
+    return code if code.strip() else None
 
 
 def _find_freecad_cmd() -> str:

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -148,6 +148,10 @@ class LLMClient:
         self.model_params = model_params or {}  # freeform per-model params
         self.api_style = get_api_style(provider_name)
 
+        # Set when the last stream ended because it hit the output-token limit
+        # rather than finishing. Read by the UI to warn the user (issue #50).
+        self.response_truncated = False
+
         # SSL context for HTTPS requests.
         # Snap-packaged FreeCAD may lack the _ssl C extension, in which
         # case we fall back to no certificate verification.  The connection
@@ -223,6 +227,7 @@ class LLMClient:
 
     def stream(self, messages: list[dict], system: str = "") -> Generator[str, None, None]:
         """Send a streaming request. Yields text deltas as they arrive."""
+        self.response_truncated = False  # never carry a stale warning into a new turn
         if self.api_style == "anthropic":
             yield from self._stream_anthropic(messages, system)
         else:
@@ -475,6 +480,8 @@ class LLMClient:
                     content = delta.get("content")
                     if content:
                         yield content
+                    if choices[0].get("finish_reason") == "length":
+                        self.response_truncated = True
                     # Skip reasoning_content in simple stream mode
             except (KeyError, IndexError):
                 continue
@@ -664,6 +671,9 @@ class LLMClient:
                 text = delta.get("text")
                 if text:
                     yield text
+            elif event_type == "message_delta":
+                if chunk.get("delta", {}).get("stop_reason") == "max_tokens":
+                    self.response_truncated = True
 
     def _stream_anthropic_tools(self, messages: list[dict], system: str,
                                 tools: list[dict] | None) -> Generator[LLMStreamEvent, None, None]:

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -34,7 +34,7 @@ QTextCursor = QtGui.QTextCursor
 
 from ..config import LOGS_DIR, get_config, prune_oldest_files, save_current_config
 from ..core.conversation import Conversation
-from ..core.executor import extract_code_blocks, execute_code
+from ..core.executor import extract_code_blocks, extract_truncated_block, execute_code
 from ..core.loop_control import should_continue_loop
 from ..core.input_history import InputHistory
 from .message_view import (
@@ -45,7 +45,9 @@ from .message_view import (
     render_message,
     render_code_block,
     render_execution_result,
+    render_plan_buttons,
     render_tool_call,
+    render_truncation_warning,
 )
 from .code_review_dialog import CodeReviewDialog
 
@@ -240,6 +242,7 @@ class _LLMWorker(QThread):
         self._max_tool_turns = get_config().max_tool_turns  # 0 = endless
         self._strip_thinking = False  # resolved in run()
         self._tool_timeline = []  # timing data for summary visualization
+        self._response_truncated = False  # response hit the output-token limit
 
     def run(self):
         try:
@@ -287,6 +290,7 @@ class _LLMWorker(QThread):
                 break
             self._full_response += chunk
             self.token_received.emit(chunk)
+        self._response_truncated = client.response_truncated
         self.response_finished.emit(self._full_response)
 
     def _tool_loop(self, client):
@@ -2249,6 +2253,11 @@ class ChatDockWidget(QDockWidget):
         # Re-render the full chat to get proper code block formatting
         self._rerender_chat()
 
+        # Warn when the model ran out of output budget mid-answer. Without this
+        # the plan just stops mid-line with no explanation (issue #50).
+        if self._worker and self._worker._response_truncated:
+            self._append_html(render_truncation_warning(get_config().max_tokens))
+
         # Tool call summary (after re-render so it's not wiped)
         if self._worker and self._worker._tool_timeline and not getattr(self, '_summary_rendered', False):
             self._summary_rendered = True
@@ -2650,9 +2659,14 @@ class ChatDockWidget(QDockWidget):
 
                 if mode == "plan" and msg["role"] == "assistant":
                     content = Conversation.extract_text(msg.get("content", ""))
-                    code_blocks = extract_code_blocks(content)
-                    for code in code_blocks:
-                        html_parts.append(self._make_plan_buttons_html(code))
+                    for code in extract_code_blocks(content):
+                        html_parts.append(render_plan_buttons(code))
+                    # A block cut off at max_tokens gets Copy but not Execute —
+                    # running a half-written script would fail or leave partial
+                    # geometry behind (issue #50).
+                    partial = extract_truncated_block(content)
+                    if partial:
+                        html_parts.append(render_plan_buttons(partial, allow_execute=False))
 
             full_html = "".join(html_parts)
             self.chat_display.setHtml(full_html)
@@ -2661,26 +2675,6 @@ class ChatDockWidget(QDockWidget):
             scrollbar.setValue(scrollbar.maximum())
         except Exception:
             pass  # Keep existing display content on error
-
-    def _make_plan_buttons_html(self, code):
-        """Create HTML for Plan mode Execute/Copy buttons."""
-        import base64
-        encoded = base64.b64encode(code.encode()).decode()
-        return (
-            '<div style="margin: 2px 0 8px 0;">'
-            '<a href="execute:{encoded}" style="text-decoration: none; '
-            'background-color: #2e7d32; color: white; padding: 3px 12px; '
-            'border-radius: 3px; font-size: 12px; margin-right: 6px;">'
-            '{execute}</a> '
-            '<a href="copy:{encoded}" style="text-decoration: none; '
-            'background-color: #666; color: white; padding: 3px 12px; '
-            'border-radius: 3px; font-size: 12px;">{copy}</a>'
-            '</div>'.format(
-                encoded=encoded,
-                execute=translate("ChatDockWidget", "Execute"),
-                copy=translate("ChatDockWidget", "Copy"),
-            )
-        )
 
     def _handle_anchor_click(self, url):
         """Handle clicks on anchor links in the chat (Execute/Copy/Image buttons)."""

--- a/freecad_ai/ui/message_view.py
+++ b/freecad_ai/ui/message_view.py
@@ -4,6 +4,7 @@ Converts chat messages (with markdown-ish formatting and code blocks)
 into HTML suitable for display in a QTextBrowser.
 """
 
+import base64
 import html
 import re
 
@@ -11,6 +12,9 @@ from ..i18n import translate
 
 # Match ```python ... ``` code blocks
 CODE_BLOCK_RE = re.compile(r"```(\w*)\n(.*?)```", re.DOTALL)
+
+# Match a trailing fence that was opened but never closed (truncated response)
+UNCLOSED_BLOCK_RE = re.compile(r"```(\w*)[ \t]*\n((?:(?!```).)*)\Z", re.DOTALL)
 
 # Match <think>...</think> blocks
 THINK_BLOCK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
@@ -284,6 +288,52 @@ def render_code_block(code: str, language: str = "python") -> str:
     )
 
 
+def render_plan_buttons(code: str, allow_execute: bool = True) -> str:
+    """Render the Plan-mode Execute/Copy buttons for a code block.
+
+    ``allow_execute=False`` withholds Execute for a truncated block: a script cut
+    off mid-expression would raise a SyntaxError or leave half-built geometry, so
+    the user gets Copy only (issue #50).
+    """
+    encoded = base64.b64encode(code.encode()).decode()
+    buttons = []
+    if allow_execute:
+        buttons.append(
+            f'<a href="execute:{encoded}" style="text-decoration: none; '
+            f'background-color: #2e7d32; color: white; padding: 3px 12px; '
+            f'border-radius: 3px; font-size: 12px; margin-right: 6px;">'
+            f'{translate("ChatDockWidget", "Execute")}</a> '
+        )
+    buttons.append(
+        f'<a href="copy:{encoded}" style="text-decoration: none; '
+        f'background-color: #666; color: white; padding: 3px 12px; '
+        f'border-radius: 3px; font-size: 12px;">'
+        f'{translate("ChatDockWidget", "Copy")}</a>'
+    )
+    return '<div style="margin: 2px 0 8px 0;">{}</div>'.format("".join(buttons))
+
+
+def render_truncation_warning(max_tokens: int) -> str:
+    """Warn that the response was cut off at the output-token limit.
+
+    Without this the truncation is silent: the plan simply stops mid-line and the
+    user has no way to tell why it looks unfinished (issue #50).
+    """
+    colors = _get_theme_colors()
+    msg = translate(
+        "MessageView",
+        "Response was cut off at the output limit ({max_tokens} tokens). "
+        "Raise Max Tokens in Settings, or ask the model to continue."
+    ).replace("{max_tokens}", str(max_tokens))
+    return (
+        f'<div style="margin: 6px 0; padding: 6px 10px; '
+        f'border-left: 3px solid {colors["tool_error_border"]}; '
+        f'background-color: {colors["system_bg"]}; border-radius: 0 4px 4px 0; '
+        f'color: {colors["stdout_text"]}; font-size: 12px;">'
+        f'&#9888; {html.escape(msg)}</div>'
+    )
+
+
 def render_execution_result(success: bool, stdout: str, stderr: str) -> str:
     """Render code execution results."""
     colors = _get_theme_colors()
@@ -524,10 +574,19 @@ def _format_content(text: str) -> str:
 
         last_end = match.end()
 
-    # Process remaining text after last block
+    # Process remaining text after last block. A trailing fence that was never
+    # closed means the response was cut off mid-block (issue #50) — still render
+    # it as code rather than dumping a wall of unformatted source on the user.
     remaining = text[last_end:]
     if remaining:
-        parts.append(_format_inline(html.escape(remaining)))
+        truncated = UNCLOSED_BLOCK_RE.search(remaining)
+        if truncated:
+            before = remaining[:truncated.start()]
+            if before:
+                parts.append(_format_inline(html.escape(before)))
+            parts.append(render_code_block(truncated.group(2), truncated.group(1) or "python"))
+        else:
+            parts.append(_format_inline(html.escape(remaining)))
 
     return "".join(parts)
 

--- a/freecad_ai/ui/message_view.py
+++ b/freecad_ai/ui/message_view.py
@@ -323,7 +323,8 @@ def render_truncation_warning(max_tokens: int) -> str:
     msg = translate(
         "MessageView",
         "Response was cut off at the output limit ({max_tokens} tokens). "
-        "Raise Max Tokens in Settings, or ask the model to continue."
+        "Raise Max Output Tokens in Settings → Model Parameters, "
+        "or ask the model to continue."
     ).replace("{max_tokens}", str(max_tokens))
     return (
         f'<div style="margin: 6px 0; padding: 6px 10px; '

--- a/tests/unit/test_plan_truncation.py
+++ b/tests/unit/test_plan_truncation.py
@@ -1,0 +1,182 @@
+"""Regression tests for issue #50 — Plan-mode Execute button missing on long plans.
+
+Root cause: a plan that hits max_tokens is cut off mid-code-block, so the closing
+``` fence never arrives. Both fence regexes require it, so the block rendered as
+plain text and no Execute/Copy buttons were emitted — with no signal to the user
+that the response had been truncated at all.
+
+Covers three defects:
+  1. executor's fence regex only matched ```python, so ```py / bare ``` blocks
+     rendered as code but never got an Execute button (independent of truncation).
+  2. A truncated (unterminated) block produced no code block and no buttons.
+  3. finish_reason="length" / stop_reason="max_tokens" was discarded, so nothing
+     told the user the plan was cut off.
+"""
+
+from unittest.mock import patch
+
+from freecad_ai.core.executor import extract_code_blocks, extract_truncated_block
+from freecad_ai.llm.client import LLMClient
+from freecad_ai.ui.message_view import render_message, render_plan_buttons
+
+TRUNCATED_PLAN = """Here is the plan:
+
+```python
+import Part, math
+bolt_circle_dia = 46.0
+for angle_deg in [45, 135, 225, 315]:
+    z = motor"""
+
+
+class TestFenceLanguageTolerance:
+    """Defect 1 — executor must match the same Python blocks the renderer styles."""
+
+    def test_python_tag(self):
+        blocks = extract_code_blocks("```python\na = 1\n```")
+        assert blocks == ["a = 1\n"]
+
+    def test_py_tag(self):
+        blocks = extract_code_blocks("```py\na = 1\n```")
+        assert blocks == ["a = 1\n"], "```py must yield an Execute button"
+
+    def test_bare_fence(self):
+        blocks = extract_code_blocks("```\na = 1\n```")
+        assert blocks == ["a = 1\n"], "untagged fence must yield an Execute button"
+
+    def test_uppercase_tag(self):
+        assert extract_code_blocks("```Python\na = 1\n```") == ["a = 1\n"]
+
+    def test_non_python_languages_are_ignored(self):
+        """Must NOT broaden to every language — these get executed as Python."""
+        for lang in ("bash", "json", "sh", "xml", "javascript"):
+            text = f"```{lang}\nrm -rf /\n```"
+            assert extract_code_blocks(text) == [], f"```{lang} must not be executable"
+
+
+class TestTruncatedBlock:
+    """Defect 2 — a cut-off block is recoverable for Copy, but never executable."""
+
+    def test_truncated_block_is_not_executable(self):
+        assert extract_code_blocks(TRUNCATED_PLAN) == [], \
+            "a block cut off mid-expression must never get an Execute button"
+
+    def test_truncated_block_is_extracted_for_copy(self):
+        partial = extract_truncated_block(TRUNCATED_PLAN)
+        assert partial is not None
+        assert "bolt_circle_dia = 46.0" in partial
+        assert partial.rstrip().endswith("z = motor")
+
+    def test_closed_block_is_not_reported_as_truncated(self):
+        assert extract_truncated_block("```python\na = 1\n```\nDone.") is None
+
+    def test_prose_without_fences_is_not_truncated(self):
+        assert extract_truncated_block("Just a plan, no code at all.") is None
+
+    def test_trailing_prose_after_closed_block_is_not_truncated(self):
+        text = "```python\na = 1\n```\nThen do the rest by hand."
+        assert extract_truncated_block(text) is None
+
+    def test_inline_backticks_are_not_mistaken_for_a_fence(self):
+        assert extract_truncated_block("Set the `radius` to 5mm.") is None
+
+    def test_second_block_truncated_after_a_complete_one(self):
+        text = "```python\na = 1\n```\nthen:\n```python\nb = 2"
+        assert extract_code_blocks(text) == ["a = 1\n"]
+        partial = extract_truncated_block(text)
+        assert partial is not None
+        assert partial.strip() == "b = 2"
+
+
+class TestPlanButtons:
+    """Defect 2 — truncated code gets Copy, but Execute is withheld."""
+
+    def test_complete_block_offers_execute_and_copy(self):
+        html = render_plan_buttons("a = 1")
+        assert "execute:" in html
+        assert "copy:" in html
+
+    def test_truncated_block_offers_copy_only(self):
+        html = render_plan_buttons("a = 1", allow_execute=False)
+        assert "execute:" not in html, "truncated code must not be executable"
+        assert "copy:" in html
+
+
+class TestTruncatedRendering:
+    """Defect 2 — the partial script still renders as a styled code block."""
+
+    def test_unterminated_fence_renders_as_code_block(self):
+        html = render_message("assistant", TRUNCATED_PLAN)
+        assert "font-family: monospace" in html, \
+            "truncated code must render as a code block, not plain prose"
+        assert "bolt_circle_dia = 46.0" in html
+
+    def test_prose_before_truncated_fence_is_preserved(self):
+        html = render_message("assistant", TRUNCATED_PLAN)
+        assert "Here is the plan:" in html
+
+
+def _make_client(api_style="openai"):
+    client = LLMClient(
+        provider_name="openai",
+        base_url="https://api.openai.com/v1",
+        api_key="test-key",
+        model="gpt-4o",
+    )
+    client.api_style = api_style  # derived from provider_name; override for the SSE shape
+    return client
+
+
+class TestTruncationSignal:
+    """Defect 3 — the provider's truncation signal must survive to the UI."""
+
+    def test_openai_stream_records_length_finish(self):
+        client = _make_client()
+        chunks = [
+            {"choices": [{"delta": {"content": "```python\na = 1"}, "finish_reason": None}]},
+            {"choices": [{"delta": {}, "finish_reason": "length"}]},
+        ]
+        with patch.object(client, "_http_stream", return_value=iter(chunks)):
+            list(client.stream([], ""))
+        assert client.response_truncated is True
+
+    def test_openai_stream_normal_stop_is_not_truncated(self):
+        client = _make_client()
+        chunks = [
+            {"choices": [{"delta": {"content": "done"}, "finish_reason": None}]},
+            {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+        ]
+        with patch.object(client, "_http_stream", return_value=iter(chunks)):
+            list(client.stream([], ""))
+        assert client.response_truncated is False
+
+    def test_anthropic_stream_records_max_tokens(self):
+        client = _make_client(api_style="anthropic")
+        chunks = [
+            {"type": "content_block_delta", "delta": {"text": "```python\na = 1"}},
+            {"type": "message_delta", "delta": {"stop_reason": "max_tokens"}},
+        ]
+        with patch.object(client, "_http_stream", return_value=iter(chunks)):
+            list(client.stream([], ""))
+        assert client.response_truncated is True
+
+    def test_anthropic_stream_normal_end_turn_is_not_truncated(self):
+        client = _make_client(api_style="anthropic")
+        chunks = [
+            {"type": "content_block_delta", "delta": {"text": "done"}},
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+        ]
+        with patch.object(client, "_http_stream", return_value=iter(chunks)):
+            list(client.stream([], ""))
+        assert client.response_truncated is False
+
+    def test_truncation_flag_resets_between_streams(self):
+        client = _make_client()
+        truncated = [{"choices": [{"delta": {}, "finish_reason": "length"}]}]
+        with patch.object(client, "_http_stream", return_value=iter(truncated)):
+            list(client.stream([], ""))
+        assert client.response_truncated is True
+
+        clean = [{"choices": [{"delta": {"content": "hi"}, "finish_reason": "stop"}]}]
+        with patch.object(client, "_http_stream", return_value=iter(clean)):
+            list(client.stream([], ""))
+        assert client.response_truncated is False, "stale truncation warning must not persist"


### PR DESCRIPTION
Fixes #50 (reported by @MusaAkyuz).

*I'm an AI assistant handling this on Alfred's behalf.*

## Root cause

The title is a red herring — **nothing is scrolled off-screen. The button is never generated.**

A plan that hits the `max_tokens` output limit (default `4096`, `config.py:392`) is cut off mid-script, so the closing ` ``` ` fence never arrives. Both fence regexes require one, so `extract_code_blocks()` returns `[]` and `_rerender_chat` appends no Execute/Copy buttons. Nothing surfaces the truncation either: Plan mode uses `_simple_stream` → `client.stream()` → `_stream_openai`, which yields content and never reads `finish_reason`.

Confirmed from the reporter's screenshot **before** any fix was written:

- The code sits on `#243229` (`assistant_bg`) with **zero** `#141414` (`code_bg`) pixels — proving the *renderer's* regex hadn't matched either, so the fence really was unterminated.
- The scrollbar thumb is at the bottom of its trough — the view *is* at the end of the document, ruling out an off-screen button.

## Changes

Three defects, each of which was degrading silently:

1. **Fence tag mismatch** — `executor.py` matched only ` ```python ` while `message_view.py` styled any fence, so ` ```py ` / untagged blocks rendered as code with **no Execute button**, independent of truncation. Now accepts `python` / `py` / `python3` / untagged. Deliberately *not* broadened to every language: this text reaches `exec()`, so ` ```bash ` and ` ```json ` must stay non-executable (covered by a test).
2. **Truncated block unusable** — new `extract_truncated_block()` + `UNCLOSED_BLOCK_RE` let the partial script render as a proper code block and get a **Copy** button. **Execute is withheld** — a script cut off mid-expression raises a `SyntaxError` or leaves half-built geometry.
3. **Silent truncation** — `LLMClient.response_truncated` now records `finish_reason="length"` (OpenAI) and `stop_reason="max_tokens"` (Anthropic), and the chat shows a warning naming the current Max Tokens value and pointing at Settings.

Plan-mode buttons moved from `chat_widget` into `message_view` as `render_plan_buttons(code, allow_execute)` so the logic is testable without Qt.

## Testing

`tests/unit/test_plan_truncation.py` — 21 regression tests written **before** the fix, covering fence-tag tolerance, the non-Python safety guard, truncated-block extraction, Copy-without-Execute, truncated rendering, and the truncation signal for both API styles (including that the flag resets between turns).

```
1042 passed in 53.24s
```
(`tests/unit/`, `--ignore=test_document_attach.py` — that one Qt-segfaults on clean master too.)

Verified end-to-end against the reporter's exact scenario: truncated plan → renders as a code block, prose preserved, Copy offered, Execute withheld; complete plans keep Execute and gain no duplicate buttons.

## Not covered

Act mode's tool-loop paths (`_send_openai_tools:462`, `_stream_openai_tools`) still collapse `finish_reason="length"` into `"end_turn"`. Surfacing truncation there needs its own decision about whether the tool loop should halt, so I left it out rather than widen this PR — happy to file a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)