### PR TITLE
fix(#64): send MCP-Protocol-Version on every request after the handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The MCP client now sends `MCP-Protocol-Version` on every request after the
+  handshake** — required of clients since the `2025-06-18` protocol revision and
+  omitted since the client was written. It worked only by coincidence: a server
+  seeing no header is told to assume `2025-03-26`, which is what we speak. A
+  server that has dropped that revision was entitled to reject every call after
+  `initialize`. The header carries the version the *server* chose during the
+  handshake, not the one we asked with, so a server negotiating a newer revision
+  is now answered correctly. Affects both HTTP client transports; STDIO has no
+  headers and is unchanged.
+  ([#64](https://github.com/ghbalf/freecad-ai/issues/64))
+
 ## [0.23.0-alpha] - 2026-08-31
 
 ### Added

--- a/freecad_ai/mcp/client.py
+++ b/freecad_ai/mcp/client.py
@@ -84,6 +84,14 @@ class MCPClient:
                 f"MCP server '{self.name}' initialization failed: {resp['error']}"
             )
 
+        # Latch the negotiated revision before anything else goes out. The
+        # server's choice wins over what we asked for; HTTP transports send it
+        # as MCP-Protocol-Version on every later request (a client MUST as of
+        # 2025-06-18). Stdio has no headers and simply ignores it.
+        self._transport.protocol_version = (
+            resp.get("result", {}).get("protocolVersion") or PROTOCOL_VERSION
+        )
+
         # Send initialized notification
         self._transport.send_notification("notifications/initialized")
 

--- a/freecad_ai/mcp/transport.py
+++ b/freecad_ai/mcp/transport.py
@@ -263,6 +263,9 @@ class SSEClientTransport:
         self._connect_timeout = connect_timeout
         self._read_timeout = read_timeout
         self._correlator = _RequestCorrelator()
+        # Negotiated MCP revision, latched by MCPClient after initialize. A
+        # client MUST send it on every later request as of 2025-06-18.
+        self.protocol_version = None
         self._resp = None
         self._reader_thread = None
         self._endpoint_url = None
@@ -348,6 +351,8 @@ class SSEClientTransport:
         for key, value in self._headers.items():
             req.add_header(key, value)
         req.add_header("Content-Type", "application/json")
+        if self.protocol_version:
+            req.add_header("MCP-Protocol-Version", self.protocol_version)
         resp = urllib.request.urlopen(
             req, timeout=self._connect_timeout, context=self._ssl_context)
         resp.read()   # drain the 202 body
@@ -385,6 +390,9 @@ class StreamableHTTPClientTransport:
         self._ssl_context = ssl_context
         self._connect_timeout = connect_timeout
         self._session_id = None
+        # Negotiated MCP revision, latched by MCPClient after initialize. A
+        # client MUST send it on every later request as of 2025-06-18.
+        self.protocol_version = None
         self._next_id = 1
         self._id_lock = threading.Lock()
         self._running = False
@@ -455,6 +463,8 @@ class StreamableHTTPClientTransport:
         req.add_header("Accept", "application/json, text/event-stream")
         if self._session_id:
             req.add_header("Mcp-Session-Id", self._session_id)
+        if self.protocol_version:
+            req.add_header("MCP-Protocol-Version", self.protocol_version)
         return urllib.request.urlopen(
             req, timeout=timeout, context=self._ssl_context)
 

--- a/tests/unit/test_mcp_client_protocol_version.py
+++ b/tests/unit/test_mcp_client_protocol_version.py
@@ -1,0 +1,183 @@
+"""The client MUST send MCP-Protocol-Version after the handshake (#64 phase 2).
+
+Required of clients since the 2025-06-18 revision: every HTTP request after
+``initialize`` carries the *negotiated* protocol version — what the server
+returned, not what we asked for. Omitting it works only because a server
+seeing no header is told to assume 2025-03-26, which happens to be what we
+speak; a server that has dropped that revision is entitled to reject us.
+"""
+
+import http.server
+import json
+import threading
+
+from freecad_ai.mcp import protocol
+from freecad_ai.mcp.client import MCPClient, PROTOCOL_VERSION
+from freecad_ai.mcp.transport import (
+    SSEClientTransport,
+    StdioClientTransport,
+    StreamableHTTPClientTransport,
+)
+
+HEADER = "MCP-Protocol-Version"
+
+
+class _StreamableStub(http.server.BaseHTTPRequestHandler):
+    """Records the MCP-Protocol-Version header of every POST it receives."""
+    seen = []
+
+    def log_message(self, *a):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length).decode("utf-8"))
+        type(self).seen.append(self.headers.get(HEADER))
+        payload = json.dumps(
+            protocol.make_response(body.get("id"), {"ok": True}),
+            separators=(",", ":")).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class _SSEStub(http.server.BaseHTTPRequestHandler):
+    """Minimal HTTP+SSE server: advertises /messages, echoes every request."""
+    seen = []
+
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        self.wfile.write(b"event: endpoint\ndata: /messages\n\n")
+        self.wfile.flush()
+        type(self).stream = self.wfile
+        type(self).ready.set()
+        type(self).done.wait(10)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length).decode("utf-8"))
+        type(self).seen.append(self.headers.get(HEADER))
+        self.send_response(202)
+        self.end_headers()
+        if body.get("id") is not None:
+            reply = json.dumps(
+                protocol.make_response(body["id"], {"ok": True}),
+                separators=(",", ":"))
+            type(self).stream.write(f"event: message\ndata: {reply}\n\n".encode())
+            type(self).stream.flush()
+
+
+class _Running:
+    def __init__(self, handler):
+        self.handler = handler
+
+    def __enter__(self):
+        self.handler.seen = []
+        if self.handler is _SSEStub:
+            _SSEStub.ready = threading.Event()
+            _SSEStub.done = threading.Event()
+        self.httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), self.handler)
+        self.port = self.httpd.server_address[1]
+        threading.Thread(target=self.httpd.serve_forever, daemon=True).start()
+        self.base = f"http://127.0.0.1:{self.port}"
+        return self
+
+    def __exit__(self, *exc):
+        if self.handler is _SSEStub:
+            _SSEStub.done.set()
+        try:
+            self.httpd.shutdown()
+        finally:
+            self.httpd.server_close()
+
+
+class _RecordingTransport:
+    """Stands in for a transport that accepts a negotiated version."""
+    protocol_version = None
+
+    def __init__(self, initialize_result):
+        self._initialize_result = initialize_result
+        self.is_alive = True
+
+    def start(self):
+        pass
+
+    def send_request(self, method, params=None, timeout=30):
+        if method == "initialize":
+            return {"result": self._initialize_result}
+        return {"result": {"tools": []}}
+
+    def send_notification(self, method, params=None):
+        pass
+
+
+class TestStreamableHTTPClientSendsHeader:
+    def test_header_absent_before_a_version_is_negotiated(self):
+        with _Running(_StreamableStub) as srv:
+            t = StreamableHTTPClientTransport(f"{srv.base}/mcp", connect_timeout=5)
+            t.start()
+            t.send_request("tools/list", timeout=5)
+            t.stop()
+        assert _StreamableStub.seen == [None]
+
+    def test_negotiated_version_is_sent_on_every_later_request(self):
+        with _Running(_StreamableStub) as srv:
+            t = StreamableHTTPClientTransport(f"{srv.base}/mcp", connect_timeout=5)
+            t.start()
+            t.protocol_version = "2025-06-18"
+            t.send_request("tools/list", timeout=5)
+            t.send_request("tools/call", timeout=5)
+            t.stop()
+        assert _StreamableStub.seen == ["2025-06-18", "2025-06-18"]
+
+    def test_notifications_carry_the_header_too(self):
+        with _Running(_StreamableStub) as srv:
+            t = StreamableHTTPClientTransport(f"{srv.base}/mcp", connect_timeout=5)
+            t.start()
+            t.protocol_version = "2025-11-25"
+            t.send_notification("notifications/initialized")
+            t.stop()
+        assert _StreamableStub.seen == ["2025-11-25"]
+
+
+class TestSSEClientSendsHeader:
+    def test_negotiated_version_is_sent_on_posts(self):
+        with _Running(_SSEStub) as srv:
+            t = SSEClientTransport(f"{srv.base}/sse", connect_timeout=5)
+            t.start()
+            t.protocol_version = "2025-06-18"
+            t.send_request("tools/list", timeout=5)
+            t.stop()
+        assert _SSEStub.seen == ["2025-06-18"]
+
+
+class TestClientLatchesNegotiatedVersion:
+    def test_server_choice_wins_over_what_we_asked_for(self):
+        """We request 2025-03-26; a server answering 2025-06-18 sets the header."""
+        transport = _RecordingTransport(
+            {"protocolVersion": "2025-06-18", "capabilities": {}})
+        client = MCPClient("test", ["echo"])
+        client._transport = transport
+        client.connect()
+        assert transport.protocol_version == "2025-06-18"
+        assert PROTOCOL_VERSION == "2025-03-26"  # what we asked with, unchanged
+
+    def test_falls_back_to_our_version_when_server_omits_it(self):
+        transport = _RecordingTransport({"capabilities": {}})
+        client = MCPClient("test", ["echo"])
+        client._transport = transport
+        client.connect()
+        assert transport.protocol_version == PROTOCOL_VERSION
+
+    def test_stdio_transport_tolerates_the_latch(self):
+        """Stdio sends no headers; latching a version must not break it."""
+        t = StdioClientTransport(["echo"], None)
+        t.protocol_version = "2025-06-18"   # must not raise
+        assert t.protocol_version == "2025-06-18"


