### PR TITLE
fix(#60): reject a wildcard MCP_HOST bind instead of locking out every client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`MCP_HOST=0.0.0.0` locked out every client it appeared to let in** — the
+  server's `Host`-header allowlist was seeded from the bind address, so a
+  wildcard bind added the literal string `0.0.0.0` to it. No client's `Host`
+  header ever names a wildcard address, so the socket listened on every
+  interface while returning 403 to every non-loopback client — with no error
+  and no log line to say why. A wildcard bind is now refused at startup with a
+  message naming the fix, instead of failing silently later. Reported and fixed
+  by @AmirF194 in [#66](https://github.com/ghbalf/freecad-ai/pull/66),
+  closing [#60](https://github.com/ghbalf/freecad-ai/issues/60).
+
+### Added
+
+- **Allowed `Host` headers are configurable** — a new
+  **AI Settings → MCP Servers → Allowed Host headers** field and a
+  `MCP_ALLOWED_HOSTS` environment variable (comma-separated, env wins) name the
+  hosts the MCP server answers to. This is what makes a non-loopback bind
+  usable: clients send the address they dialled, so it has to be named here.
+  Empty (the default) keeps today's behaviour exactly — loopback only, and a
+  wildcard bind still refused.
+  `*` is not accepted: the server has **no authentication**
+  ([#59](https://github.com/ghbalf/freecad-ai/issues/59)), so this allowlist is
+  the only thing limiting who can reach it.
+
 ## [0.22.0-alpha] - 2026-08-23
 
 ### Added

--- a/InitGui.py
+++ b/InitGui.py
@@ -224,7 +224,8 @@ class ToggleMCPServerCommand:
 
     def Activated(self, index=0):
         from freecad_ai.mcp.gui_server import (
-            get_server_controller, resolve_server_address)
+            get_server_controller, resolve_allowed_hosts,
+            resolve_server_address)
         controller = get_server_controller()
 
         if controller.is_running():
@@ -234,10 +235,16 @@ class ToggleMCPServerCommand:
             return
 
         from freecad_ai.config import get_config
-        host, port = resolve_server_address(get_config())
+        cfg = get_config()
+        host, port = resolve_server_address(cfg)
         try:
-            url = controller.start(host, port)
-        except OSError as exc:
+            # ValueError as well as OSError: resolve_allowed_hosts refuses a
+            # "*" entry, and MCP_ALLOWED_HOSTS can carry one even though the
+            # Settings dialog strips it. Unhandled, that leaves the button
+            # mid-state behind a console traceback nothing surfaces.
+            allowed_hosts = resolve_allowed_hosts(cfg)
+            url = controller.start(host, port, allowed_hosts=allowed_hosts)
+        except (OSError, ValueError) as exc:
             self._report_failure(host, port, exc)
             self._sync_action()  # a failed start must leave the button unticked
             return

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -420,6 +420,12 @@ class AppConfig:
     # restricted field made it safe. MCP_HOST / MCP_PORT override both.
     mcp_server_host: str = "127.0.0.1"
     mcp_server_port: int = 3000
+    # Host headers the server answers to. Empty means "let the transport pick
+    # its own default" (loopback, plus the rejection of a wildcard bind that
+    # would otherwise 403 every client — #60). A non-empty list here is the
+    # deliberate opt-in to a wider policy, e.g. naming the LAN address or
+    # container hostname clients actually dial. MCP_ALLOWED_HOSTS overrides.
+    mcp_server_allowed_hosts: list = field(default_factory=list)
     user_tools_disabled: list = field(default_factory=list)
     scan_freecad_macros: bool = False
     # Dangerous mode: relaxes executor safety layers (static pattern blocking,

--- a/freecad_ai/mcp/gui_server.py
+++ b/freecad_ai/mcp/gui_server.py
@@ -49,6 +49,43 @@ def resolve_server_address(cfg=None):
     return host, port
 
 
+def resolve_allowed_hosts(cfg=None):
+    """Return the ``Host``-header allowlist, or ``None`` for the default.
+
+    ``None`` is not the same as the loopback list. The transport derives its
+    own default only when ``allowed_hosts is None``, and that branch is where
+    a wildcard bind is rejected. Passing an explicit list — even one identical
+    to the default — is the documented opt-in to a wider policy, so returning
+    a list when the user configured nothing would silently disarm that guard
+    and restore #60's every-client-gets-403 dead end.
+
+    Env beats config, matching MCP_HOST / MCP_PORT. Entries are comma
+    separated.
+
+    Raises ValueError on a ``*`` entry: the allowlist is the only thing
+    standing between a wildcard bind and unauthenticated remote tool
+    execution until #59 lands a bearer token, so widening it to "any Host"
+    is refused rather than quietly honoured.
+    """
+    raw = os.environ.get("MCP_ALLOWED_HOSTS")
+    if raw:
+        hosts = raw.split(",")
+    elif cfg is not None:
+        hosts = list(getattr(cfg, "mcp_server_allowed_hosts", None) or [])
+    else:
+        hosts = []
+
+    hosts = [h.strip() for h in hosts if h and h.strip()]
+    if any(h == "*" for h in hosts):
+        raise ValueError(
+            "'*' is not accepted in the MCP allowed-hosts list. The server "
+            "has no authentication (issue #59), and this allowlist is the "
+            "only thing keeping a wildcard bind from serving arbitrary "
+            "Python to anything that can reach it. Name the concrete hosts "
+            "clients dial instead.")
+    return hosts or None
+
+
 def _default_backend():
     """Build the tool registry and the Qt main-thread executor.
 
@@ -84,8 +121,11 @@ class ServerController:
     def url(self):
         return self._url if self.is_running() else None
 
-    def start(self, host, port):
-        """Start serving and return the URL. Raises OSError if the bind fails.
+    def start(self, host, port, allowed_hosts=None):
+        """Start serving and return the URL.
+
+        Raises OSError if the bind fails, or if ``host`` is a wildcard address
+        while ``allowed_hosts`` is None — see SSEServerTransport.
 
         Binds *before* building the registry: the bind is the only step that
         realistically fails, it is cheap, and failing first leaves no
@@ -104,7 +144,8 @@ class ServerController:
 
         from .transport import SSEServerTransport
 
-        transport = SSEServerTransport(host=host, port=port)
+        transport = SSEServerTransport(host=host, port=port,
+                                       allowed_hosts=allowed_hosts)
         transport.bind()  # raises OSError on the caller's thread — the point
 
         if self._registry is None or self._executor is None:

--- a/freecad_ai/mcp/transport.py
+++ b/freecad_ai/mcp/transport.py
@@ -511,6 +511,10 @@ class StdioServerTransport:
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
+# A wildcard bind address is not a name any client's Host header ever
+# carries, so it cannot seed the default Host allowlist (see __init__).
+_WILDCARD_BIND_HOSTS = frozenset({"0.0.0.0", "::"})
+
 
 class SSEServerTransport:
     """Server-side transport: serves MCP over HTTP + Server-Sent Events.
@@ -542,6 +546,14 @@ class SSEServerTransport:
         self._serving = False
         self._lifecycle_lock = threading.Lock()
         if allowed_hosts is None:
+            if host.lower() in _WILDCARD_BIND_HOSTS:
+                raise OSError(
+                    "MCP_HOST=%s binds every interface, but no real client's "
+                    "Host header ever names a wildcard address, so every LAN "
+                    "client would get a 403. Set MCP_HOST to the concrete "
+                    "interface address clients will dial (e.g. your LAN IP), "
+                    "or pass allowed_hosts explicitly to opt into a wider "
+                    "policy." % host)
             allowed_hosts = _LOOPBACK_HOSTS | {host.lower()}
         self._allowed_hosts = frozenset(h.lower() for h in allowed_hosts)
         self._allowed_origins = frozenset(allowed_origins)

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -691,6 +691,17 @@ class SettingsDialog(QDialog):
             translate("SettingsDialog", "Server port:"),
             self.mcp_server_port_edit)
 
+        # Host headers the server answers to. Empty means the transport's own
+        # loopback default, which is also what keeps a wildcard bind refused
+        # rather than silently 403-ing every client (#60). Naming hosts here
+        # is the opt-in that makes a non-loopback bind reachable.
+        self.mcp_server_allowed_hosts_edit = QLineEdit()
+        self.mcp_server_allowed_hosts_edit.setPlaceholderText(
+            "127.0.0.1, localhost, ::1")
+        server_form.addRow(
+            translate("SettingsDialog", "Allowed Host headers:"),
+            self.mcp_server_allowed_hosts_edit)
+
         mcp_layout.addLayout(server_form)
 
         # Unconditional, not shown only for non-loopback values: the loopback
@@ -700,7 +711,12 @@ class SettingsDialog(QDialog):
             "SettingsDialog",
             "The MCP server has no authentication. Anything that can reach "
             "this address can run FreeCAD tools, including arbitrary Python. "
-            "Keep it on 127.0.0.1 unless you understand the exposure."))
+            "Keep it on 127.0.0.1 unless you understand the exposure.\n\n"
+            "Leave Allowed Host headers empty for loopback-only access. "
+            "Listing hosts is what makes a non-loopback bind reachable, so "
+            "name only the addresses clients actually dial. \"*\" is not "
+            "accepted \u2014 with no authentication, this list is the only "
+            "thing limiting who can reach the server."))
         mcp_server_warning.setWordWrap(True)
         mcp_layout.addWidget(mcp_server_warning)
 
