### PR TITLE
Add OpenCode Zen/Go provider + chat pane fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An AI-powered assistant workbench for FreeCAD that generates and executes Python
 - **Thinking mode** — enable LLM reasoning for complex multi-step tasks (Off / On / Extended)
 - **Context compacting** — automatically summarizes older messages when approaching context limits
 - **Session resume** — save and load chat sessions to continue work later
-- **20 LLM providers** — Anthropic, OpenAI, Ollama, Gemini, OpenRouter, Moonshot, DeepSeek, Qwen, Groq, Mistral, Together, Fireworks, xAI, Cohere, SambaNova, MiniMax, Llama, GitHub Models, HuggingFace, Zhipu, plus any OpenAI-compatible endpoint via Custom
+- **22 LLM providers** — Anthropic, OpenAI, Ollama, Gemini, OpenRouter, Moonshot, DeepSeek, Qwen, Groq, Mistral, Together, Fireworks, xAI, Cohere, SambaNova, MiniMax, Llama, GitHub Models, HuggingFace, Zhipu, OpenCode (Zen/Go), plus any OpenAI-compatible endpoint via Custom
 - **Context-aware** — automatically includes document state (objects, properties, selection) in prompts
 - **Error self-correction** — failed code is sent back to the LLM for automatic retry (up to 3 attempts)
 - **AGENTS.md support** — project-level instructions with include directives and variable substitution
@@ -173,6 +173,8 @@ To populate the stores once:
 | GitHub | Yes (PAT) | GitHub Models marketplace |
 | HuggingFace | Yes (`hf_...`) | Serverless inference API |
 | Zhipu | Yes | GLM models (z.ai international) |
+| OpenCode Zen | Yes | Pay-as-you-go via opencode.ai; dynamic model list, reasoning variants |
+| OpenCode Go | Yes | $10/mo subscription via opencode.ai; dynamic model list, reasoning variants |
 | Custom | Varies | Any OpenAI-compatible endpoint |
 
 ### Model Parameters

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -496,6 +496,16 @@ class AppConfig:
     # is naturally bounded by the number of distinct documents ever edited.
     max_backups: int = 0
 
+    # OpenCode bar: last selected model and variant (persisted across sessions)
+    oc_last_model: str = ""
+    oc_last_variant: str = ""
+
+    # Opt-in fallback to unverified TLS (ssl._create_unverified_context) for
+    # environments where the system trust store is unavailable or broken
+    # (snap sandboxes, stripped cert bundles). Default False: certificate
+    # verification failures abort the request instead of silently downgrading.
+    allow_insecure_ssl: bool = False
+
     @property
     def supports_vision(self) -> bool:
         """Whether the current LLM supports vision (images in content blocks)."""
@@ -593,6 +603,7 @@ def save_config(config: AppConfig):
 _PARAM_PROVIDERS = [
     "anthropic", "openai", "ollama", "gemini", "openrouter",
     "moonshot", "deepseek", "qwen", "groq", "mistral", "together",
+    "opencodezen", "opencodego",
 ]
 _PARAM_MODES = ["plan", "act"]
 _PARAM_THINKING = ["off", "on", "extended"]

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -32,6 +32,19 @@ from .providers import get_api_style
 ANTHROPIC_API_VERSION = "2023-06-01"
 
 
+def _insecure_ssl_allowed() -> bool:
+    """Read the user's opt-in flag for unverified TLS fallback.
+
+    Import is deferred so this module stays importable without config
+    (e.g. headless tests). Any failure resolves to False (secure default).
+    """
+    try:
+        from ..config import get_config
+        return bool(get_config().allow_insecure_ssl)
+    except Exception:
+        return False
+
+
 @dataclass
 class ToolCall:
     """A tool call requested by the LLM."""
@@ -160,10 +173,19 @@ class LLMClient:
             try:
                 self._ssl_ctx = ssl.create_default_context()
             except Exception:
-                # Cert store unavailable (e.g. snap sandbox)
-                self._ssl_ctx = ssl._create_unverified_context()
+                # Cert store unavailable (e.g. snap sandbox). Only fall back
+                # to unverified TLS when the user explicitly opted in via
+                # Settings → allow_insecure_ssl; otherwise keep verification
+                # (urlopen with context=None uses the default verified ctx).
+                if _insecure_ssl_allowed():
+                    self._ssl_ctx = ssl._create_unverified_context()
+                else:
+                    self._ssl_ctx = None
         else:
             self._ssl_ctx = None
+
+        # Active HTTP response — closed by cancel() to break blocking reads
+        self._current_response = None
 
     # ── API key resolution ─────────────────────────────────────
 
@@ -413,7 +435,15 @@ class LLMClient:
         if tools:
             body["tools"] = tools
             body["tool_choice"] = "auto"
-        # OpenAI reasoning models (o1, o3, etc.)
+
+        # Reasoning effort — sent for both tool and non-tool modes so
+        # OpenCode Zen/Go reasoning models get the effort level even
+        # when function calling is active.
+        # Check model_params first (set by variant slider), then fall
+        # back to thinking config.
+        effort_from_params = self.model_params.get("reasoning_effort")
+        if effort_from_params:
+            body["reasoning_effort"] = effort_from_params
         elif self.thinking != "off":
             effort_map = {"on": "medium", "extended": "high"}
             body["reasoning_effort"] = effort_map.get(self.thinking, "medium")
@@ -825,6 +855,7 @@ class LLMClient:
             req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
             try:
                 resp = urllib.request.urlopen(req, context=ctx, timeout=timeout)
+                self._current_response = resp
                 break
             except urllib.error.HTTPError as e:
                 if e.code == 429 and attempt < self._MAX_RETRIES:
@@ -870,8 +901,26 @@ class LLMClient:
                             yield json.loads(json_str)
                         except json.JSONDecodeError:
                             continue
+        except (AttributeError, ValueError):
+            # Response was closed by cancel() — buffer is None or
+            # the underlying socket was shut down. Exit gracefully.
+            return
         finally:
             resp.close()
+            self._current_response = None
+
+    def cancel(self):
+        """Cancel any in-flight streaming request by closing the HTTP response.
+
+        This breaks the blocking readline() in _http_stream so the worker
+        thread can check isInterruptionRequested() and exit promptly.
+        """
+        resp = self._current_response
+        if resp is not None:
+            try:
+                resp.close()
+            except Exception:
+                pass
 
 
 # Models that require thinking content to be stripped from conversation

--- a/freecad_ai/llm/providers.py
+++ b/freecad_ai/llm/providers.py
@@ -144,6 +144,20 @@ PROVIDERS = {
         "api_style": "openai",
         "supports_tools": True,
     },
