### PR TITLE
fix: list_documents crashed on App.Document lacking Modified attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`list_documents` raised AttributeError on every FreeCAD 1.1.x session**
+  (#57, reported and fixed by @s-light in #56) — the handler read
+  `doc.Modified`, but `App.Document` has no such property; the dirty flag lives
+  on the *Gui* document. The tool failed for all users on 1.1.x, not just the
+  Flatpak build it was reported against — confirmed locally against 1.1.1
+  (AppImage). The flag now comes from `Gui.getDocument(name).Modified`, falling
+  back to `False` when there is no GUI (the STDIO MCP server entry point runs
+  headless) or when the document is unknown to the Gui layer.
+
 ## [0.21.1-alpha] - 2026-08-05
 
 ### Fixed

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -3022,12 +3022,27 @@ def _handle_list_documents() -> ToolResult:
     active = resolve_active_document()
     active_name = active.Name if active else ""
 
+    try:
+        import FreeCADGui as Gui
+    except ImportError:
+        Gui = None
+
+    def _is_modified(doc) -> bool:
+        if Gui is None:
+            return False
+        try:
+            gdoc = Gui.getDocument(doc.Name)
+            return bool(gdoc.Modified) if gdoc else False
+        except Exception:
+            return False
+
     lines = [f"## Open Documents ({len(docs)})"]
     doc_data = []
     for doc in docs:
         obj_count = len(doc.Objects)
         marker = " (active)" if doc.Name == active_name else ""
-        modified = " *" if doc.Modified else ""
+        is_modified = _is_modified(doc)
+        modified = " *" if is_modified else ""
         path = doc.FileName or "(unsaved)"
         lines.append(
             f"- **{doc.Name}**{marker}{modified} — "
@@ -3038,7 +3053,7 @@ def _handle_list_documents() -> ToolResult:
             "label": doc.Label,
             "active": doc.Name == active_name,
             "object_count": obj_count,
-            "modified": doc.Modified,
+            "modified": is_modified,
             "path": doc.FileName,
         })
 

--- a/tests/unit/test_list_documents.py
+++ b/tests/unit/test_list_documents.py
@@ -1,0 +1,139 @@
+"""Regression tests for the list_documents tool (#57).
+
+``App.Document`` has no ``Modified`` attribute — the dirty flag lives on the
+*Gui* document instead. Reading ``doc.Modified`` raised AttributeError, which
+broke the tool for every user, not just the Flatpak reporter. Verified against
+FreeCAD 1.1.1 (AppImage)::
+
+    App.Document has Modified attr: False
+    reading .Modified raised: AttributeError:
+        'App.Document' object has no attribute 'Modified'
+
+The fakes below are deliberately plain classes rather than MagicMocks: a
+MagicMock auto-creates ``Modified`` on access and would hide the very bug
+these tests exist to catch.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class _AppDocument:
+    """Stand-in for App.Document — has no ``Modified``, like the real thing."""
+
+    def __init__(self, name, obj_count=0, filename=""):
+        self.Name = name
+        self.Label = name
+        self.Objects = [MagicMock() for _ in range(obj_count)]
+        self.FileName = filename
+
+
+def _gui_module(modified_by_name=None, raises=False):
+    """Build a fake FreeCADGui whose documents carry the dirty flag."""
+    gui = MagicMock()
+    if raises:
+        gui.getDocument.side_effect = RuntimeError("no such document")
+        return gui
+
+    modified_by_name = modified_by_name or {}
+
+    def get_document(name):
+        if name not in modified_by_name:
+            return None
+        gdoc = MagicMock()
+        gdoc.Modified = modified_by_name[name]
+        return gdoc
+
+    gui.getDocument.side_effect = get_document
+    return gui
+
+
+def _run(docs, gui=None, active=None):
+    """Invoke the handler with FreeCAD/FreeCADGui faked out.
+
+    ``gui=None`` simulates a headless session: binding FreeCADGui to None in
+    sys.modules makes ``import FreeCADGui`` raise ImportError, which is exactly
+    what happens under the STDIO MCP server entry point.
+    """
+    app = MagicMock()
+    app.listDocuments.return_value = {d.Name: d for d in docs}
+
+    with patch.dict(sys.modules, {"FreeCAD": app, "FreeCADGui": gui}):
+        with patch(
+            "freecad_ai.core.active_document.resolve_active_document",
+            return_value=active,
+        ):
+            from freecad_ai.tools.freecad_tools import _handle_list_documents
+
+            return _handle_list_documents()
+
+
+class TestListDocumentsModifiedFlag(unittest.TestCase):
+    def test_succeeds_when_app_document_has_no_modified_attribute(self):
+        """The #57 regression: the handler must not touch App.Document.Modified."""
+        doc = _AppDocument("Unnamed", obj_count=2)
+
+        result = _run([doc], gui=_gui_module({"Unnamed": False}), active=doc)
+
+        self.assertTrue(result.success)
+        self.assertIn("Unnamed", result.output)
+
+    def test_reports_modified_from_the_gui_document(self):
+        doc = _AppDocument("Dirty", obj_count=1)
+
+        result = _run([doc], gui=_gui_module({"Dirty": True}), active=doc)
+
+        self.assertTrue(result.data["documents"][0]["modified"])
+        # The dirty marker is " *" before the separator. Asserting on a bare
+        # "*" would match the markdown bold around the document name and pass
+        # no matter what the flag says.
+        self.assertIn(" * —", result.output)
+
+    def test_clean_gui_document_is_not_marked_modified(self):
+        doc = _AppDocument("Clean", obj_count=1)
+
+        result = _run([doc], gui=_gui_module({"Clean": False}), active=doc)
+
+        self.assertFalse(result.data["documents"][0]["modified"])
+        self.assertNotIn(" * —", result.output)
+
+    def test_headless_session_reports_not_modified(self):
+        """No FreeCADGui at all — the MCP STDIO entry point runs this way."""
+        doc = _AppDocument("Headless", obj_count=1)
+
+        result = _run([doc], gui=None, active=doc)
+
+        self.assertTrue(result.success)
+        self.assertFalse(result.data["documents"][0]["modified"])
+
+    def test_document_unknown_to_the_gui_reports_not_modified(self):
+        doc = _AppDocument("Ghost", obj_count=1)
+
+        result = _run([doc], gui=_gui_module({}), active=doc)
+
+        self.assertTrue(result.success)
+        self.assertFalse(result.data["documents"][0]["modified"])
+
+    def test_gui_lookup_failure_is_swallowed(self):
+        doc = _AppDocument("Boom", obj_count=1)
+
+        result = _run([doc], gui=_gui_module(raises=True), active=doc)
+
+        self.assertTrue(result.success)
+        self.assertFalse(result.data["documents"][0]["modified"])
+
+    def test_active_marker_still_applied(self):
+        """Guard the surrounding behaviour the fix reaches into."""
+        a = _AppDocument("A", obj_count=1)
+        b = _AppDocument("B", obj_count=1)
+
+        result = _run([a, b], gui=_gui_module({"A": False, "B": False}), active=b)
+
+        by_name = {d["name"]: d for d in result.data["documents"]}
+        self.assertFalse(by_name["A"]["active"])
+        self.assertTrue(by_name["B"]["active"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
App.Document has no Modified property in this FreeCAD version; the modified flag lives on the Gui document instead. Fall back to False when running headless.