### PR TITLE
fix(#69): guard the legacy /messages parse the way /mcp already does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The legacy `POST /messages` endpoint no longer answers `500` to malformed
+  input** — it parsed `Content-Length` and decoded the body without guarding
+  either, so a non-integer header or a body that was not valid UTF-8 escaped as
+  an uncaught exception: the client got a `500` and the user got a traceback in
+  the FreeCAD console. A negative `Content-Length` was worse — it made the read
+  block to end-of-stream, pinning a worker thread until the socket timed out
+  without answering at all. All three now return `400` with JSON-RPC `-32700`,
+  matching what the `/mcp` route has done since v0.23.0-alpha. The success path
+  is unchanged.
+  ([#69](https://github.com/ghbalf/freecad-ai/issues/69))
+
 - **The MCP client now sends `MCP-Protocol-Version` on every request after the
   handshake** — required of clients since the `2025-06-18` protocol revision and
   omitted since the client was written. It worked only by coincidence: a server

--- a/freecad_ai/mcp/transport.py
+++ b/freecad_ai/mcp/transport.py
@@ -777,12 +777,25 @@ class HTTPServerTransport:
                             transport._sse_wfile = None
 
             def _handle_messages(self):
-                length = int(self.headers.get("Content-Length", 0))
-                body = self.rfile.read(length).decode("utf-8")
-
+                # Same guard as _handle_streamable, for the same reason (#69):
+                # this endpoint is unauthenticated (#59), so a malformed
+                # header or body must answer with a JSON-RPC error rather
+                # than escape as a traceback in the user's FreeCAD console.
+                # ValueError covers a non-integer Content-Length and
+                # json.JSONDecodeError (a ValueError subclass, so the
+                # pre-existing parse-error behaviour is unchanged); a body
+                # that isn't valid UTF-8 raises UnicodeDecodeError. The range
+                # check matters most: rfile.read(-1) would block to EOF and
+                # pin a worker thread until the socket timeout, answering
+                # nothing at all.
                 try:
+                    length = int(self.headers.get("Content-Length", 0))
+                    if length < 0 or length > MAX_REQUEST_BODY:
+                        raise ValueError(
+                            "Content-Length %d out of range" % length)
+                    body = self.rfile.read(length).decode("utf-8")
                     msg = json.loads(body)
-                except json.JSONDecodeError:
+                except (ValueError, UnicodeDecodeError):
                     err = protocol.make_error(
                         None, protocol.PARSE_ERROR, "Parse error"
                     )

--- a/tests/unit/test_mcp_streamable_server.py
+++ b/tests/unit/test_mcp_streamable_server.py
@@ -60,12 +60,12 @@ def _request(port, path="/mcp", method="POST", data=None, headers=None):
         return exc.code, exc.read(), exc.headers
 
 
-def _post(port, payload, headers=None):
-    """POST a JSON-RPC message to /mcp. ``payload`` is encoded verbatim if bytes."""
+def _post(port, payload, headers=None, path="/mcp"):
+    """POST a JSON-RPC message. ``payload`` is encoded verbatim if bytes."""
     body = payload if isinstance(payload, bytes) else json.dumps(payload).encode()
     hdrs = {"Content-Type": "application/json"}
     hdrs.update(headers or {})
-    return _request(port, data=body, headers=hdrs)
+    return _request(port, path=path, data=body, headers=hdrs)
 
 
 class TestStreamableRequests:
@@ -404,3 +404,71 @@ class TestClientServerRoundTrip:
                 assert client._session_id is None
             finally:
                 client.stop()
+
+
+class TestLegacyMessagesParsing:
+    """The same malformed input the /mcp route rejects cleanly (#69).
+
+    /messages parsed Content-Length and decoded the body outside its try, and
+    caught only JSONDecodeError — so a bad header or a non-UTF-8 body escaped
+    as a 500 with a traceback in the user's FreeCAD console, and a negative
+    length pinned a worker thread reading to EOF with no answer at all. #65
+    fixed this for /mcp only, under a constraint not to touch legacy
+    behaviour; this is the legacy side getting the same treatment.
+    """
+
+    def test_a_valid_message_still_gets_the_legacy_202(self):
+        """Control: the success path must be untouched by the error-path fix."""
+        with _RunningServer() as srv:
+            status, body, _ = _post(
+                srv.port, {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+                path="/messages")
+
+        assert status == 202
+        assert json.loads(body) == {"accepted": True}
+
+    def test_a_non_integer_content_length_is_a_parse_error(self):
+        with _RunningServer() as srv:
+            status, body, _ = _post(
+                srv.port, {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+                headers={"Content-Length": "notanumber"}, path="/messages")
+
+        assert status == 400
+        assert json.loads(body)["error"]["code"] == protocol.PARSE_ERROR
+
+    def test_a_negative_content_length_is_a_parse_error(self):
+        """rfile.read(-1) would block to EOF and answer nothing. The point of
+        this test is that a response arrives at all."""
+        with _RunningServer() as srv:
+            status, body, _ = _post(
+                srv.port, {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+                headers={"Content-Length": "-1"}, path="/messages")
+
+        assert status == 400
+        assert json.loads(body)["error"]["code"] == protocol.PARSE_ERROR
+
+    def test_an_oversized_content_length_is_a_parse_error(self):
+        with _RunningServer() as srv:
+            status, body, _ = _post(
+                srv.port, {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+                headers={"Content-Length": str(MAX_REQUEST_BODY + 1)},
+                path="/messages")
+
+        assert status == 400
+        assert json.loads(body)["error"]["code"] == protocol.PARSE_ERROR
+
+    def test_a_non_utf8_body_is_a_parse_error(self):
+        with _RunningServer() as srv:
+            status, body, _ = _post(srv.port, b"\xff\xfe", path="/messages")
+
+        assert status == 400
+        assert json.loads(body)["error"]["code"] == protocol.PARSE_ERROR
+
+    def test_unparseable_json_is_still_a_parse_error(self):
+        """Pre-existing behaviour: JSONDecodeError is a ValueError subclass,
+        so broadening the except must not change this case."""
+        with _RunningServer() as srv:
+            status, body, _ = _post(srv.port, b"{not json", path="/messages")
+
+        assert status == 400
+        assert json.loads(body)["error"]["code"] == protocol.PARSE_ERROR


### PR DESCRIPTION
*(I'm an AI assistant handling this on Alfred's behalf. The implementation work below is mine; Alfred directs and reviews.)*

Closes #69.

## The bug

`_handle_messages` — the legacy HTTP+SSE endpoint — parsed `Content-Length` and decoded the body **outside** its `try`, and caught only `json.JSONDecodeError`:

```python
length = int(self.headers.get("Content-Length", 0))
body = self.rfile.read(length).decode("utf-8")

try:
    msg = json.loads(body)
except json.JSONDecodeError:
    ...
```

Three ways in:

| Input | Before | After |
| --- | --- | --- |
| `Content-Length: abc` | `ValueError` escapes → **500** + traceback in the FreeCAD console | **400**, JSON-RPC `-32700` |
| Body that isn't valid UTF-8 | `UnicodeDecodeError` escapes → **500** + traceback | **400**, `-32700` |
| `Content-Length: -1` | `rfile.read(-1)` blocks to EOF — the worker thread is pinned until the socket times out and **nothing** is answered | **400**, `-32700` |

The third is the one that matters most. This endpoint is unauthenticated (#59), so the Host allowlist is the only access control in front of it, and a request that costs one byte to send but holds a `ThreadingHTTPServer` worker until timeout is a cheap way to exhaust the pool.

## The fix

Parse, range-check, read and decode inside one `try`, mirroring what `_handle_streamable` has done since v0.23.0-alpha:

```python
try:
    length = int(self.headers.get("Content-Length", 0))
    if length < 0 or length > MAX_REQUEST_BODY:
        raise ValueError("Content-Length %d out of range" % length)
    body = self.rfile.read(length).decode("utf-8")
    msg = json.loads(body)
except (ValueError, UnicodeDecodeError):
    ...400 / -32700...
```

`json.JSONDecodeError` is a `ValueError` subclass, so the broadened `except` **subsumes** the existing parse-error path rather than changing it. The success path is untouched.

## Why this wasn't done in #65

PR #68 fixed exactly this shape of bug for the new `POST /mcp` route, under a constraint not to change HTTP+SSE behaviour beyond what that branch reviewed. #69 was filed to carry the legacy side on its own terms. That's this PR.

## Tests

Six new tests in `tests/unit/test_mcp_streamable_server.py::TestLegacyMessagesParsing`, all posting to `/messages`. **Four failed before the fix**; two pass either way, deliberately:

- `test_a_valid_message_still_gets_the_legacy_202` — control, proves the error-path change didn't touch the success path
- `test_unparseable_json_is_still_a_parse_error` — control, proves the broadened `except` preserved the original behaviour

The other four cover non-integer, negative, and oversized `Content-Length`, plus a non-UTF-8 body.

The class runtime dropped **13.05s → 3.13s**: the negative and oversized cases had each been burning the full client timeout, so the timing independently confirms the blocking read is gone.

## What was actually tested

`env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q` → **1196 passed** (1190 + 6). No GUI path was exercised — this change is confined to the HTTP request handler and has no UI surface. Please reopen or comment if the endpoint still misbehaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRah8RdoyrFLoWWka9Wbgb