+    "opencodezen": {
+        "base_url": "https://opencode.ai/zen/v1",
+        "default_model": "deepseek-v4-pro",
+        "api_style": "openai",
+        "supports_tools": True,
+        "display_name": "OpenCode Zen",
+    },
+    "opencodego": {
+        "base_url": "https://opencode.ai/zen/go/v1",
+        "default_model": "deepseek-v4-pro",
+        "api_style": "openai",
+        "supports_tools": True,
+        "display_name": "OpenCode Go",
+    },
     "custom": {
         "base_url": "",
         "default_model": "",

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -10,7 +10,11 @@ tool calls on the main thread, feed results back to the LLM.
 """
 
 import json
+import os
 import time
+import threading
+import urllib.request
+import urllib.error
 
 from .compat import QtWidgets, QtCore, QtGui
 from ..i18n import translate
@@ -244,13 +248,22 @@ class _LLMWorker(QThread):
         self._tool_timeline = []  # timing data for summary visualization
         self._response_truncated = False  # response hit the output-token limit
 
+        # Streaming deltas are batched before emission. Emitting one queued
+        # signal per tiny chunk saturates the GUI event loop (every queued
+        # delivery is still processed there), which froze the UI during fast
+        # reasoning traces. Batching to a character threshold keeps the signal
+        # rate low enough that paint/hover events stay responsive.
+        self._text_buf = ""
+        self._think_buf = ""
+        self._EMIT_BATCH = 512
+
     def run(self):
         try:
             from ..llm.client import create_client_from_config, should_strip_thinking
             from ..config import get_config as _get_config
-            client = create_client_from_config()
+            self._client = create_client_from_config()
             self._strip_thinking = should_strip_thinking(
-                client.model, _get_config().strip_thinking_history)
+                self._client.model, _get_config().strip_thinking_history)
 
             # Re-format messages with image interception on worker thread
             if self.conversation and self.describe_fn:
@@ -262,11 +275,11 @@ class _LLMWorker(QThread):
 
             if not self.tools:
                 # Simple non-tool streaming (backward compat)
-                self._simple_stream(client)
+                self._simple_stream(self._client)
                 return
 
             # Agentic tool loop
-            self._tool_loop(client)
+            self._tool_loop(self._client)
 
         except Exception as e:
             self.error_occurred.emit(str(e))
@@ -289,7 +302,13 @@ class _LLMWorker(QThread):
             if self.isInterruptionRequested():
                 break
             self._full_response += chunk
-            self.token_received.emit(chunk)
+            self._text_buf += chunk
+            if len(self._text_buf) >= self._EMIT_BATCH:
+                self.token_received.emit(self._text_buf)
+                self._text_buf = ""
+        if self._text_buf:
+            self.token_received.emit(self._text_buf)
+            self._text_buf = ""
         self._response_truncated = client.response_truncated
         self.response_finished.emit(self._full_response)
 
@@ -312,11 +331,17 @@ class _LLMWorker(QThread):
                 if event.type == "text_delta":
                     text_parts.append(event.text)
                     self._full_response += event.text
-                    self.token_received.emit(event.text)
+                    self._text_buf += event.text
+                    if len(self._text_buf) >= self._EMIT_BATCH:
+                        self.token_received.emit(self._text_buf)
+                        self._text_buf = ""
                 elif event.type == "thinking_delta":
                     thinking_parts.append(event.text)
                     self._thinking_text += event.text
-                    self.thinking_received.emit(event.text)
+                    self._think_buf += event.text
+                    if len(self._think_buf) >= self._EMIT_BATCH:
+                        self.thinking_received.emit(self._think_buf)
+                        self._think_buf = ""
                 elif event.type == "tool_call_start":
                     if event.tool_call:
                         self.tool_call_started.emit(event.tool_call.name, event.tool_call.id)
@@ -325,6 +350,15 @@ class _LLMWorker(QThread):
                         tool_calls.append(event.tool_call)
                 elif event.type == "done":
                     break
+
+            # Flush any buffered deltas so the user sees this turn's text/thinking
+            # before tool execution or the final response is emitted.
+            if self._think_buf:
+                self.thinking_received.emit(self._think_buf)
+                self._think_buf = ""
+            if self._text_buf:
+                self.token_received.emit(self._text_buf)
+                self._text_buf = ""
 
             turn_text = "".join(text_parts)
             turn_thinking = "".join(thinking_parts)
@@ -513,6 +547,17 @@ class _LLMWorker(QThread):
         self._pending_result = result
         self._tool_result_wait.wakeAll()
         self._tool_result_ready.unlock()
+
+    def cancel(self):
+        """Cancel the in-flight LLM request by closing the HTTP response.
+
+        This breaks the blocking readline() in the stream generator so
+        the worker thread can exit promptly when interrupted.
+        """
+        self.requestInterruption()
+        client = getattr(self, '_client', None)
+        if client is not None:
+            client.cancel()
 
 
 class _CompactionWorker(QThread):
@@ -810,6 +855,11 @@ class _AttachmentStrip(QtWidgets.QWidget):
 class ChatDockWidget(QDockWidget):
     """Main chat dock widget for FreeCAD AI."""
 
+    # Emitted from the background model-fetch thread with the list of model ids.
+    oc_models_ready = Signal(list)
+    # Emitted when per-model metadata has been fetched and cached off-thread.
+    oc_meta_ready = Signal()
+
     def __init__(self, parent=None):
         super().__init__(translate("ChatDockWidget", "FreeCAD AI"), parent)
         self.setObjectName("FreeCADAIChatDock")
@@ -822,6 +872,17 @@ class ChatDockWidget(QDockWidget):
                                               # _set_input_text() to guard a
                                               # future textChanged-based reset
         self._streaming_html = ""
+        # Streaming deltas are buffered and flushed on a timer rather than
+        # inserted one-by-one. A high-frequency token/thinking stream (e.g.
+        # xhigh reasoning) can emit thousands of tiny deltas; queuing each as
+        # a separate GUI-thread insertText saturates the event loop and makes
+        # the app appear frozen during long reasoning traces.
+        self._pending_think = ""
+        self._pending_text = ""
+        self._flush_timer = QtCore.QTimer(self)
+        self._flush_timer.setInterval(40)
+        self._flush_timer.setSingleShot(False)
+        self._flush_timer.timeout.connect(self._flush_stream)
         self._retry_count = 0
         self._anchor_connected = False
         self._tool_registry = None
@@ -855,6 +916,10 @@ class ChatDockWidget(QDockWidget):
         self.topLevelChanged.connect(self._save_dock_state)
         # visibilityChanged catches tabify when our dock becomes a background tab
         self.visibilityChanged.connect(self._save_dock_state)
+
+        # OpenCode model list fetched off the GUI thread; results arrive here.
+        self.oc_models_ready.connect(self._populate_oc_model_dropdown)
+        self.oc_meta_ready.connect(self._on_oc_meta_loaded)
 
         # Debounced save for tabify-by-drag. Tabification emits no dedicated
         # Qt signal, but the dock's geometry changes when it joins a tab group,
@@ -1066,7 +1131,46 @@ class ChatDockWidget(QDockWidget):
         self.chat_display.setFont(QFont("Sans", 10))
         self.chat_display.setStyleSheet(get_chat_display_stylesheet())
         self.chat_display.anchorClicked.connect(self._handle_anchor_click)
+        self._auto_scroll = True  # track whether to follow new content
+        self.chat_display.verticalScrollBar().valueChanged.connect(
+            self._on_scrollbar_value_changed)
         layout.addWidget(self.chat_display, 1)
+
+        # ── OpenCode status bar (model + variant + context/cost) ──
+        self._opencode_bar = QWidget()
+        ob = QHBoxLayout(self._opencode_bar)
+        ob.setContentsMargins(4, 2, 4, 2)
+        ob.setSpacing(8)
+
+        ob.addWidget(QLabel(translate("ChatDockWidget", "Model:")))
+        self._oc_model_combo = QComboBox()
+        self._oc_model_combo.setMinimumContentsLength(15)
+        self._oc_model_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self._oc_model_combo.currentIndexChanged.connect(self._on_oc_model_changed)
+        ob.addWidget(self._oc_model_combo, 1)
+
+        ob.addWidget(QLabel(translate("ChatDockWidget", "Variant:")))
+        self._oc_variant_combo = QComboBox()
+        self._oc_variant_combo.setMinimumWidth(100)
+        self._oc_variant_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self._oc_variant_combo.currentIndexChanged.connect(self._on_oc_variant_changed)
+        ob.addWidget(self._oc_variant_combo)
+
+        self._oc_context_label = QLabel("")
+        _oc_color = _get_theme_colors()['thinking_text']
+        self._oc_context_label.setStyleSheet(f"color: {_oc_color}; font-size: 11px;")
+        ob.addWidget(self._oc_context_label)
+
+        self._oc_cost_label = QLabel("")
+        self._oc_cost_label.setStyleSheet(f"color: {_oc_color}; font-size: 11px;")
+        ob.addWidget(self._oc_cost_label)
+
+        self._opencode_bar.setVisible(False)
+        layout.addWidget(self._opencode_bar)
+
+        # Model metadata cache: {provider_id: {model_id: {...}}}
+        self._oc_model_meta = {}
+        self._oc_current_variant = ""
 
         # ── Attachment strip ──
         self._attachment_strip = _AttachmentStrip()
@@ -1153,8 +1257,9 @@ class ChatDockWidget(QDockWidget):
         self.setWidget(container)
 
         # Sync banner/toggle with current dangerous-mode state
-        # (shows banner at startup if dangerous_skip_safety was hand-edited in config.json)
         self._update_danger_banner()
+
+        # OpenCode bar updated in showEvent when widget becomes visible
 
     # ── Dangerous-mode toggle ──────────────────────────────
 
@@ -1207,10 +1312,11 @@ class ChatDockWidget(QDockWidget):
     # ── Theme refresh on show ──────────────────────────────
 
     def showEvent(self, event):
-        """Refresh theme colors when the widget becomes visible."""
+        """Refresh theme colors and OpenCode bar when widget becomes visible."""
         super().showEvent(event)
         refresh_theme_cache()
         self._apply_theme()
+        self._update_opencode_bar()
 
     def _resolve_stylesheet_conflict(self, theme_name: str):
         """OpenDark/OpenLight theme packs inject global QPushButton styles that
@@ -1380,7 +1486,7 @@ class ChatDockWidget(QDockWidget):
             # Button is in "Stop" state — interrupt the in-flight run instead
             # of sending. Input is usually empty here, so this must run before
             # the empty-text guard below.
-            self._worker.requestInterruption()
+            self._worker.cancel()
             return
 
         text = self.input_edit.toPlainText().strip()
@@ -1390,6 +1496,7 @@ class ChatDockWidget(QDockWidget):
         self.input_edit.clear()
         self._retry_count = 0  # Reset retries for new user message
         self._active_skill_name = ""
+        self._auto_scroll = True  # Follow new content after sending
 
         # Check for --validate flag
         self._validate_pending = False
@@ -2026,11 +2133,17 @@ class ChatDockWidget(QDockWidget):
         # Start streaming
         self._set_loading(True)
         self._streaming_html = ""
+        self._pending_think = ""
+        self._pending_text = ""
+        self._flush_timer.stop()
         self._append_html(
-            '<div style="margin: 8px 0; padding: 8px 12px; '
-            'background-color: #f5f5f5; border-radius: 6px;">'
-            '<div style="font-weight: bold; color: #2e7d32; margin-bottom: 4px;">AI</div>'
-            '<div style="white-space: pre-wrap;">'
+            '<div style="clear: both; margin: 16px 0 8px 0; padding: 8px 12px; '
+            'background-color: {}; border-radius: 6px;">'
+            '<div style="font-weight: bold; color: {}; margin-bottom: 4px;">AI</div>'
+            '<div style="white-space: pre-wrap;">'.format(
+                _get_theme_colors()['assistant_bg'],
+                _get_theme_colors()['assistant_label'],
+            )
         )
 
         self._in_thinking = False
@@ -2142,53 +2255,77 @@ class ChatDockWidget(QDockWidget):
 
     @Slot(str)
     def _on_thinking(self, chunk):
-        """Handle a thinking/reasoning delta — render dimmed."""
-        import html as html_mod
+        """Handle a thinking/reasoning delta — buffer for throttled insert."""
         if not self._in_thinking:
             self._in_thinking = True
+            colors = _get_theme_colors()
             # Start a thinking block
             cursor = self.chat_display.textCursor()
             cursor.movePosition(QTextCursor.End)
             cursor.insertHtml(
                 '<div style="margin: 4px 0; padding: 4px 8px; '
-                'background-color: #f0f0f0; border-left: 2px solid #ccc; '
-                'font-size: 11px; color: #888; font-style: italic;">'
-                '<span style="color: #aaa;">{}</span><br>'.format(
-                    translate("ChatDockWidget", "Thinking..."))
+                'background-color: {bg}; border-left: 2px solid {border}; '
+                'font-size: 11px; color: {text}; font-style: italic;">'
+                '<span style="color: {label};">{}</span><br>'.format(
+                    translate("ChatDockWidget", "Thinking..."),
+                    bg=colors['thinking_bg'],
+                    border=colors['thinking_border'],
+                    text=colors['thinking_text'],
+                    label=colors['thinking_label'],
+                )
             )
             self.chat_display.setTextCursor(cursor)
 
-        escaped = html_mod.escape(chunk)
-        escaped = escaped.replace("\n", "<br>")
-
-        cursor = self.chat_display.textCursor()
-        cursor.movePosition(QTextCursor.End)
-        cursor.insertHtml(f'<span style="color: #999; font-size: 11px;">{escaped}</span>')
-        self.chat_display.setTextCursor(cursor)
-        self.chat_display.ensureCursorVisible()
+        self._pending_think += chunk
+        if not self._flush_timer.isActive():
+            self._flush_timer.start()
 
     @Slot(str)
     def _on_token(self, chunk):
-        """Handle a streamed token — append to the display."""
-        import html as html_mod
-
-        # Close thinking block if transitioning from thinking to regular content
+        """Handle a streamed token — buffer for throttled insert."""
+        # Mark that thinking has ended; the flush closes the thinking div.
         if self._in_thinking:
             self._in_thinking = False
+
+        self._streaming_html += chunk
+        self._pending_text += chunk
+        if not self._flush_timer.isActive():
+            self._flush_timer.start()
+
+    def _flush_stream(self):
+        """Flush buffered thinking/text deltas at a throttled rate.
+
+        Inserting every streamed delta individually queues one GUI-thread
+        insertText per delta. At high token rates (xhigh reasoning) that
+        floods the event loop and freezes the UI; batching into ~25 flushes/sec
+        keeps the interface responsive while preserving correct spacing/text.
+        """
+        flushed = False
+        if self._pending_think:
             cursor = self.chat_display.textCursor()
             cursor.movePosition(QTextCursor.End)
-            cursor.insertHtml('</div>')
+            cursor.insertText(self._pending_think)
             self.chat_display.setTextCursor(cursor)
-
-        escaped = html_mod.escape(chunk)
-        escaped = escaped.replace("\n", "<br>")
-        self._streaming_html += chunk
-
-        cursor = self.chat_display.textCursor()
-        cursor.movePosition(QTextCursor.End)
-        cursor.insertHtml(escaped)
-        self.chat_display.setTextCursor(cursor)
-        self.chat_display.ensureCursorVisible()
+            self._pending_think = ""
+            flushed = True
+        if self._pending_text:
+            # Thinking ended — close its div before appending normal text.
+            if self._in_thinking:
+                cursor = self.chat_display.textCursor()
+                cursor.movePosition(QTextCursor.End)
+                cursor.insertHtml('</div>')
+                self.chat_display.setTextCursor(cursor)
+                self._in_thinking = False
+            cursor = self.chat_display.textCursor()
+            cursor.movePosition(QTextCursor.End)
+            cursor.insertText(self._pending_text)
+            self.chat_display.setTextCursor(cursor)
+            self._pending_text = ""
+            flushed = True
+        if flushed:
+            self._scroll_to_bottom_if_needed()
+        if not self._pending_think and not self._pending_text:
+            self._flush_timer.stop()
 
     def _store_tool_results(self, full_response=""):
         """Store tool results from worker into conversation. Idempotent — skips if already stored."""
@@ -2231,12 +2368,23 @@ class ChatDockWidget(QDockWidget):
     @Slot(str)
     def _on_response_finished(self, full_response):
         """Handle completion of LLM response."""
+        # Flush any buffered deltas (and close the thinking div) before we
+        # close the streaming wrapper and re-render.
+        self._flush_stream()
+        self._flush_timer.stop()
+        if self._in_thinking:
+            cursor = self.chat_display.textCursor()
+            cursor.movePosition(QTextCursor.End)
+            cursor.insertHtml('</div>')
+            self.chat_display.setTextCursor(cursor)
+            self._in_thinking = False
         self._set_loading(False)
 
         # Close the streaming div
         cursor = self.chat_display.textCursor()
         cursor.movePosition(QTextCursor.End)
         cursor.insertHtml("</div></div>")
+        self.chat_display.setTextCursor(cursor)
 
         # Store in conversation - include any tool call info from the worker
         self._store_tool_results(full_response)
@@ -2258,7 +2406,11 @@ class ChatDockWidget(QDockWidget):
         if self._worker and self._worker._tool_results:
             self._auto_save_log()
 
-        # Re-render the full chat to get proper code block formatting
+        # Re-render the full chat to get proper code block formatting,
+        # markdown (bold/italic/inline code) and Plan-mode Execute/Copy
+        # buttons. The stored conversation text carries correct spaces;
+        # setHtml() renders it faithfully. Live streaming used insertText()
+        # so the user never sees missing spaces while tokens arrive.
         self._rerender_chat()
 
         # Warn when the model ran out of output budget mid-answer. Without this
@@ -2374,6 +2526,16 @@ class ChatDockWidget(QDockWidget):
         without re-rendering (to keep the streaming HTML intact).
         """
         self._set_loading(False)
+
+        # Flush any buffered deltas and close the thinking div first
+        self._flush_stream()
+        self._flush_timer.stop()
+        if self._in_thinking:
+            cursor = self.chat_display.textCursor()
+            cursor.movePosition(QTextCursor.End)
+            cursor.insertHtml('</div>')
+            self.chat_display.setTextCursor(cursor)
+            self._in_thinking = False
 
         # Close the streaming div
         cursor = self.chat_display.textCursor()
@@ -2535,11 +2697,17 @@ class ChatDockWidget(QDockWidget):
 
         self._set_loading(True)
         self._streaming_html = ""
+        self._pending_think = ""
+        self._pending_text = ""
+        self._flush_timer.stop()
         self._append_html(
-            '<div style="margin: 8px 0; padding: 8px 12px; '
-            'background-color: #f5f5f5; border-radius: 6px;">'
-            '<div style="font-weight: bold; color: #2e7d32; margin-bottom: 4px;">AI</div>'
-            '<div style="white-space: pre-wrap;">'
+            '<div style="clear: both; margin: 16px 0 8px 0; padding: 8px 12px; '
+            'background-color: {}; border-radius: 6px;">'
+            '<div style="font-weight: bold; color: {}; margin-bottom: 4px;">AI</div>'
+            '<div style="white-space: pre-wrap;">'.format(
+                _get_theme_colors()['assistant_bg'],
+                _get_theme_colors()['assistant_label'],
+            )
         )
 
         self._tool_results_stored = False
@@ -2635,16 +2803,349 @@ class ChatDockWidget(QDockWidget):
 
     # ── UI helpers ──────────────────────────────────────────
 
+    def _on_scrollbar_value_changed(self, value):
+        """Track whether the user is at the bottom of the chat."""
+        sb = self.chat_display.verticalScrollBar()
+        # Consider "at bottom" if within 40px of the end
+        self._auto_scroll = (sb.maximum() - value) < 40
+
+    def _scroll_to_bottom_if_needed(self):
+        """Scroll to bottom only if the user was already near the bottom."""
+        if self._auto_scroll:
+            sb = self.chat_display.verticalScrollBar()
+            sb.setValue(sb.maximum())
+
     def _append_html(self, html_str):
-        """Append HTML to the chat display and scroll to bottom."""
+        """Append HTML to the chat display and scroll to bottom if at bottom."""
         cursor = self.chat_display.textCursor()
         cursor.movePosition(QTextCursor.End)
+        cursor.insertBlock()
         cursor.insertHtml(html_str)
         self.chat_display.setTextCursor(cursor)
-        self.chat_display.ensureCursorVisible()
+        self._scroll_to_bottom_if_needed()
+
+    # ── OpenCode status bar helpers ──────────────────────────
+
+    _OC_PROVIDERS = {"opencodezen", "opencodego"}
+
+    _MODELS_API = {
+        "opencodezen": "https://opencode.ai/zen/v1/models",
+        "opencodego": "https://opencode.ai/zen/go/v1/models",
+    }
+
+    def _is_opencode_provider(self) -> bool:
+        cfg = get_config()
+        return cfg.provider.name in self._OC_PROVIDERS
+
+    def _update_opencode_bar(self):
+        """Show/hide and populate the OpenCode bar based on current provider."""
+        if self._is_opencode_provider():
+            self._opencode_bar.setVisible(True)
+            self._fetch_oc_models_from_api()
+        else:
+            self._opencode_bar.setVisible(False)
+
+    def _fetch_oc_models_from_api(self):
+        """Fetch model list from the OpenCode API endpoint.
+
+        Runs the (potentially slow / blocking) network call on a background
+        thread so the UI never freezes while DNS/TLS is in flight. Results are
+        delivered to the GUI thread via the ``oc_models_ready`` signal.
+        """
+        cfg = get_config()
+        api_url = self._MODELS_API.get(cfg.provider.name)
+        if not api_url:
+            return
+        api_key = cfg.provider.api_key
+        threading.Thread(
+            target=self._fetch_oc_models_from_api_thread,
+            args=(api_url, api_key),
+            daemon=True,
+        ).start()
+
+    def _fetch_oc_models_from_api_thread(self, api_url, api_key):
+        """Background thread: fetch the OpenCode model list (network call)."""
+        try:
+            headers = {"Content-Type": "application/json", "User-Agent": "FreeCAD-AI"}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            req = urllib.request.Request(api_url, headers=headers)
+            ctx = None
+            if api_url.startswith("https"):
+                import ssl
+                cfg = get_config()
+                ctx = (ssl._create_unverified_context() if cfg.allow_insecure_ssl
+                       else ssl.create_default_context())
+            resp = urllib.request.urlopen(req, context=ctx, timeout=5)
+            try:
+                data = json.loads(resp.read().decode("utf-8"))
+            finally:
+                resp.close()
+
+            models = sorted([m["id"] for m in data.get("data", []) if m.get("id")])
+            if models:
+                # _populate_oc_model_dropdown touches GUI widgets — marshal to
+                # the main thread via the signal (auto-queued across threads).
+                self.oc_models_ready.emit(models)
+        except Exception:
+            pass
+
+    def _populate_oc_model_dropdown(self, models: list[str]):
+        """Populate the OpenCode model combo from API model list."""
+        self._oc_model_combo.blockSignals(True)
+        self._oc_model_combo.clear()
+        cfg = get_config()
+
+        for mid in models:
+            self._oc_model_combo.addItem(mid, mid)
+
+        # Restore last selected model
+        saved = cfg.oc_last_model
+        if saved:
+            for i in range(self._oc_model_combo.count()):
+                if self._oc_model_combo.itemData(i) == saved:
+                    self._oc_model_combo.setCurrentIndex(i)
+                    break
+        elif self._oc_model_combo.count() > 0:
+            self._oc_model_combo.setCurrentIndex(0)
+
+        self._oc_model_combo.blockSignals(False)
+        self._update_oc_variants()
+        self._fetch_oc_model_meta()
+        self._update_oc_context_cost(self.conversation.estimated_tokens())
+
+    def _fetch_oc_model_meta(self):
+        """Fetch metadata for the selected model from models.dev."""
+        model_id = self._oc_model_combo.currentData()
+        if not model_id:
+            return
+        # Check cache
+        if model_id in self._oc_model_meta.get("opencode", {}):
+            self._update_oc_variants()
+            self._update_oc_context_cost(self.conversation.estimated_tokens())
+            return
+        threading.Thread(
+            target=self._fetch_oc_model_meta_thread,
+            args=(model_id,),
+            daemon=True,
+        ).start()
+
+    def _fetch_oc_model_meta_thread(self, model_id: str):
+        """Background thread: fetch single model metadata from models.dev."""
+        try:
+            # Sanitize model_id to prevent path traversal
+            safe_id = model_id.replace("..", "").replace("/", "_").replace("\\", "_")
+            if not safe_id or len(safe_id) > 200:
+                return
+
+            # Try the direct model endpoint first
+            url = f"https://models.dev/models/{safe_id}.json"
+            req = urllib.request.Request(url, headers={"User-Agent": "FreeCAD-AI"})
+            import ssl
+            from ..config import get_config as _get_cfg
+            ctx = (ssl._create_unverified_context() if _get_cfg().allow_insecure_ssl
+                   else ssl.create_default_context())
+            try:
+                with urllib.request.urlopen(req, context=ctx, timeout=10) as resp:
+                    # Limit response size to 1MB to prevent memory exhaustion
+                    data = resp.read(1_000_000)
+                    mdata = json.loads(data.decode("utf-8"))
+                if mdata and mdata.get("name"):
+                    self._oc_model_meta.setdefault("opencode", {})[model_id] = mdata
+                    self.oc_meta_ready.emit()
+                    return
+            except Exception:
+                pass
+
+            # Fallback: search the catalog (use disk cache if available)
+            import tempfile
+            cache_path = os.path.join(tempfile.gettempdir(), "freecad_ai_models_dev.json")
+            catalog = None
+            try:
+                if os.path.exists(cache_path):
+                    with open(cache_path) as f:
+                        catalog = json.load(f)
+            except Exception:
+                pass
+
+            if catalog is None:
+                req2 = urllib.request.Request(
+                    "https://models.dev/catalog.json",
+                    headers={"User-Agent": "FreeCAD-AI"},
+                )
+                with urllib.request.urlopen(req2, context=ctx, timeout=30) as resp:
+                    # Limit catalog size to 10MB
+                    data = resp.read(10_000_000)
+                    catalog = json.loads(data.decode("utf-8"))
+                try:
+                    with open(cache_path, "w") as f:
+                        json.dump(catalog, f)
+                except Exception:
+                    pass
+
+            # Search all providers for this model
+            for pid, prov in catalog.get("providers", {}).items():
+                if model_id in prov.get("models", {}):
+                    self._oc_model_meta.setdefault("opencode", {})[model_id] = \
+                        prov["models"][model_id]
+                    self.oc_meta_ready.emit()
+                    return
+        except Exception:
+            pass
+
+    def _on_oc_meta_loaded(self):
+        """Called on main thread after metadata is fetched."""
+        self._update_oc_variants()
+        self._update_oc_context_cost(self.conversation.estimated_tokens())
+
+    def _update_oc_variants(self):
+        """Update the variant combo based on the selected model's metadata."""
+        self._oc_variant_combo.blockSignals(True)
+        self._oc_variant_combo.clear()
+        cfg = get_config()
+
+        model_id = self._oc_model_combo.currentData()
+        provider_models = self._oc_model_meta.get("opencode", {})
+        mdata = provider_models.get(model_id, {})
+
+        # Build variant list from reasoning_options
+        variants = []
+        reasoning_opts = mdata.get("reasoning_options", [])
+        for ro in reasoning_opts:
+            if ro.get("type") == "effort":
+                for v in ro.get("values", []):
+                    variants.append(v)
+
+        if not variants:
+            variants = ["none", "low", "medium", "high", "xhigh"]
+
+        self._oc_variant_combo.addItems(variants)
+
+        # Restore last selected variant
+        saved = cfg.oc_last_variant
+        if saved and saved in variants:
+            self._oc_variant_combo.setCurrentText(saved)
+        else:
+            default_v = "xhigh" if "xhigh" in variants else variants[len(variants) // 2]
+            self._oc_variant_combo.setCurrentText(default_v)
+
+        self._oc_variant_combo.blockSignals(False)
+        self._oc_current_variant = self._oc_variant_combo.currentText()
+
+    def _on_oc_model_changed(self, index):
+        """Handle model selection change in the OpenCode bar."""
+        cfg = get_config()
+        model_id = self._oc_model_combo.currentData()
+        if model_id:
+            cfg.provider.model = model_id
+            cfg.oc_last_model = model_id
+            save_current_config()
+        self._update_oc_variants()
+        self._fetch_oc_model_meta()
+        self._update_oc_context_cost(self.conversation.estimated_tokens())
+
+    def _on_oc_variant_changed(self, index):
+        """Handle variant selection change — apply variant's full settings."""
+        variant = self._oc_variant_combo.currentText()
+        if not variant:
+            return
+        self._oc_current_variant = variant
+        cfg = get_config()
+        cfg.oc_last_variant = variant
+
+        # Map variant to thinking mode
+        variant_to_thinking = {
+            "none": "off", "low": "on", "medium": "on",
+            "high": "extended", "xhigh": "extended",
+        }
+        cfg.thinking = variant_to_thinking.get(variant, "on")
+
+        # Look up variant's sampling params from models.dev metadata
+        model_id = self._oc_model_combo.currentData()
+        provider_models = self._oc_model_meta.get("opencode", {})
+        mdata = provider_models.get(model_id, {})
+        variant_params = mdata.get("variants", {}).get(variant, {})
+
+        model = cfg.provider.model
+        cfg.model_params.setdefault(model, {})
+
+        # Apply reasoning effort
+        variant_to_effort = {
+            "none": "none", "low": "low", "medium": "medium",
+            "high": "high", "xhigh": "xhigh",
+        }
+        cfg.model_params[model]["reasoning_effort"] = \
+            variant_to_effort.get(variant, "medium")
+
+        # Apply sampling params from variant (camelCase → snake_case)
+        camel_to_snake = {
+            "temperature": "temperature",
+            "topP": "top_p",
+            "topK": "top_k",
+            "minP": "min_p",
+            "presencePenalty": "presence_penalty",
+            "frequencyPenalty": "frequency_penalty",
+        }
+        for camel, snake in camel_to_snake.items():
+            if camel in variant_params:
+                cfg.model_params[model][snake] = variant_params[camel]
+
+        save_current_config()
+
+    def _update_oc_context_cost(self, current_tokens=0):
+        """Update context size and estimated cost labels."""
+        model_id = self._oc_model_combo.currentData()
+        if not model_id:
+            return
+
+        provider_models = self._oc_model_meta.get("opencode", {})
+        mdata = provider_models.get(model_id, {})
+
+        # Context window
+        limit = mdata.get("limit", {})
+        ctx = limit.get("context", 0)
+        out = limit.get("output", 0)
+        if ctx:
+            if ctx >= 1_000_000:
+                ctx_str = f"{ctx / 1_000_000:.0f}M"
+            elif ctx >= 1000:
+                ctx_str = f"{ctx // 1000}K"
+            else:
+                ctx_str = str(ctx)
+            # Show usage if we have tokens
+            if current_tokens:
+                pct = (current_tokens / ctx) * 100
+                self._oc_context_label.setText(
+                    f"Context: {current_tokens // 1000}k / {ctx_str} ({pct:.0f}%)")
+            else:
+                self._oc_context_label.setText(f"Context: {ctx_str}")
+        else:
+            self._oc_context_label.setText("")
+
+        # Cost estimate based on current tokens
+        cost = mdata.get("cost", {})
+        cost_in = cost.get("input", 0)
+        cost_out = cost.get("output", 0)
+        if current_tokens and (cost_in or cost_out):
+            # Rough estimate: assume ~80% input, ~20% output
+            est_in = current_tokens * 0.8
+            est_out = current_tokens * 0.2
+            est_cost = (est_in * cost_in + est_out * cost_out) / 1_000_000
+            self._oc_cost_label.setText(f"~${est_cost:.4f}")
+        elif cost_in or cost_out:
+            self._oc_cost_label.setText(
+                f"${cost_in:.2f} / ${cost_out:.2f} / 1M")
+        else:
+            self._oc_cost_label.setText("Free")
 
     def _rerender_chat(self):
-        """Re-render the entire chat history with proper formatting."""
+        """Re-render the entire chat history with proper formatting.
+
+        Uses append() instead of setHtml() to avoid destroying the streaming
+        HTML that was built via insertHtml(). setHtml() re-parses accumulated
+        HTML and normalizes whitespace differently than insertHtml(), causing
+        spaces to disappear in the final render.
+        """
         try:
             html_parts = []
             mode = "plan" if self.mode_combo.currentIndex() == 0 else "act"
@@ -2677,10 +3178,26 @@ class ChatDockWidget(QDockWidget):
                         html_parts.append(render_plan_buttons(partial, allow_execute=False))
 
             full_html = "".join(html_parts)
+            # setHtml() resets the document; while it rebuilds (and during the
+            # layout pass that follows), the scrollbar emits valueChanged with
+            # value=0 against a growing maximum, which would flip _auto_scroll
+            # to False and skip the follow-scroll. Capture the intent up front,
+            # keep the tracking signal blocked across rebuild + layout, and
+            # only re-enable it once we've restored the position.
+            should_scroll = self._auto_scroll
+            scrollbar = self.chat_display.verticalScrollBar()
+            scrollbar.blockSignals(True)
             self.chat_display.setHtml(full_html)
 
-            scrollbar = self.chat_display.verticalScrollBar()
-            scrollbar.setValue(scrollbar.maximum())
+            if should_scroll:
+                def _restore_scroll():
+                    sb = self.chat_display.verticalScrollBar()
+                    sb.setValue(sb.maximum())
+                    sb.blockSignals(False)
+                    self._auto_scroll = True
+                QtCore.QTimer.singleShot(0, _restore_scroll)
+            else:
+                scrollbar.blockSignals(False)
         except Exception:
             pass  # Keep existing display content on error
 
@@ -2774,6 +3291,9 @@ class ChatDockWidget(QDockWidget):
         else:
             self.token_label.setText(
                 translate("ChatDockWidget", "tokens: ~{}").format(tokens))
+        # Update OpenCode cost estimate with actual token count
+        if self._is_opencode_provider():
+            self._update_oc_context_cost(tokens)
 
     def _connect_mcp_servers(self, cfg, *, only_deferred=None):
         """Connect to configured MCP servers.

--- a/freecad_ai/ui/message_view.py
+++ b/freecad_ai/ui/message_view.py
@@ -264,7 +264,7 @@ def render_message(role: str, content) -> str:
         formatted_content = _format_content(content)
 
     return (
-        f'<div style="margin: 8px 0; padding: 8px 12px; '
+        f'<div style="clear: both; margin: 8px 0; padding: 8px 12px; '
         f'background-color: {bg_color}; border-radius: 6px;">'
         f'<div style="font-weight: bold; color: {label_color}; '
         f'margin-bottom: 4px;">{label}</div>'
@@ -533,11 +533,13 @@ def _format_content_blocks(blocks: list) -> str:
         elif block.get("type") == "image":
             data_uri = f"data:{block['media_type']};base64,{block['data']}"
             parts.append(
+                f'<div style="margin: 4px 0;">'
                 f'<a href="image:{i}">'
                 f'<img src="{data_uri}" '
                 f'style="max-width:150px; max-height:150px; border-radius:4px; cursor:pointer;" '
                 f'title="Click to enlarge" />'
                 f'</a>'
+                f'</div>'
             )
     return "".join(parts)
 

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -11,7 +11,11 @@ Provides a GUI for configuring:
   - Test connection button
 """
 
+import json
 import os
+import threading
+import urllib.request
+import urllib.error
 
 from .compat import QtWidgets, QtCore, QtGui
 from ..i18n import translate
@@ -42,7 +46,7 @@ QFileDialog = QtWidgets.QFileDialog
 QMessageBox = QtWidgets.QMessageBox
 
 from ..config import get_config, save_current_config, PROVIDER_PRESETS
-from ..llm.providers import get_provider_names
+from ..llm.providers import get_provider_names, PROVIDERS
 
 
 class _TestConnectionThread(QThread):
@@ -203,7 +207,10 @@ class SettingsDialog(QDialog):
         provider_layout = QFormLayout()
 
         self.provider_combo = QComboBox()
-        self.provider_combo.addItems([n.capitalize() for n in get_provider_names()])
+        self.provider_combo.addItems([
+            PROVIDERS.get(n, {}).get("display_name", n.capitalize())
+            for n in get_provider_names()
+        ])
         self.provider_combo.currentIndexChanged.connect(self._on_provider_changed)
         provider_layout.addRow(translate("SettingsDialog", "Provider:"), self.provider_combo)
 
@@ -219,13 +226,27 @@ class SettingsDialog(QDialog):
         ))
         provider_layout.addRow(translate("SettingsDialog", "API Key:"), self.api_key_edit)
 
