### PR TITLE
fix(#52): halt the Act-mode tool loop on a truncated turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Truncated responses are now flagged** (#50) — `finish_reason="length"`
   (OpenAI-style) and `stop_reason="max_tokens"` (Anthropic) were both discarded,
   so a plan simply stopped mid-line with no explanation. The chat now shows a
-  warning naming the current Max Tokens value and pointing at Settings.
+  warning naming the current Max Output Tokens value and pointing at Settings.
 - **`` ```py `` and untagged code blocks now get an Execute button** (#50) — the
   executor matched only `` ```python `` while the renderer styled any fence, so
   models that tag fences differently produced a code block with no way to run it.
   Non-Python fences (`` ```bash ``, `` ```json ``) remain non-executable.
+- **Act mode no longer acts on a truncated turn** (#52) — the tool-carrying
+  request paths discarded the same truncation signal #50 fixed for Plan mode,
+  collapsing `finish_reason="length"` into a normal finish. The agentic loop
+  could not tell a cut-off turn from a completed one, so it executed tool calls
+  parsed from a half-formed payload and let the model build on its own
+  mid-sentence output. The loop now **halts** on truncation without running that
+  turn's tool calls, and shows the truncation warning. A truncated turn still
+  counts against the max tool-call iteration budget — it consumed a real
+  request, and refunding it would let repeated truncations run past the limit.
+- **Streaming tool calls are no longer silently dropped on truncation** (#52) —
+  when an OpenAI-style stream ended with `finish_reason="length"`, the handler
+  matched only `"tool_calls"`/`"stop"`, so it never emitted the pending tool
+  calls *or* a `done` event. Those calls are now deliberately discarded (their
+  arguments JSON stops mid-object) and the turn ends cleanly.
 
 ## [0.21.0-alpha] - 2026-07-27
 

--- a/freecad_ai/core/loop_control.py
+++ b/freecad_ai/core/loop_control.py
@@ -11,3 +11,18 @@ def should_continue_loop(max_turns: int, turn: int, interrupted: bool) -> bool:
     if max_turns == 0:
         return True
     return turn < max_turns
+
+
+def resolve_turn_outcome(truncated: bool, tool_calls: list, interrupted: bool) -> str:
+    """Classify a finished turn: "stopped", "truncated", "done" or "continue".
+
+    Precedence matters. An interruption is the user's explicit stop and outranks
+    everything. Truncation halts next: a response cut off at the output limit can
+    carry half-formed tool calls, and acting on a partial payload is worse than
+    stopping (issue #52). Only an intact turn earns the right to continue.
+    """
+    if interrupted:
+        return "stopped"
+    if truncated:
+        return "truncated"
+    return "continue" if tool_calls else "done"

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -236,6 +236,7 @@ class LLMClient:
     def send_with_tools(self, messages: list[dict], system: str = "",
                         tools: list[dict] | None = None) -> LLMResponse:
         """Send a non-streaming request with tool definitions. Returns full response."""
+        self.response_truncated = False  # never carry a stale warning into a new turn
         if self.api_style == "anthropic":
             return self._send_anthropic_tools(messages, system, tools)
         else:
@@ -244,6 +245,7 @@ class LLMClient:
     def stream_with_tools(self, messages: list[dict], system: str = "",
                           tools: list[dict] | None = None) -> Generator[LLMStreamEvent, None, None]:
         """Send a streaming request with tool definitions. Yields LLMStreamEvents."""
+        self.response_truncated = False  # never carry a stale warning into a new turn
         if self.api_style == "anthropic":
             yield from self._stream_anthropic_tools(messages, system, tools)
         else:
@@ -464,6 +466,9 @@ class LLMClient:
                     arguments=args,
                 ))
 
+            if finish == "length":
+                self.response_truncated = True
+
             stop_reason = "tool_use" if (finish == "tool_calls" or tool_calls) else "end_turn"
             return LLMResponse(text=text, tool_calls=tool_calls, stop_reason=stop_reason)
         except (KeyError, IndexError, json.JSONDecodeError) as e:
@@ -537,6 +542,17 @@ class LLMClient:
                     if arg_chunk:
                         pt["arguments_json"] += arg_chunk
                         yield LLMStreamEvent(type="tool_call_delta", argument_delta=arg_chunk)
+
+                # Cut off at the output limit. Any pending tool call is
+                # incomplete — its arguments JSON stops mid-object — so it is
+                # deliberately dropped rather than emitted with silently
+                # defaulted arguments. Record the truncation and end the turn;
+                # the loop halts on it instead of acting on a partial payload
+                # (issue #52).
+                if finish == "length":
+                    self.response_truncated = True
+                    yield LLMStreamEvent(type="done")
+                    return
 
                 # Finish — emit any pending tool calls regardless of
                 # finish_reason, because some providers (e.g. Moonshot/Kimi)
@@ -657,6 +673,8 @@ class LLMClient:
                         arguments=block.get("input", {}),
                     ))
             stop_reason = data.get("stop_reason", "end_turn")
