### PR TITLE
Fix/sandbox arch segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (AppImage). The flag now comes from `Gui.getDocument(name).Modified`, falling
   back to `False` when there is no GUI (the STDIO MCP server entry point runs
   headless) or when the document is unknown to the Gui layer.
+- **Sandbox pre-check picked the wrong FreeCAD install** (#58, by @s-light) —
+  `_find_freecad_cmd()` guessed from `~/bin` AppImages and `PATH`, which could
+  resolve to a completely unrelated install (a Snap package on `PATH` while the
+  live session runs from a Flatpak). That foreign binary loads its own
+  incompatible Draft/Arch/PySide stack and segfaults. The console binary is now
+  resolved from the running session's own `FreeCAD.getHomePath()` first, which
+  is guaranteed to match; the existing AppImage/`PATH` chain remains as a
+  fallback for builds that ship no `freecadcmd`.
+- **Sandbox segfaulted on any code importing Arch/BIM** (#58, by @s-light) —
+  the harness imported the real `FreeCADGui` and then patched `ActiveDocument`
+  to a no-op. But the crash happens *during* the import: the real module pulls
+  in PySide/Qt, and anything that later touches Arch dies in C++ where no
+  Python handler can catch it — there is no display and no `QApplication` event
+  loop. The harness now installs a fake `FreeCADGui` module into `sys.modules`
+  instead, so the real one is never imported. Same view-cosmetics
+  neutralisation as before (#14), without the crash. Note that `Gui.Selection`
+  is now a no-op stub rather than the real (empty) selection API.
 
 ## [0.21.1-alpha] - 2026-08-05
 

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -83,6 +83,24 @@ def _find_freecad_cmd() -> str:
     """
     import glob
 
+    # 0. Ask the running FreeCAD for its own install directory and use the
+    # console binary that ships next to it. A PATH-based guess can resolve to
+    # a completely unrelated FreeCAD install (e.g. a Snap package sitting on
+    # PATH while the live session runs from a Flatpak) — that binary imports
+    # its own, incompatible Draft/Arch/PySide stack and segfaults on import,
+    # permanently blocking the sandbox pre-check for anything Arch-related.
+    # The home path is guaranteed to match the live session exactly.
+    try:
+        import FreeCAD as _App
+        home = _App.getHomePath()
+        if home:
+            for name in ("freecadcmd", "FreeCADCmd", "freecadcmd.exe", "FreeCADCmd.exe"):
+                candidate = os.path.join(home, "bin", name)
+                if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                    return candidate
+    except Exception:
+        pass
+
     # 1. Look for AppImages in ~/bin (preferred — direct binary, not a wrapper script)
     appimage_patterns = [
         os.path.expanduser("~/bin/FreeCAD*.AppImage"),
@@ -213,28 +231,27 @@ try:
     except Exception:
         pass
 
-    try:
-        import FreeCADGui as Gui
-        # Console mode: Gui module exists but has no active document/view.
-        # LLM-generated code routinely ends with view-framing cosmetics
-        # (Gui.ActiveDocument.ActiveView.viewIsometric(), fitAll(),
-        # SendMsgToActiveView("ViewFit")). Headlessly FreeCADGui has no
-        # ActiveDocument, so these raise AttributeError and fail the pre-check
-        # for geometry that runs fine in the user's real GUI. Neutralize the
-        # whole Gui.ActiveDocument.* surface with a recursive no-op — any
-        # attribute access or call returns the same stub, so arbitrary view
-        # chains become harmless while the geometry is still validated (#14).
-        if not hasattr(Gui, "ActiveDocument") or Gui.ActiveDocument is None:
-            class _NoOpGui:
-                def __getattr__(self, _name):
-                    return self
-                def __call__(self, *a, **kw):
-                    return self
-            Gui.ActiveDocument = _NoOpGui()
-            Gui.SendMsgToActiveView = lambda *a, **kw: None
-            Gui.updateGui = lambda *a, **kw: None
-    except ImportError:
-        pass
+    # Console mode: install a fake FreeCADGui module instead of importing the
+    # real one. LLM-generated code routinely ends with view-framing cosmetics
+    # (Gui.ActiveDocument.ActiveView.viewIsometric(), fitAll(),
+    # SendMsgToActiveView("ViewFit")); a real headless FreeCADGui has no
+    # ActiveDocument, so these raise AttributeError and fail the pre-check for
+    # geometry that runs fine in the user's real GUI (#14). A plain no-op stub
+    # covers that. Importing the *real* FreeCADGui and then anything that
+    # touches Arch/Draft (which pull in PySide) segfaults this console
+    # binary — no display, no QApplication event loop — so the real module
+    # must never be imported here at all, not just patched afterward.
+    import types
+    class _NoOpGui:
+        def __getattr__(self, _name):
+            return self
+        def __call__(self, *a, **kw):
+            return self
+    _fake_gui = types.ModuleType("FreeCADGui")
+    _fake_gui.ActiveDocument = _NoOpGui()
+    _fake_gui.SendMsgToActiveView = lambda *a, **kw: None
+    _fake_gui.updateGui = lambda *a, **kw: None
+    sys.modules["FreeCADGui"] = _fake_gui
 {open_block}
 
     # Per-object problem snapshot — shared by the baseline (pre-code) and the

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,10 +1,11 @@
 """Tests for code execution engine — extract, validate, and safety checks."""
 
 import os
+import sys
 
 import pytest
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from freecad_ai.core import executor
 from freecad_ai.core.executor import (
@@ -567,3 +568,117 @@ class TestAutoSave:
         doc = _FakeDoc("")
         self._run(doc, str(tmp_path))
         assert doc.saved_paths == []
+
+
+class TestFindFreecadCmd:
+    """Regression tests for console-binary discovery (#58).
+
+    A PATH/glob-based guess can resolve to a completely unrelated FreeCAD
+    install — a Snap package on PATH while the live session runs from a
+    Flatpak. That foreign binary imports its own incompatible Draft/Arch/PySide
+    stack and segfaults, permanently blocking the sandbox pre-check for
+    anything BIM-related. The running session's own ``FreeCAD.getHomePath()``
+    is the only source guaranteed to match.
+    """
+
+    @staticmethod
+    def _make_home(tmp_path, name="freecadcmd"):
+        """Build a fake FreeCAD home with an executable console binary."""
+        bin_dir = tmp_path / "usr" / "bin"
+        bin_dir.mkdir(parents=True)
+        binary = bin_dir / name
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        return str(tmp_path / "usr"), str(binary)
+
+    @staticmethod
+    def _app_module(home):
+        app = MagicMock()
+        app.getHomePath.return_value = home
+        return app
+
+    def test_prefers_running_sessions_own_console_binary(self, tmp_path):
+        # A decoy AppImage is present and would win under the old glob-first
+        # ordering; the live session's binary must take precedence.
+        home, binary = self._make_home(tmp_path)
+        with patch.dict(sys.modules, {"FreeCAD": self._app_module(home)}), patch(
+            "glob.glob", return_value=["/home/someone/bin/FreeCAD_9.9.9.AppImage"]
+        ):
+            assert executor._find_freecad_cmd() == binary
+
+    def test_accepts_capitalised_binary_name(self, tmp_path):
+        home, binary = self._make_home(tmp_path, name="FreeCADCmd")
+        with patch.dict(sys.modules, {"FreeCAD": self._app_module(home)}), patch(
+            "glob.glob", return_value=[]
+        ):
+            assert executor._find_freecad_cmd() == binary
+
+    def test_non_executable_binary_is_ignored(self, tmp_path):
+        home, binary = self._make_home(tmp_path)
+        os.chmod(binary, 0o644)
+        decoy = "/home/someone/bin/FreeCAD_9.9.9.AppImage"
+        with patch.dict(sys.modules, {"FreeCAD": self._app_module(home)}), patch(
+            "glob.glob", return_value=[decoy]
+        ):
+            assert executor._find_freecad_cmd() == decoy
+
+    def test_falls_back_when_home_has_no_console_binary(self, tmp_path):
+        # Some builds ship no freecadcmd next to the GUI binary — the existing
+        # AppImage/PATH chain must still be reachable.
+        (tmp_path / "usr" / "bin").mkdir(parents=True)
+        decoy = "/home/someone/bin/FreeCAD_9.9.9.AppImage"
+        with patch.dict(
+            sys.modules, {"FreeCAD": self._app_module(str(tmp_path / "usr"))}
+        ), patch("glob.glob", return_value=[decoy]):
+            assert executor._find_freecad_cmd() == decoy
+
+    def test_falls_back_when_freecad_is_not_importable(self, tmp_path):
+        # Unit-test context, or any process without FreeCAD on sys.path.
+        decoy = "/home/someone/bin/FreeCAD_9.9.9.AppImage"
+        with patch.dict(sys.modules, {"FreeCAD": None}), patch(
+            "glob.glob", return_value=[decoy]
+        ):
+            assert executor._find_freecad_cmd() == decoy
+
+
+class TestSandboxGuiStub:
+    """Regression tests for the headless FreeCADGui stub (#58).
+
+    Importing the *real* FreeCADGui in the console sandbox and then anything
+    that pulls in Arch segfaults — no display, no QApplication event loop. The
+    crash happens during the import itself, so patching attributes afterwards
+    is too late; the real module must never be imported at all.
+    """
+
+    def _generated_script(self):
+        """Run _sandbox_test far enough to capture the generated harness."""
+        captured = {}
+        real_open = open
+
+        def spy_open(path, mode="r", *a, **kw):
+            handle = real_open(path, mode, *a, **kw)
+            if "w" in mode and str(path).endswith(".py"):
+                original_write = handle.write
+
+                def write(text):
+                    captured["src"] = text
+                    return original_write(text)
+
+                handle.write = write
+            return handle
+
+        with patch("freecad_ai.core.executor._find_freecad_cmd", return_value="/bin/true"), \
+                patch("builtins.open", spy_open), \
+                patch("subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            executor._sandbox_test("pass", timeout=1)
+        return captured.get("src", "")
+
+    def test_harness_installs_a_fake_gui_module(self):
+        src = self._generated_script()
+        assert 'sys.modules["FreeCADGui"]' in src
+
+    def test_harness_never_imports_the_real_gui_module(self):
+        # `import FreeCADGui` is the exact statement that segfaults.
+        src = self._generated_script()
+        assert "import FreeCADGui" not in src


### PR DESCRIPTION
fix: sandbox pre-check segfaults on Arch import, blocking all BIM tooling
_find_freecad_cmd() picked up an unrelated FreeCAD install from PATH
(e.g. a Snap package) instead of the one actually running (Flatpak,
AppImage, etc.), whose incompatible bundled PySide/Draft/Arch stack
crashed on import. Resolve the console binary from the live session's
own FreeCAD.getHomePath() first.

Separately, even with the right binary, importing the real FreeCADGui
in the headless console sandbox and then anything that pulls in Arch
segfaults (no display, no QApplication event loop). Install a fake
FreeCADGui stub module directly instead of importing the real one —
same view-cosmetics neutralization, without ever touching the real
module.

Together these unblock any code path that imports Arch/BIM, which was
previously impossible to execute via execute_code.