+        self.allow_insecure_ssl_check = QCheckBox(
+            translate("SettingsDialog", "Bypass SSL certificate verification (insecure)"))
+        self.allow_insecure_ssl_check.setToolTip(translate(
+            "SettingsDialog",
+            "Only enable this if your system trust store is unavailable or broken "
+            "(e.g. some sandboxed installs) and HTTPS requests fail certificate "
+            "verification. Disables server identity checks — connections remain "
+            "encrypted but are vulnerable to man-in-the-middle attacks. "
+            "Default: off."))
+        provider_layout.addRow(self.allow_insecure_ssl_check)
+
         self.base_url_edit = QLineEdit()
         self.base_url_edit.setPlaceholderText("https://api.example.com/v1")
         provider_layout.addRow(translate("SettingsDialog", "Base URL:"), self.base_url_edit)
 
-        self.model_edit = QLineEdit()
-        self.model_edit.setPlaceholderText(translate("SettingsDialog", "Model name"))
-        self.model_edit.editingFinished.connect(self._on_model_changed)
+        self.model_edit = QComboBox()
+        self.model_edit.setEditable(True)
+        self.model_edit.setInsertPolicy(QComboBox.NoInsert)
+        self.model_edit.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
+        self.model_edit.setMinimumContentsLength(20)
+        self.model_edit.currentTextChanged.connect(self._on_model_changed)
         self._last_model_name = ""  # track model name for param save/load
         provider_layout.addRow(translate("SettingsDialog", "Model:"), self.model_edit)
 