### PR DESCRIPTION
*(I'm an AI assistant handling this on Alfred's behalf.)*

Phase 2 of [#64](https://github.com/ghbalf/freecad-ai/issues/64) — and, per the [research comment on that issue](https://github.com/ghbalf/freecad-ai/issues/64#issuecomment-5471826408), the only item in phase 2 that is actual conformance debt rather than optional metadata.

## The bug

A client **MUST** send the negotiated protocol revision as an `MCP-Protocol-Version` header on every HTTP request after `initialize`. That has been required since the `2025-06-18` spec revision. Our client never sent it.

It works today only by coincidence: a server that sees no header is told to assume `2025-03-26`, which happens to be exactly what we speak. A server that has dropped that revision is entitled to reject every call we make after the handshake — `tools/list`, every `tools/call` — and the user would see the failure with nothing explaining it.

## The fix

`MCPClient.connect()` latches the version the **server** returned from `initialize` — not the one we asked with — onto the transport, before `notifications/initialized` goes out. Both HTTP client transports then send it from `_post()`. STDIO has no headers and ignores it.

Ten lines of code plus comments, across `client.py` and `transport.py`.

Two details worth calling out:

- **The server's choice wins.** We request `2025-03-26`; if a server negotiates something else, that is what we must echo. If a server omits `protocolVersion` from its reply (out of spec, but it happens) we fall back to our own constant rather than sending no header.
- **Latching in the client, not the transport.** The transport already sniffs responses for `Mcp-Session-Id`, so riding that mechanism was tempting. But `SSEClientTransport` reads replies on a separate thread, so a transport-side latch could lose the race to the first `tools/list`. Doing it in `connect()` means the first message after the handshake already carries the header.

## Not in scope

The revision we *request* stays `2025-03-26`. Advertising a newer one means implementing it — that is #64 phase 3, which this does not touch. The optional additive fields (`title`, `outputSchema`/`structuredContent`, `icons`, `serverInfo.description`, `_meta`) make us sparse, not non-conformant, and are left for a separate judgement call.

## Testing

- **7 new tests** in `tests/unit/test_mcp_client_protocol_version.py`, written before the fix: 5 failed for the right reasons and then passed.
- Two of the seven pass both before and after by design. `test_header_absent_before_a_version_is_negotiated` is a control — it pins that the header appears only once a version has actually been negotiated, so a fix that hardcoded the header unconditionally would be caught rather than sailing through.
- Coverage: both HTTP transports against real stub servers (requests *and* notifications), server-negotiates-a-different-version, server-omits-the-version, and STDIO tolerating the latch.
- **Full unit suite: 1190 passed** (1183 + 7), zero failures.
- Not exercised: no live probe against a third-party MCP server that enforces the header — the change is verified against stub servers and our own server only.
