### PR TITLE
Fix Anthropic extended-thinking response parsing and image format selection

### DIFF
--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -652,7 +652,9 @@ class LLMClient:
         body = self._anthropic_body(messages, system, stream=False)
         data = self._http_post(self._anthropic_url(), self._anthropic_headers(), body)
         try:
-            return data["content"][0]["text"]
+            return "".join(
+                block["text"] for block in data["content"] if block["type"] == "text"
+            )
         except (KeyError, IndexError) as e:
             raise LLMError(f"Unexpected response format: {e}\n{json.dumps(data, indent=2)}")
 

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -1912,7 +1912,8 @@ class ChatDockWidget(QDockWidget):
         # won't get tools sent to it.
         use_tools = cfg.enable_tools and mode == "act" and cfg.supports_tools
         tools_schema = None
-        api_style = "openai"
+        from ..llm.providers import get_api_style
+        api_style = get_api_style(cfg.provider.name)
 
         if use_tools:
             # Connect MCP servers on first tool-enabled send
@@ -1920,7 +1921,6 @@ class ChatDockWidget(QDockWidget):
                 self._connect_mcp_servers(cfg)
 
             from ..tools.setup import create_default_registry
-            from ..llm.providers import get_api_style
 
             # Build extra tools for active optimization
             extra_tools = []
@@ -2523,15 +2523,17 @@ class ChatDockWidget(QDockWidget):
 
         from ..core.system_prompt import build_system_prompt
         from ..llm.client import should_strip_thinking
+        from ..llm.providers import get_api_style
         mode = "plan" if self.mode_combo.currentIndex() == 0 else "act"
         system_prompt = build_system_prompt(mode=mode)
         cfg = get_config()
         strip = should_strip_thinking(
             cfg.provider.model, cfg.strip_thinking_history)
+        api_style = get_api_style(cfg.provider.name)
         # This retry attached a viewport snapshot above; drop history images
         # for non-vision models so they aren't sent raw (issue #30).
         messages = self.conversation.get_messages_for_api(
-            strip_images=not cfg.supports_vision, strip_thinking=strip)
+            api_style=api_style, strip_images=not cfg.supports_vision, strip_thinking=strip)
 
         self._set_loading(True)
         self._streaming_html = ""
@@ -2543,7 +2545,7 @@ class ChatDockWidget(QDockWidget):
         )
 
         self._tool_results_stored = False
-        self._worker = _LLMWorker(messages, system_prompt, parent=self)
+        self._worker = _LLMWorker(messages, system_prompt, api_style=api_style, parent=self)
         self._worker.token_received.connect(self._on_token)
         self._worker.response_finished.connect(self._on_response_finished)
         self._worker.error_occurred.connect(self._on_error)


### PR DESCRIPTION
## Summary

Two related bugs surfaced when using the Anthropic provider with extended thinking and image attachments enabled:

- **`freecad_ai/llm/client.py`** — `_send_anthropic()` assumed `content[0]` was always the text block. With extended thinking enabled, the first content block is `{"type": "thinking", ...}` (no `text` key), so indexing `content[0]["text"]` raises a `KeyError`, surfaced to the user as `Failed: Unexpected response format: 'text'`. Fixed to scan all content blocks for `type == "text"` and concatenate them, matching the existing (correct) behaviour already present in `_send_anthropic_tools()`.

- **`freecad_ai/ui/chat_widget.py`** — `api_style` defaulted to `"openai"` in `_continue_send()` and was only corrected to the configured provider's actual style inside the tools/Act-mode branch (`if use_tools:`). In Plan mode, or with tools disabled, an Anthropic conversation was still formatted with OpenAI-style `image_url` content blocks via `get_messages_for_api()`, which the Anthropic API rejects outright:
  ```
  HTTP 400: messages.0.content.1: Input tag 'image_url' found using 'type' does not match any of the expected tags: ... 'image' ...
  ```
  This reproduces reliably by attaching images (e.g. a reference drawing) and sending a message while on the Anthropic provider. The same default-to-`"openai"` bug also existed in the separate "Fix with AI" retry path (triggered when a viewport screenshot is attached to an auto-retry after a code execution error), which never set `api_style` at all. Both paths now resolve `api_style` from the configured provider unconditionally.

## Test plan

- [x] Reproduced the "Unexpected response format: 'text'" error via Test Connection with Anthropic + extended thinking enabled; confirmed fixed after the change.
- [x] Reproduced the HTTP 400 `image_url` error by attaching images in Plan mode with the Anthropic provider selected; confirmed fixed after the change.
- [ ] Maintainer smoke-test across other providers (OpenAI/Ollama) to confirm no regression, since `api_style` resolution now runs unconditionally rather than only in the tools branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)