@@ -935,6 +951,8 @@ class SettingsDialog(QDialog):
 
         self.mcp_server_host_edit.setText(cfg.mcp_server_host)
         self.mcp_server_port_edit.setText(str(cfg.mcp_server_port))
+        self.mcp_server_allowed_hosts_edit.setText(
+            ", ".join(cfg.mcp_server_allowed_hosts or []))
 
         # Editor preference
         self.use_external_editor_cb.setChecked(cfg.use_external_editor)
@@ -1206,6 +1224,8 @@ class SettingsDialog(QDialog):
         cfg.mcp_server_host, cfg.mcp_server_port = self._parse_server_address(
             self.mcp_server_host_edit.text(),
             self.mcp_server_port_edit.text())
+        cfg.mcp_server_allowed_hosts = self._parse_allowed_hosts(
+            self.mcp_server_allowed_hosts_edit.text())
         cfg.use_external_editor = self.use_external_editor_cb.isChecked()
         cfg.scan_freecad_macros = self.scan_macros_cb.isChecked()
 
@@ -1558,6 +1578,21 @@ class SettingsDialog(QDialog):
             args = " ".join(entry.get("args", []))
             target = f"{entry.get('command', '')} {args}".strip()
         return f"{prefix}{entry.get('name', '?')} — {target}"