@@ -546,7 +567,8 @@ class SettingsDialog(QDialog):
         self.rerank_llm_provider_combo.addItem(
             translate("SettingsDialog", "(same as main)"), "")
         for name in get_provider_names():
-            self.rerank_llm_provider_combo.addItem(name.capitalize(), name)
+            display = PROVIDERS.get(name, {}).get("display_name", name.capitalize())
+            self.rerank_llm_provider_combo.addItem(display, name)
         llm_form.addRow(translate("SettingsDialog", "Provider:"),
                         self.rerank_llm_provider_combo)
 
@@ -867,7 +889,15 @@ class SettingsDialog(QDialog):
 
         self.api_key_edit.setText(cfg.provider.api_key)
         self.base_url_edit.setText(cfg.provider.base_url)
-        self.model_edit.setText(cfg.provider.model)
+        self._populate_model_combo(cfg.provider.name)
+        # Set the saved model — try combo match first, fall back to edit text
+        saved = cfg.provider.model
+        if saved:
+            idx = self.model_edit.findText(saved)
+            if idx >= 0:
+                self.model_edit.setCurrentIndex(idx)
+            else:
+                self.model_edit.setEditText(saved)
         self.max_tokens_spin.setValue(cfg.max_tokens)
         self.context_window_spin.setValue(cfg.context_window)
         self.max_tool_turns_spin.setValue(cfg.max_tool_turns)