+            if stop_reason == "max_tokens":
+                self.response_truncated = True
             return LLMResponse(text=text, tool_calls=tool_calls, stop_reason=stop_reason)
         except (KeyError, IndexError) as e:
             raise LLMError(f"Unexpected response format: {e}\n{json.dumps(data, indent=2)}")
@@ -734,7 +752,9 @@ class LLMClient:
             elif event_type == "message_delta":
                 # Check stop_reason
                 delta = chunk.get("delta", {})
-                if delta.get("stop_reason") == "tool_use":
+                if delta.get("stop_reason") == "max_tokens":
+                    self.response_truncated = True  # issue #52
+                elif delta.get("stop_reason") == "tool_use":
                     pass  # tool_call_end already emitted from content_block_stop
 
         yield LLMStreamEvent(type="done")

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -35,7 +35,7 @@ QTextCursor = QtGui.QTextCursor
 from ..config import LOGS_DIR, get_config, prune_oldest_files, save_current_config
 from ..core.conversation import Conversation
 from ..core.executor import extract_code_blocks, extract_truncated_block, execute_code
-from ..core.loop_control import should_continue_loop
+from ..core.loop_control import resolve_turn_outcome, should_continue_loop
 from ..core.input_history import InputHistory
 from .message_view import (
     _get_theme_colors,
@@ -329,12 +329,20 @@ class _LLMWorker(QThread):
             turn_text = "".join(text_parts)
             turn_thinking = "".join(thinking_parts)
 
-            if self.isInterruptionRequested():
+            outcome = resolve_turn_outcome(
+                client.response_truncated, tool_calls, self.isInterruptionRequested())
+            if outcome == "stopped":
                 self._full_response += "\n\n_⏹ Stopped by user._"
                 self.response_finished.emit(self._full_response)
                 return
-            if not tool_calls:
-                # No tool calls — we're done
+            if outcome == "truncated":
+                # Cut off at the output limit. Any tool calls in this turn came
+                # from a half-formed payload, so the loop halts here instead of
+                # acting on them; the UI shows the truncation warning (#52).
+                self._response_truncated = True
+                self.response_finished.emit(self._full_response)
+                return
+            if outcome == "done":
                 self.response_finished.emit(self._full_response)
                 return
 

--- a/tests/unit/test_act_truncation.py
+++ b/tests/unit/test_act_truncation.py
@@ -1,0 +1,238 @@
+"""Regression tests for issue #52 — Act mode discards the truncation signal.
+
+#51 surfaced output-token truncation in Plan mode. The tool-carrying paths still
+collapsed finish_reason="length" / stop_reason="max_tokens" into a clean finish,
+so `_tool_loop` could not tell a truncated turn from a completed one and would
+proceed on a half-formed message — running tool calls parsed from a truncated
+payload, or letting the model build on its own mid-sentence output.
+
+Decided behaviour: halt the loop on truncation (do NOT execute that turn's tool
+calls), warn the user, and let the truncated turn count against max_tool_turns.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from freecad_ai.core.loop_control import resolve_turn_outcome, should_continue_loop
+from freecad_ai.llm.client import LLMClient, LLMStreamEvent, ToolCall
+
+
+class TestResolveTurnOutcome:
+    """The per-turn decision: stop, halt-on-truncation, finish, or keep going."""
+
+    def _tc(self):
+        return [ToolCall(id="call_1", name="create_body", arguments={})]
+
+    def test_tool_calls_continue_the_loop(self):
+        assert resolve_turn_outcome(False, self._tc(), False) == "continue"
+
+    def test_no_tool_calls_finishes_normally(self):
+        assert resolve_turn_outcome(False, [], False) == "done"
+
+    def test_truncated_turn_halts_even_with_tool_calls(self):
+        assert resolve_turn_outcome(True, self._tc(), False) == "truncated", \
+            "a truncated turn's tool calls must never be executed"
+
+    def test_truncated_turn_halts_without_tool_calls(self):
+        assert resolve_turn_outcome(True, [], False) == "truncated"
+
+    def test_interrupt_beats_truncation(self):
+        assert resolve_turn_outcome(True, self._tc(), True) == "stopped"
+
+    def test_interrupt_beats_everything(self):
+        assert resolve_turn_outcome(False, self._tc(), True) == "stopped"
+
+
+class TestTruncatedTurnCountsAgainstBudget:
+    """A truncated turn consumed a request; it must not be refunded."""
+
+    def test_turn_budget_is_unchanged_by_truncation(self):
+        # should_continue_loop has no truncation concept: the turn counter is
+        # incremented by the caller for every turn, truncated or not.
+        assert should_continue_loop(30, 29, False) is True
+        assert should_continue_loop(30, 30, False) is False
+
+
+def _make_client(api_style="openai"):
+    client = LLMClient(
+        provider_name="openai",
+        base_url="https://api.openai.com/v1",
+        api_key="test-key",
+        model="gpt-4o",
+    )
+    client.api_style = api_style  # derived from provider_name; override for the SSE shape
+    return client
+
+
+class TestStreamingToolPathsRecordTruncation:
+    def test_openai_tools_stream_records_length(self):
+        client = _make_client()
+        chunks = [
+            {"choices": [{"delta": {"content": "partial"}, "finish_reason": None}]},
+            {"choices": [{"delta": {}, "finish_reason": "length"}]},
+        ]
+        with patch.object(client, "_http_stream", return_value=iter(chunks)):
+            list(client.stream_with_tools([], "", tools=[]))
+        assert client.response_truncated is True
+
+    def test_openai_tools_stream_normal_finish_is_clean(self):
+        client = _make_client()
+        chunks = [
+            {"choices": [{"delta": {"content": "all done"}, "finish_reason": None}]},
+            {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+        ]
+        with patch.object(client, "_http_stream", return_value=iter(chunks)):
+            list(client.stream_with_tools([], "", tools=[]))
+        assert client.response_truncated is False
+
+    def test_anthropic_tools_stream_records_max_tokens(self):
+        client = _make_client(api_style="anthropic")
+        chunks = [
+            {"type": "content_block_delta",
+             "delta": {"type": "text_delta", "text": "partial"}},
+            {"type": "message_delta", "delta": {"stop_reason": "max_tokens"}},
+        ]
+        with patch.object(client, "_http_stream", return_value=iter(chunks)):
+            list(client.stream_with_tools([], "", tools=[]))
+        assert client.response_truncated is True
+
+    def test_anthropic_tools_stream_normal_end_turn_is_clean(self):
+        client = _make_client(api_style="anthropic")
+        chunks = [
+            {"type": "content_block_delta",
+             "delta": {"type": "text_delta", "text": "done"}},
+            {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+            {"type": "message_stop"},
+        ]
+        with patch.object(client, "_http_stream", return_value=iter(chunks)):
+            list(client.stream_with_tools([], "", tools=[]))
+        assert client.response_truncated is False
+
+    def test_flag_resets_between_tool_streams(self):
+        client = _make_client()
+        truncated = [{"choices": [{"delta": {}, "finish_reason": "length"}]}]
+        with patch.object(client, "_http_stream", return_value=iter(truncated)):
+            list(client.stream_with_tools([], "", tools=[]))
+        assert client.response_truncated is True
+
+        clean = [{"choices": [{"delta": {"content": "hi"}, "finish_reason": "stop"}]}]
+        with patch.object(client, "_http_stream", return_value=iter(clean)):
+            list(client.stream_with_tools([], "", tools=[]))
+        assert client.response_truncated is False, "stale warning must not persist"
+
+
+class TestNonStreamingToolPathsRecordTruncation:
+    def test_send_openai_tools_records_length(self):
+        client = _make_client()
+        data = {"choices": [{"message": {"content": "partial"}, "finish_reason": "length"}]}
+        with patch.object(client, "_http_post", return_value=data):
+            client.send_with_tools([], "", tools=[])
+        assert client.response_truncated is True
+
+    def test_send_openai_tools_normal_finish_is_clean(self):
+        client = _make_client()
+        data = {"choices": [{"message": {"content": "done"}, "finish_reason": "stop"}]}
+        with patch.object(client, "_http_post", return_value=data):
+            client.send_with_tools([], "", tools=[])
+        assert client.response_truncated is False
+
+    def test_send_anthropic_tools_records_max_tokens(self):
+        client = _make_client(api_style="anthropic")
+        data = {"content": [{"type": "text", "text": "partial"}],
+                "stop_reason": "max_tokens"}
+        with patch.object(client, "_http_post", return_value=data):
+            client.send_with_tools([], "", tools=[])
+        assert client.response_truncated is True
+
+    def test_send_anthropic_tools_normal_end_turn_is_clean(self):
+        client = _make_client(api_style="anthropic")
+        data = {"content": [{"type": "text", "text": "done"}],
+                "stop_reason": "end_turn"}
+        with patch.object(client, "_http_post", return_value=data):
+            client.send_with_tools([], "", tools=[])
+        assert client.response_truncated is False
+
+
+class _FakeClient:
+    """Yields a fixed event sequence, then reports whether it was truncated."""
+
+    def __init__(self, events, truncated):
+        self._events = events
+        self.response_truncated = truncated
+
+    def stream_with_tools(self, messages, system="", tools=None):
+        yield from self._events
+
+
+def _fake_worker(max_turns=30):
+    """A stand-in for _LLMWorker carrying only what _tool_loop touches.
+
+    _LLMWorker is a QThread; running the real one needs an event loop and a live
+    provider. _tool_loop never calls super(), so it can be invoked unbound
+    against this fake to exercise the halt decision on its own.
+    """
+    return SimpleNamespace(
+        messages=[{"role": "user", "content": "make a box"}],
+        system_prompt="",
+        tools=[],
+        api_style="openai",
+        registry=None,
+        conversation=None,
+        _max_tool_turns=max_turns,
+        _full_response="",
+        _thinking_text="",
+        _strip_thinking=False,
+        _tool_timeline=[],
+        _response_truncated=False,
+        isInterruptionRequested=lambda: False,
+        token_received=MagicMock(),
+        thinking_received=MagicMock(),
+        tool_call_started=MagicMock(),
+        tool_call_finished=MagicMock(),
+        response_finished=MagicMock(),
+        _execute_tool_on_main_thread=MagicMock(
+            side_effect=AssertionError(
+                "a truncated turn's tool calls must never be executed")),
+    )
+
+
+class TestToolLoopHaltsOnTruncation:
+    """The behaviour issue #52 is actually about: don't act on a partial turn."""
+
+    _TOOL_TURN = [
+        LLMStreamEvent(type="text_delta", text="I'll create the body."),
+        LLMStreamEvent(
+            type="tool_call_end",
+            tool_call=ToolCall(id="call_1", name="create_body", arguments={}),
+        ),
+        LLMStreamEvent(type="done"),
+    ]
+
+    def _run(self, truncated, events=None):
+        from freecad_ai.ui.chat_widget import _LLMWorker
+        worker = _fake_worker()
+        client = _FakeClient(events or self._TOOL_TURN, truncated)
+        _LLMWorker._tool_loop(worker, client)  # type: ignore[arg-type]
+        return worker
+
+    def test_truncated_turn_does_not_execute_tool_calls(self):
+        worker = self._run(truncated=True)
+        worker._execute_tool_on_main_thread.assert_not_called()
+
+    def test_truncated_turn_flags_the_worker_for_the_warning(self):
+        worker = self._run(truncated=True)
+        assert worker._response_truncated is True, \
+            "the UI reads this flag to render the truncation warning"
+
+    def test_truncated_turn_finishes_the_response(self):
+        worker = self._run(truncated=True)
+        worker.response_finished.emit.assert_called_once()
+
+    def test_clean_turn_without_tool_calls_does_not_flag_truncation(self):
+        events = [
+            LLMStreamEvent(type="text_delta", text="All done."),
+            LLMStreamEvent(type="done"),
+        ]
+        worker = self._run(truncated=False, events=events)
+        assert worker._response_truncated is False
+        worker.response_finished.emit.assert_called_once()


### PR DESCRIPTION
Fixes #52. Follow-up to #50 / PR #51, which surfaced output-token truncation in Plan mode but deliberately left the tool-carrying paths alone.

## The problem

All four tool paths discarded the provider's truncation signal, collapsing `finish_reason="length"` (OpenAI-style) and `stop_reason="max_tokens"` (Anthropic) into a normal finish. `_tool_loop` therefore could not tell a cut-off turn from a completed one, so it:

- executed tool calls parsed from a half-formed payload, and
- let the model keep building on its own mid-sentence output.

A regression test confirmed this rather than assuming it: a fake tool executor wired to raise on invocation **did** fire against the old code.

## The fix

| Path | Before | After |
|---|---|---|
| `_send_openai_tools` | `"length"` collapsed to `end_turn` | records truncation |
| `_stream_openai_tools` | `"length"` emitted neither pending tool calls **nor** `done` | records truncation, ends the turn cleanly |
| `_send_anthropic_tools` | `max_tokens` passed through unread | records truncation |
| `_stream_anthropic_tools` | only `tool_use` inspected | records truncation |
| `send_with_tools` / `stream_with_tools` | never reset the flag | reset per turn |

`_tool_loop` now consults a new pure helper, `resolve_turn_outcome(truncated, tool_calls, interrupted)`, and **halts** on truncation without running that turn's tool calls. Precedence is ordered deliberately: an interruption outranks truncation, so a user Stop still reports "Stopped by user" rather than a token-limit warning.

The existing #50 warning renders unchanged — `_on_response_finished` was already mode-agnostic, so Act mode picks it up for free.

## Decisions

- **Halt rather than warn-and-continue or auto-continue.** A truncated `tool_calls` payload is malformed intent; acting on it is worse than stopping.
- **A truncated turn counts against `max_tool_turns`.** It consumed a real request, and refunding it would let repeated truncations run past the budget.
- **The OpenAI stream's pending tool calls are discarded, not emitted.** Their arguments JSON stops mid-object, so `json.loads` would fail and silently substitute `{}` — a tool call with defaulted arguments is more dangerous than no tool call. In the Anthropic stream those calls have already been emitted by `content_block_stop`, so there the loop halt is the only guard.

## Testing

20 new regression tests in `tests/unit/test_act_truncation.py` covering outcome precedence, turn-budget accounting, truncation recording across all four tool paths, and the loop halt itself. `_tool_loop` is a `QThread` method that never calls `super()`, so it is exercised unbound against a fake self — no event loop or live provider needed.

**1062 unit tests pass** (baseline 1042).

Not verified against a live provider: I can't run FreeCAD over SSH on this box, so the halt path has unit coverage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