+
+    @staticmethod
+    def _parse_allowed_hosts(hosts_text):
+        """Normalise the allowed-Host-headers field into a list.
+
+        Empty means "let the transport pick its own default" — loopback, and
+        with it the wildcard-bind rejection that keeps #60 from returning.
+
+        A "*" entry is dropped rather than raised on, because the dialog must
+        always be closable. The warning under the field is what explains why;
+        the env-var path (resolve_allowed_hosts) refuses it loudly instead,
+        since a traceback is the only feedback available there.
+        """
+        return [h.strip() for h in (hosts_text or "").split(",")
+                if h.strip() and h.strip() != "*"]
 
     @staticmethod
     def _parse_server_address(host_text, port_text):

--- a/mcp_server_http.py
+++ b/mcp_server_http.py
@@ -23,6 +23,11 @@ MCP configuration:
 Environment variables:
     MCP_HOST  — listen address  (default: 127.0.0.1)
     MCP_PORT  — listen port     (default: 3000)
+    MCP_ALLOWED_HOSTS — comma-separated Host headers the server answers to
+                        (default: loopback only). Needed when binding a
+                        non-loopback address: clients send the address they
+                        dialled, so it must be named here. "*" is refused —
+                        the server has no authentication.
 """
 
 import os
@@ -45,7 +50,11 @@ import FreeCAD
 if not FreeCAD.ActiveDocument:
     FreeCAD.newDocument("Unnamed")
 
-from freecad_ai.mcp.gui_server import get_server_controller, resolve_server_address
+from freecad_ai.mcp.gui_server import (
+    get_server_controller,
+    resolve_allowed_hosts,
+    resolve_server_address,
+)
 
 # Config is only a fallback here; MCP_HOST / MCP_PORT still win. Reading it
 # can fail outside a configured install, which must not stop the server.
@@ -56,9 +65,10 @@ except Exception:
     _cfg = None
 
 host, port = resolve_server_address(_cfg)
+allowed_hosts = resolve_allowed_hosts(_cfg)
 
 # start() binds before returning, so this line can no longer announce a
 # server that never came up.
-url = get_server_controller().start(host, port)
+url = get_server_controller().start(host, port, allowed_hosts=allowed_hosts)
 
 print(f"MCP SSE server running on {url}", flush=True)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1235,3 +1235,13 @@ def test_mcp_server_address_roundtrip():
     restored = AppConfig.from_dict(cfg.to_dict())
     assert restored.mcp_server_host == "0.0.0.0"
     assert restored.mcp_server_port == 8080
+
+
+def test_mcp_server_allowed_hosts_defaults_to_empty():
+    """Empty means "let the transport pick", which is today's behaviour.
+
+    A non-empty default would be handed to SSEServerTransport as an explicit
+    allowlist, skipping the branch that rejects a wildcard bind (#60/#66).
+    """
+    from freecad_ai.config import AppConfig
+    assert AppConfig().mcp_server_allowed_hosts == []

--- a/tests/unit/test_initgui_commands.py
+++ b/tests/unit/test_initgui_commands.py
@@ -138,3 +138,40 @@ def test_toggling_keep_dock_pushes_the_new_state(initgui, ticks, tmp_config_dir)
 
     assert cfg.keep_dock_on_workbench_switch is False
     assert ticks["FreeCADAI_ToggleKeepDock"] is False
+
+
+# ---------------------------------------------------------------------------
+# A rejected allowed-hosts list must fail the click, not the session
+# ---------------------------------------------------------------------------
+
+def test_toggle_reports_a_rejected_allowed_hosts_list(initgui, ticks,
+                                                      monkeypatch):
+    """MCP_ALLOWED_HOSTS="*" is refused by resolve_allowed_hosts.
+
+    That raises ValueError, not the OSError the bind path raises, so without
+    handling it the toggle propagates out of Activated() into FreeCAD's
+    command dispatcher — a console traceback and a button left mid-state.
+
+    The rejection must also happen before any bind is attempted, so this
+    never depends on a port being free.
+    """
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "*")
+
+    import freecad_ai.mcp.gui_server as gui_server
+
+    def _must_not_bind(self, *args, **kwargs):
+        raise AssertionError("start() ran despite a rejected allowlist")
+
+    monkeypatch.setattr(gui_server.ServerController, "start", _must_not_bind)
+
+    command = initgui["ToggleMCPServerCommand"]()
+    reported = []
+    monkeypatch.setattr(type(command), "_report_failure",
+                        lambda self, host, port, exc: reported.append(exc))
+
+    command.Activated()
+
+    assert len(reported) == 1
+    assert isinstance(reported[0], ValueError)
+    assert "*" in str(reported[0])
+    assert ticks["FreeCADAI_ToggleMCPServer"] is False

--- a/tests/unit/test_mcp_gui_server.py
+++ b/tests/unit/test_mcp_gui_server.py
@@ -16,6 +16,7 @@ from freecad_ai.mcp.gui_server import (
     DEFAULT_PORT,
     ServerController,
     get_server_controller,
+    resolve_allowed_hosts,
     resolve_server_address,
 )
 
@@ -84,6 +85,87 @@ def test_resolve_ignores_a_non_numeric_env_port(monkeypatch):
     monkeypatch.setenv("MCP_PORT", "not-a-port")
     cfg = type("Cfg", (), {"mcp_server_host": "10.0.0.5", "mcp_server_port": 9000})()
     assert resolve_server_address(cfg) == ("10.0.0.5", 9000)
+
+
+# --- allowed-host resolution -----------------------------------------------
+#
+# Nothing configured must resolve to None, not to the loopback list. The
+# transport's own ``allowed_hosts is None`` branch is what rejects a wildcard
+# bind; handing it an explicit list — even the identical one — bypasses that
+# guard and silently restores the every-client-gets-403 dead end of #60.
+
+def test_allowed_hosts_is_none_when_nothing_is_configured(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    assert resolve_allowed_hosts(None) is None
+
+
+def test_allowed_hosts_is_none_when_the_config_list_is_empty(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    cfg = type("Cfg", (), {"mcp_server_allowed_hosts": []})()
+    assert resolve_allowed_hosts(cfg) is None
+
+
+def test_allowed_hosts_prefers_config_over_default(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    cfg = type("Cfg", (), {
+        "mcp_server_allowed_hosts": ["fileserver.local", "192.168.1.50"]})()
+    assert resolve_allowed_hosts(cfg) == ["fileserver.local", "192.168.1.50"]
+
+
+def test_allowed_hosts_prefers_env_over_config(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "box.lan, 10.0.0.7")
+    cfg = type("Cfg", (), {"mcp_server_allowed_hosts": ["ignored.local"]})()
+    assert resolve_allowed_hosts(cfg) == ["box.lan", "10.0.0.7"]
+
+
+def test_allowed_hosts_drops_blank_entries(monkeypatch):
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "box.lan, ,, 10.0.0.7,")
+    assert resolve_allowed_hosts(None) == ["box.lan", "10.0.0.7"]
+
+
+def test_allowed_hosts_rejects_a_wildcard_entry(monkeypatch):
+    # "*" would re-open exactly the hole #60 declined to open: the Host
+    # allowlist is the only thing standing between a wildcard bind and
+    # unauthenticated remote tool execution until #59 lands a token.
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "box.lan, *")
+    with pytest.raises(ValueError, match=r"\*"):
+        resolve_allowed_hosts(None)
+
+
+def test_allowed_hosts_rejects_a_wildcard_entry_from_config(monkeypatch):
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    cfg = type("Cfg", (), {"mcp_server_allowed_hosts": ["*"]})()
+    with pytest.raises(ValueError, match=r"\*"):
+        resolve_allowed_hosts(cfg)
+
+
+# --- allowed hosts reach the transport -------------------------------------
+
+def test_explicit_allowed_hosts_admit_a_non_loopback_client():
+    # The escape hatch #66's own error message advertises: naming the host
+    # clients actually dial makes a non-loopback bind usable.
+    controller = _controller()
+    port = _free_port()
+    try:
+        controller.start("127.0.0.1", port,
+                         allowed_hosts=["fileserver.local"])
+        transport = controller._transport
+        assert transport._request_allowed("fileserver.local:%d" % port,
+                                          None) is True
+    finally:
+        controller.stop()
+
+
+def test_start_without_allowed_hosts_keeps_the_loopback_default():
+    controller = _controller()
+    port = _free_port()
+    try:
+        controller.start("127.0.0.1", port)
+        transport = controller._transport
+        assert transport._request_allowed("evil.example:%d" % port,
+                                          None) is False
+    finally:
+        controller.stop()
 
 
 # --- lifecycle -------------------------------------------------------------

--- a/tests/unit/test_mcp_sse_transport.py
+++ b/tests/unit/test_mcp_sse_transport.py
@@ -350,21 +350,56 @@ def test_http_entry_point_delegates_to_the_shared_controller(monkeypatch):
     started = []
 
     class _FakeController:
-        def start(self, host, port):
-            started.append((host, port))
+        def start(self, host, port, allowed_hosts=None):
+            started.append((host, port, allowed_hosts))
             return "http://%s:%d/sse" % (host, port)
 
     import freecad_ai.mcp.gui_server as gui_server
     monkeypatch.setattr(gui_server, "get_server_controller",
                         lambda: _FakeController())
 
-    # Pin both so the assertion cannot depend on the developer's config.json.
+    # Pin all three so the assertion cannot depend on the developer's
+    # config.json or environment.
     monkeypatch.setenv("MCP_HOST", "127.0.0.1")
     monkeypatch.setenv("MCP_PORT", "3131")
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
 
     exec(compile(source, "mcp_server_http.py", "exec"), {})
 
-    assert started == [("127.0.0.1", 3131)]
+    # allowed_hosts stays None with nothing configured, so the transport keeps
+    # deriving its own default — and with it the wildcard-bind rejection.
+    assert started == [("127.0.0.1", 3131, None)]
+
+
+def test_http_entry_point_forwards_the_allowed_hosts_env_var(monkeypatch):
+    """MCP_ALLOWED_HOSTS must reach the transport, not just parse cleanly."""
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    source = (repo_root / "mcp_server_http.py").read_text()
+
+    fake_freecad = types.ModuleType("FreeCAD")
+    fake_freecad.ActiveDocument = object()
+    fake_freecad.newDocument = lambda name: None
+    monkeypatch.setitem(sys.modules, "FreeCAD", fake_freecad)
+
+    started = []
+
+    class _FakeController:
+        def start(self, host, port, allowed_hosts=None):
+            started.append((host, port, allowed_hosts))
+            return "http://%s:%d/sse" % (host, port)
+
+    import freecad_ai.mcp.gui_server as gui_server
+    monkeypatch.setattr(gui_server, "get_server_controller",
+                        lambda: _FakeController())
+
+    monkeypatch.setenv("MCP_HOST", "192.168.1.50")
+    monkeypatch.setenv("MCP_PORT", "3131")
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "fileserver.local, 192.168.1.50")
+
+    exec(compile(source, "mcp_server_http.py", "exec"), {})
+
+    assert started == [("192.168.1.50", 3131,
+                        ["fileserver.local", "192.168.1.50"])]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_sse_transport.py
+++ b/tests/unit/test_mcp_sse_transport.py
@@ -144,6 +144,22 @@ def test_request_allows_explicitly_configured_bind_host():
     assert transport._request_allowed("192.168.1.5:3000", None) is True
 
 
+@pytest.mark.parametrize("wildcard_host", ["0.0.0.0", "::"])
+def test_wildcard_bind_host_rejected_instead_of_locking_out_every_client(
+        wildcard_host):
+    # A wildcard bind address is not a name any real client's Host header
+    # ever carries, so seeding the default allowlist from it locks out every
+    # LAN client instead of the loopback-only client it was meant to guard.
+    with pytest.raises(OSError, match="MCP_HOST"):
+        SSEServerTransport(host=wildcard_host)
+
+
+def test_wildcard_bind_host_allowed_with_explicit_allowed_hosts():
+    transport = SSEServerTransport(
+        host="0.0.0.0", allowed_hosts=["fileserver.local"])
+    assert transport._request_allowed("fileserver.local:3000", None) is True
+
+
 def test_cross_origin_post_rejected_and_no_wildcard_cors_header():
     transport = SSEServerTransport(host="127.0.0.1", port=0)
     transport._handler = lambda msg: {

--- a/tests/unit/test_settings_dialog_mcp_address.py
+++ b/tests/unit/test_settings_dialog_mcp_address.py
@@ -53,3 +53,37 @@ def test_privileged_ports_are_allowed():
     through the same modal as any other bind failure.
     """
     assert parse("127.0.0.1", "80") == ("127.0.0.1", 80)
+
+
+# --- allowed Host headers --------------------------------------------------
+#
+# Same contract as the address fields: the dialog must always be closable, so
+# unusable input is dropped rather than raised on. The env-var path
+# (resolve_allowed_hosts) refuses a "*" loudly instead, because there is no
+# dialog there and a traceback is the only feedback available.
+
+parse_hosts = SettingsDialog._parse_allowed_hosts
+
+
+def test_allowed_hosts_empty_field_means_the_transport_default():
+    assert parse_hosts("") == []
+    assert parse_hosts("   ") == []
+
+
+def test_allowed_hosts_splits_and_strips():
+    assert parse_hosts("fileserver.local, 192.168.1.50") == [
+        "fileserver.local", "192.168.1.50"]
+
+
+def test_allowed_hosts_drops_blank_entries():
+    assert parse_hosts("box.lan, ,, 10.0.0.7,") == ["box.lan", "10.0.0.7"]
+
+
+def test_allowed_hosts_drops_a_wildcard_entry_keeping_the_rest():
+    # Dropped, not raised on: the dialog must stay closable. The warning
+    # under the field is what tells the user why "*" is not honoured.
+    assert parse_hosts("box.lan, *") == ["box.lan"]
+
+
+def test_allowed_hosts_a_lone_wildcard_falls_back_to_the_default():
+    assert parse_hosts("*") == []


### PR DESCRIPTION
## Root cause

`SSEServerTransport.__init__` (`freecad_ai/mcp/transport.py`) seeds its default
Host-header allowlist from the bind address:

```python
allowed_hosts = _LOOPBACK_HOSTS | {host.lower()}
```

With `MCP_HOST=0.0.0.0` that adds the literal string `"0.0.0.0"` to the
allowlist. No real client's `Host` header ever names a wildcard address, so
`_request_allowed()` rejects every non-loopback client even though the socket
is genuinely listening on every interface.

## Fix

The issue's own analysis lays out three options and prefers option 2 in the
short term: widening the allowlist to accept any Host on a wildcard bind
(option 1) would remove the only thing currently standing between a wildcard
bind and unauthenticated remote tool execution, since #59 (optional auth)
hasn't landed yet.

This takes that option: `SSEServerTransport.__init__` now raises `OSError`
with an actionable message when `host` is a wildcard bind address (`0.0.0.0`
or `::`) and `allowed_hosts` wasn't given explicitly. On the toolbar path this
surfaces as the existing modal failure report (`InitGui.py` already catches
`OSError` from `ServerController.start()`); on the command-line/`exec()` path
it's a plain traceback instead of a silent, unexplained 403 later. Passing
`allowed_hosts` explicitly still opts into a wider policy for advanced
deployments, unchanged.

## Verification

- New `test_wildcard_bind_host_rejected_instead_of_locking_out_every_client`
  (parametrized over `0.0.0.0` and `::`) fails on unmodified HEAD (`a064d6d`,
  no error raised, wildcard silently accepted) and passes on this branch;
  ran both in the same container with only the source file swapped,
  `__file__` printed to confirm provenance.
- `test_wildcard_bind_host_allowed_with_explicit_allowed_hosts` confirms the
  explicit-`allowed_hosts` escape hatch still works.
- Full `tests/unit/` (Python 3.12, no FreeCAD): 1097 passed, 16 skipped, 17
  failed. The 17 failures are identical on unmodified HEAD with no diff
  applied (missing `PySide2`/`PySide6` in this container, unrelated to MCP
  transport).
- Did not check the toolbar's modal dialog path against a real FreeCAD GUI;
  verified only that `InitGui.py`'s existing `except OSError` around
  `controller.start()` matches the exception type this raises.

Fixes #60