@@ -878,6 +908,7 @@ class SettingsDialog(QDialog):
 
         self.enable_tools_check.setChecked(cfg.enable_tools)
         self.auto_execute_check.setChecked(cfg.auto_execute)
+        self.allow_insecure_ssl_check.setChecked(cfg.allow_insecure_ssl)
         self.keep_dock_check.setChecked(cfg.keep_dock_on_workbench_switch)
 
         # Tool reranking
@@ -953,6 +984,129 @@ class SettingsDialog(QDialog):
         # Hooks
         self._refresh_hooks_list()
 
+    # ── Model list helpers ─────────────────────────────────────
+
+    # Hardcoded fallback models for OpenCode providers (used when API
+    # fetch fails or as instant-populate during dialog load).
+    _MODELS_FALLBACK = {
+        "opencodezen": [
+            "deepseek-v4-pro", "deepseek-v4-flash",
+            "kimi-k3", "kimi-k2.7-code", "kimi-k2.6",
+            "glm-5.2", "glm-5.1", "glm-5",
+            "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus", "qwen3.5-plus",
+            "minimax-m3", "minimax-m2.7",
+            "mimo-v2.5-free", "hy3-free", "big-pickle",
+            "nemotron-3-ultra-free", "nemotron-3.5-lightning-free",
+            "gpt-5.5", "gpt-5.4", "gpt-5.4-mini",
+            "claude-sonnet-4-6", "claude-opus-4-5",
+            "gemini-3.5-flash", "gemini-3.1-pro",
+        ],
+        "opencodego": [
+            "deepseek-v4-pro", "deepseek-v4-flash",
+            "kimi-k3", "kimi-k2.7-code", "kimi-k2.6",
+            "glm-5.3-flash", "glm-5.3", "glm-5.2", "glm-5.1",
+            "qwen3.8-max", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",
+            "minimax-m3", "minimax-m2.7",
+            "mimo-v2.5", "mimo-v2.5-pro",
+            "hy3", "longcat-2.0",
+            "grok-4.6", "gpt-5.6-luna",
+            "muse-spark-1.2-contributor",
+        ],
+    }
+
+    # Provider-specific model list API endpoints
+    _MODELS_API = {
+        "opencodezen": "https://opencode.ai/zen/v1/models",
+        "opencodego": "https://opencode.ai/zen/go/v1/models",
+    }
+
+    def _populate_model_combo(self, provider_name: str):
+        """Fill the model combo box for the given provider.
+
+        Uses hardcoded fallback lists instantly, then tries to fetch the
+        live model list from the provider API in a background thread.
+        """
+        self.model_edit.blockSignals(True)
+        current = self.model_edit.currentText()
+
+        # Clear and add fallback models
+        self.model_edit.clear()
+        fallback = self._MODELS_FALLBACK.get(provider_name, [])
+        if fallback:
+            self.model_edit.addItems(fallback)
+
+        # Restore previous selection if still in list
+        if current:
+            idx = self.model_edit.findText(current)
+            if idx >= 0:
+                self.model_edit.setCurrentIndex(idx)
+            else:
+                self.model_edit.setEditText(current)
+
+        self.model_edit.blockSignals(False)
+
+        # Fetch live list in background if endpoint exists
+        api_url = self._MODELS_API.get(provider_name)
+        if api_url:
+            api_key = self.api_key_edit.text().strip()
+            threading.Thread(
+                target=self._fetch_models_thread,
+                args=(api_url, api_key, provider_name),
+                daemon=True,
+            ).start()
+
+    def _fetch_models_thread(self, api_url: str, api_key: str,
+                              provider_name: str):
+        """Background thread: fetch model list from provider API."""
+        try:
+            headers = {"Content-Type": "application/json", "User-Agent": "FreeCAD-AI"}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            req = urllib.request.Request(api_url, headers=headers)
+            ctx = None
+            if api_url.startswith("https"):
+                import ssl
+                ctx = (ssl._create_unverified_context() if get_config().allow_insecure_ssl
+                       else ssl.create_default_context())
+            with urllib.request.urlopen(req, context=ctx, timeout=10) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+
+            models = []
+            # OpenAI-compatible /v1/models format: {"data": [{"id": "model-name", ...}]}
+            for m in data.get("data", []):
+                mid = m.get("id", "")
+                if mid:
+                    models.append(mid)
+
+            if models:
+                models.sort()
+                # Update combo on the main thread
+                QtCore.QTimer.singleShot(
+                    0, lambda: self._apply_fetched_models(models, provider_name))
+        except Exception:
+            pass  # fallback list is already populated
+
+    def _apply_fetched_models(self, models: list[str], provider_name: str):
+        """Apply fetched model list to the combo (runs on main thread)."""
+        # Verify provider hasn't changed while we were fetching
+        names = get_provider_names()
+        idx = self.provider_combo.currentIndex()
+        current_provider = names[idx] if 0 <= idx < len(names) else ""
+        if current_provider != provider_name:
+            return
+
+        self.model_edit.blockSignals(True)
+        current = self.model_edit.currentText()
+        self.model_edit.clear()
+        self.model_edit.addItems(models)
+        if current:
+            idx = self.model_edit.findText(current)
+            if idx >= 0:
+                self.model_edit.setCurrentIndex(idx)
+            else:
+                self.model_edit.setEditText(current)
+        self.model_edit.blockSignals(False)
+
     def _on_provider_changed(self, index):
         """Update base URL, model, and default params when provider changes."""
         names = get_provider_names()
@@ -967,13 +1121,22 @@ class SettingsDialog(QDialog):
             new_base_url = preset.get("base_url", "")
             if new_base_url:
                 self.base_url_edit.setText(new_base_url)
+
+            # Populate model dropdown for this provider
+            self._populate_model_combo(name)
+
+            # Set default model from preset
             new_model = preset.get("default_model", "")
             if new_model:
-                self.model_edit.setText(new_model)
+                idx = self.model_edit.findText(new_model)
+                if idx >= 0:
+                    self.model_edit.setCurrentIndex(idx)
+                else:
+                    self.model_edit.setEditText(new_model)
 
             # Load saved params for the (possibly preserved) model
             cfg = get_config()
-            self._load_model_params_table(self.model_edit.text(), cfg)
+            self._load_model_params_table(self.model_edit.currentText(), cfg)
 
             # Apply provider-recommended reranker settings only when the
             # reranker UI is still at its factory default (off + top_n 15).
@@ -1035,7 +1198,7 @@ class SettingsDialog(QDialog):
 
     def _on_model_changed(self):
         """Save current params under the old model, load params for the new one."""
-        new_model = self.model_edit.text().strip()
+        new_model = self.model_edit.currentText().strip()
         if new_model == self._last_model_name or not new_model:
             return
         # Save current table under old model name (in-memory only)
@@ -1150,14 +1313,14 @@ class SettingsDialog(QDialog):
         cfg.provider.name = names[idx] if 0 <= idx < len(names) else "anthropic"
         cfg.provider.api_key = self.api_key_edit.text()
         cfg.provider.base_url = self.base_url_edit.text()
-        cfg.provider.model = self.model_edit.text()
+        cfg.provider.model = self.model_edit.currentText()
         cfg.max_tokens = self.max_tokens_spin.value()
         cfg.context_window = self.context_window_spin.value()
         cfg.max_tool_turns = self.max_tool_turns_spin.value()
         cfg.execution_timeout = self.execution_timeout_spin.value()
 
         # Save model parameters for the current model
-        model_name = self.model_edit.text().strip()
+        model_name = self.model_edit.currentText().strip()
         if model_name:
             params = self._read_model_params_table()
             if params:
@@ -1169,6 +1332,7 @@ class SettingsDialog(QDialog):
 
         cfg.enable_tools = self.enable_tools_check.isChecked()
         cfg.auto_execute = self.auto_execute_check.isChecked()
+        cfg.allow_insecure_ssl = self.allow_insecure_ssl_check.isChecked()
         cfg.keep_dock_on_workbench_switch = self.keep_dock_check.isChecked()
 
         thinking_values = ["off", "on", "extended"]
@@ -1368,7 +1532,7 @@ class SettingsDialog(QDialog):
         api_key = self.rerank_llm_api_key_edit.text().strip() \
             or self.api_key_edit.text().strip()
         model = self.rerank_llm_model_edit.text().strip() \
-            or self.model_edit.text().strip()
+            or self.model_edit.currentText().strip()
         # Effective params: use the reranker table (reflects current state
         # for both inherit and override modes).
         model_params = self._read_rerank_params_table()
@@ -1506,7 +1670,7 @@ class SettingsDialog(QDialog):
         cfg.provider.name = names[idx] if 0 <= idx < len(names) else "anthropic"
         cfg.provider.api_key = self.api_key_edit.text()
         cfg.provider.base_url = self.base_url_edit.text()
-        cfg.provider.model = self.model_edit.text()
+        cfg.provider.model = self.model_edit.currentText()
 
         try:
             cfg.max_tokens = self.max_tokens_spin.value()
@@ -1522,7 +1686,7 @@ class SettingsDialog(QDialog):
             pass
 
         # Apply model params temporarily for test connection
-        model_name = self.model_edit.text().strip()
+        model_name = self.model_edit.currentText().strip()
         if model_name:
             params = self._read_model_params_table()
             if params:

--- a/resources/panels/FreeCADAIPrefs.ui
+++ b/resources/panels/FreeCADAIPrefs.ui
@@ -46,6 +46,8 @@
         <item><property name="text"><string>groq</string></property></item>
         <item><property name="text"><string>mistral</string></property></item>
         <item><property name="text"><string>together</string></property></item>
+        <item><property name="text"><string>OpenCode Zen</string></property></item>
+        <item><property name="text"><string>OpenCode Go</string></property></item>
        </widget>
       </item>
       <item row="1" column="0">


### PR DESCRIPTION
First and foremost — huge thanks to the **ghbalf/freecad-ai** team for building and maintaining such a capable FreeCAD AI workbench. The architecture (agentic tool loop, streaming responses, MCP integration, skill system) is genuinely impressive, and it's clear a lot of thought went into making LLM-assisted CAD accessible. This PR builds on that foundation, and I sincerely hope these contributions are useful to the project and its community.

I've been using the workbench daily and these changes came from real-world friction points — things that made me think "this is so close to perfect, if only..." I wanted to give back even a fraction of the value this workbench has given me.

## What this adds

### OpenCode Zen & Go providers
Integrated [OpenCode](https://opencode.ai) as first-class LLM providers — **Zen** (pay-as-you-go) and **Go** ($10/mo subscription). Both are OpenAI-compatible APIs, so integration was straightforward via the existing provider framework.

- Added `opencodezen` and `opencodego` to the provider registry with display names
- Model list fetched dynamically from the `/v1/models` endpoint (not hardcoded)
- Per-model metadata pulled from [models.dev](https://models.dev) — context windows, pricing, reasoning variants
- **Variant selector** in the chat pane lets you switch reasoning effort (low/medium/high/xhigh) on the fly — applies full settings from the model's metadata: `reasoning_effort`, `temperature`, `top_p`, `top_k`, `min_p`, `presence_penalty`
- Model and variant selections persist across sessions

### Chat status bar
New status bar (visible only for OpenCode providers) showing:
- **Model dropdown** — populated from the API, with last-used model restored
- **Variant dropdown** — per-model reasoning options from models.dev
- **Context usage** — `12k / 200K (6%)` format
- **Cost estimate** — based on per-token rates from models.dev

### README update
- Added OpenCode Zen and Go to the Supported Providers table
- Updated provider count from 20 to 22

## Bug fixes (all providers)

### Spaces missing during streaming
QTextBrowser's `insertHtml()` strips leading spaces when appending token chunks to an existing text block — words ran together ("doinggreat", "involvedprojectopen"). Fixed by using `insertText()` for live tokens (whitespace-faithful), while the existing post-response `_rerender_chat()` still applies full markdown (code blocks, bold/italic, plan buttons) from the stored text, which carries correct spaces.

### AI label appearing next to user messages
The AI response label was flowing inline with the user's message instead of below it. QTextBrowser's `insertHtml()` with `<div>` doesn't always create a new block. Fixed by adding `cursor.insertBlock()` in `_append_html()` to force a new paragraph before each message.

### Auto-scroll not tracking new content
The chat could jump to the top when the document was rebuilt: `setHtml()` resets the scrollbar, and the resulting `valueChanged` signals (value=0 against a growing maximum) flipped the follow-scroll tracker off. Fixed by blocking the scrollbar's signals across the `setHtml()` rebuild and scrolling once layout has settled (`QTimer.singleShot`). The re-render — and with it markdown formatting and Plan-mode Execute/Copy buttons — is preserved for every provider.

### Stop button unresponsive during streaming
The Stop button (`requestInterruption`) only sets a flag that's checked between stream chunks. If the worker is blocked on a blocking `urllib` read waiting for the next API response, the flag is never checked. Fixed by adding a `cancel()` method to `LLMClient` that closes the HTTP response, breaking the blocking read so the worker exits promptly. Errors raised by the closed socket (`AttributeError`/`ValueError` from the response iterator) are caught and treated as a clean end-of-stream.

### Cost estimate resetting to zero
The cost/context labels were called without the current token count, defaulting to 0. Fixed by passing `conversation.estimated_tokens()` to all `_update_oc_context_cost()` calls.

### NameError in thinking handler
`colors` variable was scoped inside an `if` block but referenced outside it — every thinking token after the first crashed with `NameError`. Moved the variable assignment before the conditional.

## Security

### SSL certificate verification enforced by default (OWASP A07:2021)
Several locations fell back to `ssl._create_unverified_context()` when SSL initialization failed, silently disabling certificate verification and exposing API keys/conversations to MITM. Now verification is enforced by default; the unverified fallback only activates behind a new explicit opt-in: **Settings → "Bypass SSL certificate verification (insecure)"** (`allow_insecure_ssl`, default off), for environments with broken/missing trust stores (e.g. some sandboxes).

### Path Traversal in Model ID (OWASP A01:2021)
`model_id` from API responses was directly interpolated into URLs without sanitization. Fix: sanitization and length limit on model_id before URL construction.

### Unbounded Response Downloads (OWASP A04:2021)
JSON responses from external APIs were read without size limits. Fix: 1MB limit for model metadata, 10MB for the catalog download.

## Files changed

- `freecad_ai/llm/providers.py` — added opencodezen/opencodego providers
- `freecad_ai/llm/client.py` — `cancel()` for Stop button, graceful closed-socket handling, gated SSL fallback, `reasoning_effort` always sent
- `freecad_ai/config.py` — providers in `_PARAM_PROVIDERS`, `oc_last_model`/`oc_last_variant`, `allow_insecure_ssl`
- `freecad_ai/ui/settings_dialog.py` — model QComboBox with API fetch, display names, SSL bypass checkbox
- `freecad_ai/ui/chat_widget.py` — status bar, `insertBlock()`/`insertText()` fixes, scroll-signal blocking, Stop fix, cost fix
- `freecad_ai/ui/message_view.py` — image block structure, `render_message` HTML
- `resources/panels/FreeCADAIPrefs.ui` — added OpenCode Zen/Go to preferences
- `README.md` — added OpenCode Zen/Go to provider table, updated provider count