### PR TITLE
Fix-branding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,29 @@ The `SKILL.md` file contains instructions the LLM follows using tool calls. See 
 - Specify default values for all parameters
 - Test with multiple LLM providers (tool-calling quality varies)
 
+### Assets shipped by another workbench
+
+A FreeCAD module can ship its own skills, tools and hooks instead of adding them
+here. Put them in an `ai/` directory inside the module, and they are discovered
+automatically once it is installed:
+
+```
+Mod/<YourModule>/ai/
+├── skills/<name>/SKILL.md    # same format as skills/ in this repo
+├── tools/*.py                # same format as user tools
+├── hooks/<name>/hook.py      # same format as user hooks
+└── INSTRUCTIONS.md           # (optional) appended to the system prompt
+```
+
+Precedence is built-in < module < user, so a user copy still overrides yours.
+Set `__tool_prefix__ = "yourwb_"` at the top of a tool file to namespace its
+tools instead of inheriting the default `user_` prefix. Point
+`FREECAD_AI_ASSET_DIRS` at an `ai/` directory to test one without installing.
+
+This is the right home for workbench-specific knowledge — it stays versioned and
+tested next to the code it describes. See
+`docs/superpowers/specs/2026-08-14-module-assets-design.md`.
+
 ### New Providers
 
 Adding an LLM provider is a one-file change. Add an entry to `PROVIDERS` in `freecad_ai/llm/providers.py`:

--- a/InitGui.py
+++ b/InitGui.py
@@ -217,14 +217,15 @@ class ToggleMCPServerCommand:
     """
 
     def GetResources(self):
-        from freecad_ai.i18n import translate
+        from freecad_ai.branding import PRODUCT_NAME
+        from freecad_ai.i18n import translate, translate_branded
         return {
-            "GroupName": "FreeCAD AI",
+            "GroupName": PRODUCT_NAME,
             "MenuText": translate("ToggleMCPServerCommand", "MCP Server"),
-            "ToolTip": translate(
+            "ToolTip": translate_branded(
                 "ToggleMCPServerCommand",
                 "Start or stop the MCP server, letting external clients such "
-                "as Claude Code drive this FreeCAD session. The server has no "
+                "as Claude Code drive this %1 session. The server has no "
                 "authentication; set its address in AI Settings."),
             # False = starts unticked. FreeCAD treats this as the initial
             # state, not as "may this action be checked"; True showed a ticked
@@ -239,7 +240,9 @@ class ToggleMCPServerCommand:
 
         if controller.is_running():
             controller.stop()
-            App.Console.PrintMessage("FreeCAD AI: MCP server stopped\n")
+            from freecad_ai.branding import PRODUCT_NAME
+            App.Console.PrintMessage(
+                "%s: MCP server stopped\n" % PRODUCT_NAME)
             self._sync_action()
             return
 
@@ -252,8 +255,9 @@ class ToggleMCPServerCommand:
             self._sync_action()  # a failed start must leave the button unticked
             return
 
+        from freecad_ai.branding import PRODUCT_NAME
         App.Console.PrintMessage(
-            "FreeCAD AI: MCP server listening on %s\n" % url)
+            "%s: MCP server listening on %s\n" % (PRODUCT_NAME, url))
         window = Gui.getMainWindow()
         if window:
             window.statusBar().showMessage(
@@ -276,14 +280,16 @@ class ToggleMCPServerCommand:
 
         This used to be a traceback in a daemon thread that nothing surfaced.
         """
-        from freecad_ai.i18n import translate
+        from freecad_ai.branding import PRODUCT_NAME
+        from freecad_ai.i18n import translate_branded
         from freecad_ai.ui.compat import QtWidgets
-        message = translate(
+        message = translate_branded(
             "ToggleMCPServerCommand",
             "Could not start the MCP server on {address}.\n\n{error}\n\n"
-            "Change the address in FreeCAD AI → AI Settings → "
+            "Change the address in %2 → AI Settings → "
             "MCP Servers.").format(address="%s:%d" % (host, port), error=exc)
-        App.Console.PrintError("FreeCAD AI: %s\n" % message.replace("\n\n", " "))
+        App.Console.PrintError(
+            "%s: %s\n" % (PRODUCT_NAME, message.replace("\n\n", " ")))
         QtWidgets.QMessageBox.warning(
             Gui.getMainWindow(),
             translate("ToggleMCPServerCommand", "MCP server failed to start"),

--- a/InitGui.py
+++ b/InitGui.py
@@ -9,19 +9,27 @@ class FreeCADAIWorkbench(Gui.Workbench):
 
     # FreeCAD auto-translates MenuText/ToolTip using class name as context.
     # The .qm file provides translations under the "FreeCADAIWorkbench" context.
+    # MenuText is the unbranded default; __init__ replaces it with the host's
+    # branded product name.
     MenuText = "FreeCAD AI"
     ToolTip = "AI-powered assistant for 3D modeling"
 
     def __init__(self):
+        from freecad_ai.branding import PRODUCT_NAME
         from freecad_ai.paths import get_icon_path
+        # Assigned here rather than in the class body: FreeCAD exec()s this
+        # file with separate globals/locals mappings, so class and function
+        # bodies cannot see module-level names. Same reason Icon is set here.
+        self.__class__.MenuText = PRODUCT_NAME
         icon = get_icon_path()
         if icon:
             self.__class__.Icon = icon
 
     def Initialize(self):
         """Called when the workbench is first activated."""
-        self.appendToolbar("FreeCAD AI", ["FreeCADAI_OpenChat", "FreeCADAI_OpenSettings"])
-        self.appendMenu("FreeCAD AI", ["FreeCADAI_OpenChat", "FreeCADAI_OpenSettings",
+        from freecad_ai.branding import PRODUCT_NAME
+        self.appendToolbar(PRODUCT_NAME, ["FreeCADAI_OpenChat", "FreeCADAI_OpenSettings"])
+        self.appendMenu(PRODUCT_NAME, ["FreeCADAI_OpenChat", "FreeCADAI_OpenSettings",
                                        "FreeCADAI_ToggleKeepDock"])
 
     def Activated(self):
@@ -58,12 +66,13 @@ class OpenChatCommand:
     """Command to open/show the AI chat panel."""
 
     def GetResources(self):
+        from freecad_ai.branding import PRODUCT_NAME
         from freecad_ai.paths import get_icon_path
-        from freecad_ai.i18n import translate
+        from freecad_ai.i18n import translate, translate_branded
         d = {
-            "GroupName": "FreeCAD AI",
+            "GroupName": PRODUCT_NAME,
             "MenuText": translate("OpenChatCommand", "Open AI Chat"),
-            "ToolTip": translate("OpenChatCommand", "Open the FreeCAD AI chat panel"),
+            "ToolTip": translate_branded("OpenChatCommand", "Open the %2 chat panel"),
         }
         icon = get_icon_path()
         if icon:
@@ -85,11 +94,12 @@ class OpenSettingsCommand:
     """Command to open the settings dialog."""
 
     def GetResources(self):
-        from freecad_ai.i18n import translate
+        from freecad_ai.branding import PRODUCT_NAME
+        from freecad_ai.i18n import translate, translate_branded
         return {
-            "GroupName": "FreeCAD AI",
+            "GroupName": PRODUCT_NAME,
             "MenuText": translate("OpenSettingsCommand", "AI Settings"),
-            "ToolTip": translate("OpenSettingsCommand", "Configure FreeCAD AI providers and options"),
+            "ToolTip": translate_branded("OpenSettingsCommand", "Configure %2 providers and options"),
         }
 
     def Activated(self, index=0):
@@ -110,13 +120,14 @@ class ToggleKeepDockCommand:
     """
 
     def GetResources(self):
-        from freecad_ai.i18n import translate
+        from freecad_ai.branding import PRODUCT_NAME
+        from freecad_ai.i18n import translate, translate_branded
         return {
-            "GroupName": "FreeCAD AI",
+            "GroupName": PRODUCT_NAME,
             "MenuText": translate("ToggleKeepDockCommand", "Keep Chat Panel Open"),
-            "ToolTip": translate(
+            "ToolTip": translate_branded(
                 "ToggleKeepDockCommand",
-                "Toggle whether the FreeCAD AI chat panel stays open when "
+                "Toggle whether the %2 chat panel stays open when "
                 "switching to other workbenches"),
             "Checkable": True,
         }
@@ -171,15 +182,16 @@ try:
 except Exception:
     pass
 
-# Register the FreeCAD AI preferences page in Edit → Preferences. The
+# Register the preferences page in Edit → Preferences. The
 # Gui::Pref* widgets in the form auto-save to BaseApp/Preferences/Mod/FreeCADAI;
 # our config layer mirrors values from there into ~/.config/FreeCAD/FreeCADAI/config.json
 # on load so both this page and the workbench's Settings dialog stay in sync.
 try:
+    from freecad_ai.branding import PRODUCT_NAME as _pn
     from freecad_ai.paths import get_prefs_ui_path as _gpup
     _prefs_ui = _gpup()
     if _prefs_ui:
-        Gui.addPreferencePage(_prefs_ui, "FreeCAD AI")
+        Gui.addPreferencePage(_prefs_ui, _pn)
 except Exception:
     pass
 

--- a/Resources/Documents/Overview.md
+++ b/Resources/Documents/Overview.md
@@ -1,6 +1,6 @@
-# RioD AI
+# FreeCAD AI
 
-An AI-powered assistant workbench for RioD that creates and modifies
+An AI-powered assistant workbench for FreeCAD that creates and modifies
 3D models from natural language descriptions.
 
 ## Features
@@ -19,12 +19,12 @@ An AI-powered assistant workbench for RioD that creates and modifies
 
 ## Requirements
 
-- RioD (or FreeCAD 1.0+)
+- FreeCAD 1.0+
 - An LLM provider (local Ollama, or a cloud API key)
 
 ## Getting Started
 
 1. Clone or symlink this repository into `~/.local/share/FreeCAD/Mod/freecad-ai` (see README for OS-specific paths). The workbench isn't in the FreeCAD Addon Manager registry yet.
-2. Switch to the **RioD AI** workbench
+2. Switch to the **FreeCAD AI** workbench
 3. Open settings (gear icon) and configure your LLM provider
 4. Start chatting — ask it to create geometry, modify parts, or explain modeling concepts

--- a/Resources/Documents/Overview.md
+++ b/Resources/Documents/Overview.md
@@ -1,6 +1,6 @@
-# FreeCAD AI
+# RioD AI
 
-An AI-powered assistant workbench for FreeCAD that creates and modifies
+An AI-powered assistant workbench for RioD that creates and modifies
 3D models from natural language descriptions.
 
 ## Features
@@ -19,12 +19,12 @@ An AI-powered assistant workbench for FreeCAD that creates and modifies
 
 ## Requirements
 
-- FreeCAD 1.0+
+- RioD (or FreeCAD 1.0+)
 - An LLM provider (local Ollama, or a cloud API key)
 
 ## Getting Started
 
 1. Clone or symlink this repository into `~/.local/share/FreeCAD/Mod/freecad-ai` (see README for OS-specific paths). The workbench isn't in the FreeCAD Addon Manager registry yet.
-2. Switch to the **FreeCAD AI** workbench
+2. Switch to the **RioD AI** workbench
 3. Open settings (gear icon) and configure your LLM provider
-4. Start chatting — ask it to create geometry, modify parts, or explain FreeCAD concepts
+4. Start chatting — ask it to create geometry, modify parts, or explain modeling concepts

--- a/docs/superpowers/specs/2026-08-14-module-assets-design.md
+++ b/docs/superpowers/specs/2026-08-14-module-assets-design.md
@@ -1,0 +1,131 @@
+# Design: module assets — workbenches shipping their own assistant assets
+
+- **Date:** 2026-08-14
+- **Status:** Implemented
+- **Scope:** discovery of `Mod/<Module>/ai/` directories, wired into skills,
+  extension tools, hooks and the system prompt. No change to any asset format —
+  a module's skill is a normal skill, a module's tool is a normal user tool.
+- **Base:** branch off `master`.
+
+## Background
+
+Assistant assets can live in exactly two places today:
+
+1. **Built-in** — `skills/` and `hooks/` in this repository, and the tools
+   hard-coded in `freecad_ai/tools/freecad_tools.py`.
+2. **User** — `<config dir>/{skills,tools,hooks}/`, scanned by
+   `SkillsRegistry._load_skills`, `load_user_tools(USER_TOOLS_DIR, ...)` and
+   `HookRegistry._load_hooks`.
+
+Neither fits a third case that keeps coming up: **a workbench that knows things
+the generic assistant cannot infer.** A module defining its own document types
+knows their property semantics, the object hierarchy they require, and the order
+its operations must run in. None of that is discoverable from `addObject()` and
+a property list.
+
+Today that knowledge has one route into the assistant — someone hand-copies a
+`SKILL.md` into the user config directory. That is unversioned, untested,
+invisible to the module's own CI, silently divergent from the code it describes,
+and gone on the next machine. Alternatively the module's assets get merged into
+*this* repository, which does not scale and makes every downstream fork carry
+vendor-specific content it has no use for.
+
+## Design
+
+Any installed FreeCAD module may carry an `ai/` directory:
+
+```
+Mod/<AnyModule>/ai/
+    skills/<name>/SKILL.md    same layout and parser as built-in skills
+    tools/*.py                same contract as user extension tools
+    hooks/<name>/hook.py      same contract as user hooks
+    INSTRUCTIONS.md           appended to the system prompt
+```
+
+`freecad_ai/extensions/module_assets.py` walks `Mod/` under both
+`App.getUserAppDataDir()` and `App.getResourceDir()` — the same probe order as
+`paths.get_wb_dir()` — and returns each `ai/` directory it finds. An
+os.pathsep-separated `FREECAD_AI_ASSET_DIRS` adds directories directly, so a
+development checkout can be pointed at without installing; it mirrors the
+existing `FREECAD_AI_CONFIG_DIR` escape hatch and is what the tests use.
+
+### Naming
+
+"Provider" was the obvious word and is unavailable: `freecad_ai/llm/providers.py`,
+`cfg.provider`, `rerank_llm_provider_name` and CONTRIBUTING's "New Providers"
+section all mean *LLM provider*. These are **module assets**, and the discovery
+module is named for that.
+
+### Precedence
+
+**Built-in < module < user.** A module may extend the assistant; the user always
+keeps the last word over both. This falls out of the existing scan order —
+skills overwrite by name as directories are scanned, so module skills are
+inserted between built-in and user.
+
+Hooks invert this (`_load_hooks` keeps the *first* name it sees), so the module
+list is inserted at the same position and the same built-in-wins-over-user
+precedence is preserved.
+
+### Why nothing vendor-specific enters this repository
+
+The mechanism names no module. It is a directory convention plus four call
+sites. A workbench that wants to teach the assistant does so entirely from its
+own repository, where its skills are versioned and tested next to the code they
+document. This repository gains a general capability, not a customer.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `freecad_ai/extensions/module_assets.py` | New. `discover_asset_dirs`, `asset_subdirs`, `owning_module`, `load_module_instructions`, `reset_cache`. |
+| `freecad_ai/extensions/skills.py` | `_skill_dirs()` inserts module skill dirs between built-in and user. `get_skill_status()` gains a `"module"` source and a `module_path` key. `reset_to_builtin()` also reverts to a module copy. |
+| `freecad_ai/tools/setup.py` | Module tool dirs appended to the `extra_dirs` already passed to `load_user_tools`. |
+| `freecad_ai/hooks/registry.py` | `_hook_dirs()` inserts module hook dirs. |
+| `freecad_ai/core/system_prompt.py` | `## Workbench Instructions` section from each `INSTRUCTIONS.md`. |
+| `freecad_ai/ui/settings_dialog.py` | Skills list shows a `module` tag; reset enables against a module copy too. |
+
+Every call site wraps discovery in `try/except` — an assistant that cannot scan
+for module assets still starts.
+
+## Supporting changes to the user-tool loader
+
+A module's tools are ordinary user tools, and writing real ones surfaced three
+limits in `extensions/user_tools.py` that apply equally to user-authored tools:
+
+1. **No sequence types.** `_TYPE_MAP` accepted only `float|int|str|bool`, so a
+   tool taking a list of names could not be expressed. Added `list[str]`,
+   `list[float]` and `list[int]`, each emitting `items` alongside `array` —
+   required by strict providers and asserted by
+   `tests/unit/test_registry.py::test_every_array_property_has_items`.
+   Unsupported generics still warn, and now name themselves accurately
+   (`tuple[int]` rather than an empty string).
+2. **Placeholder parameter descriptions.** Every parameter was described as
+   `"Parameter: {name}"`. The docstring's Google-style `Args:` block is now
+   parsed and each parameter carries the author's own prose. Parameters the
+   author did not document keep the placeholder.
+3. **Fixed `user_` prefix.** A module may set `__tool_prefix__` to namespace its
+   tools. It is read from the AST, so it is honoured without executing the file,
+   and a non-string value falls back to the default.
+
+The tool description is now the full docstring up to `Args:` rather than only
+its first line — a one-line summary is rarely enough for the model to decide
+whether a tool applies. `Returns:`/`Raises:` are dropped; the model sees the
+return value directly in the tool result.
+
+## Caching
+
+`create_default_registry()` runs on every message, so the directory scan is
+cached process-wide. `discover_asset_dirs(refresh=True)` and `reset_cache()`
+exist for tests and for installing a module into a running session.
+
+## Testing
+
+- `tests/unit/test_module_assets.py` — 20 tests covering discovery, the env
+  override, caching, instruction collection, and the integration of all three
+  asset types including precedence and reset behaviour.
+- `tests/unit/test_user_tools.py` — 20 added tests for sequence params, the
+  tool prefix, and docstring parsing.
+
+FreeCAD is never imported: the tests monkeypatch `_mod_roots`, matching how the
+rest of the unit suite stays FreeCAD-free.

--- a/freecad_ai/branding.py
+++ b/freecad_ai/branding.py
@@ -1,0 +1,37 @@
+"""Host application and product names, resolved from the host's branding.
+
+The names are read from the host's branding.xml through FreeCAD.ConfigGet so
+this addon carries no hardcoded brand: it displays whatever application it is
+running inside. Unbranded hosts -- stock FreeCAD, dev builds started from the
+build tree, headless test runs -- fall back to "FreeCAD".
+
+See the host's src/App/Branding.cpp for the key whitelist, and
+src/Gui/CommandStd.cpp for the %1-placeholder convention translate_branded()
+in i18n.py mirrors.
+"""
+
+DEFAULT_APP_NAME = "FreeCAD"
+
+
+def _resolve_app_name() -> str:
+    """Read the branded application name, or fall back to the FreeCAD default."""
+    try:
+        import FreeCAD
+    except Exception:
+        return DEFAULT_APP_NAME
+    # ConfigGet returns "" for an unknown key instead of raising, so test for
+    # truthiness. ExeName is populated in GUI, console and module run modes;
+    # Application only exists when a branding.xml was loaded.
+    for key in ("ExeName", "Application"):
+        try:
+            value = (FreeCAD.ConfigGet(key) or "").strip()
+        except Exception:
+            continue
+        if value:
+            return value
+    return DEFAULT_APP_NAME
+
+
+APP_NAME = _resolve_app_name()
+PRODUCT_NAME = "{} AI".format(APP_NAME)
+IS_BRANDED = APP_NAME != DEFAULT_APP_NAME

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -33,6 +33,8 @@ import time
 import time
 from dataclasses import dataclass, field, asdict
 
+from .branding import PRODUCT_NAME
+
 
 # Marker filename inside the active config dir. Its presence signals that
 # this version of the workbench has already migrated into this target.
@@ -149,7 +151,7 @@ def _drop_marker(target: str) -> None:
     marker = os.path.join(target, _ACTIVE_MARKER_FILE)
     with open(marker, "w") as f:
         f.write(
-            "FreeCAD AI v0.13.0+ -- active config dir.\n"
+            f"{PRODUCT_NAME} v0.13.0+ -- active config dir.\n"
             f"Created: {datetime.datetime.now().isoformat()}\n"
             "Removing this file will trigger re-migration on next launch.\n"
         )
@@ -198,7 +200,7 @@ def _sweep_stale_candidates(candidates: list[str], target: str) -> list[str]:
             renamed.append(_rename_with_collision_suffix(c, _DUPLICATE_CLEANUP_SUFFIX))
         except OSError as e:
             print(
-                f"FreeCAD AI: could not rename stale dir {c} ({e!r}); leaving in place",
+                f"{PRODUCT_NAME}: could not rename stale dir {c} ({e!r}); leaving in place",
                 file=sys.stderr,
             )
     return renamed
@@ -278,7 +280,7 @@ def _resolve_config_dir() -> str:
             _sweep_stale_candidates(candidates, target)
         except Exception as e:
             print(
-                f"FreeCAD AI: stale legacy sweep failed ({e!r}); leaving as-is",
+                f"{PRODUCT_NAME}: stale legacy sweep failed ({e!r}); leaving as-is",
                 file=sys.stderr,
             )
         return target
@@ -288,7 +290,7 @@ def _resolve_config_dir() -> str:
         return target
     except Exception as e:
         print(
-            f"FreeCAD AI: config migration to {target} failed ({e!r}); "
+            f"{PRODUCT_NAME}: config migration to {target} failed ({e!r}); "
             f"falling back to a legacy candidate",
             file=sys.stderr,
         )
@@ -465,7 +467,7 @@ class AppConfig:
     # lands at its default area every startup. We snapshot our own state
     # on dock-move events and reapply in get_chat_dock().
     # When True, the chat dock is NOT hidden when switching away from the
-    # FreeCAD AI workbench — the panel stays open and usable in any other
+    # AI workbench — the panel stays open and usable in any other
     # workbench. When False (default), leaving the workbench hides the dock.
     keep_dock_on_workbench_switch: bool = False
     chat_dock_floating: bool = False

--- a/freecad_ai/core/context.py
+++ b/freecad_ai/core/context.py
@@ -14,7 +14,8 @@ def get_document_context() -> str:
     try:
         import FreeCAD as App
     except ImportError:
-        return "(FreeCAD not available — running outside FreeCAD)"
+        from ..branding import APP_NAME
+        return "({0} not available — running outside {0})".format(APP_NAME)
 
     from .active_document import resolve_active_document, sync_app_active_document
 

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -23,6 +23,8 @@ import tempfile
 import traceback
 from dataclasses import dataclass
 
+from ..branding import APP_NAME
+
 
 @dataclass
 class ExecutionResult:
@@ -279,7 +281,7 @@ try:
         for _e in _err_obs.errors:
             if _e and _e not in _seen:
                 _seen.add(_e)
-                _issues.append("FreeCAD error: " + _e)
+                _issues.append("{app_name} error: " + _e)
     _objects_state = [_snap(_obj) for _obj in doc.Objects]
     _issues.extend(_collect_object_issues(_objects_state, _baseline_bad))
 
@@ -311,6 +313,7 @@ finally:
         open_block=open_block,
         indented_code="\n".join("    " + line for line in code.splitlines()),
         result_path=result_file,
+        app_name=APP_NAME,
     )
 
     try:
@@ -334,8 +337,8 @@ finally:
             sig = -proc.returncode
             sig_name = signal.Signals(sig).name if sig in signal.Signals._value2member_map_ else str(sig)
             return False, (
-                "Sandbox: code CRASHED FreeCAD (signal {}). "
-                "This code is not safe to execute.".format(sig_name)
+                "Sandbox: code CRASHED {} (signal {}). "
+                "This code is not safe to execute.".format(APP_NAME, sig_name)
             )
 
         # Read result
@@ -500,8 +503,8 @@ def execute_code(code: str, timeout: int | None = None, sandbox: bool = True,
             success=False,
             stdout="",
             stderr=(
-                "No active document — open a document in FreeCAD or click "
-                "its tab so it is the focused window."
+                "No active document — open a document in {} or click "
+                "its tab so it is the focused window.".format(APP_NAME)
             ),
             code=code,
         )
@@ -662,9 +665,9 @@ def _validate_code(code: str) -> list[str]:
         has_arc = bool(re.search(r"ArcOfCircle|Arc\s*\(", code))
         if has_full_circle and not has_arc:
             warnings.append(
-                "Revolution with a full Part.Circle profile will crash FreeCAD. "
+                "Revolution with a full Part.Circle profile will crash {}. "
                 "Use Part.ArcOfCircle (semicircle) + a closing line instead, "
-                "or use Part.makeSphere() for spheres."
+                "or use Part.makeSphere() for spheres.".format(APP_NAME)
             )
         # Check for 360 degree revolution — always risky with sketch profiles
         if re.search(r"\.Angle\s*=\s*360", code):

--- a/freecad_ai/core/loop_control.py
+++ b/freecad_ai/core/loop_control.py
@@ -1,4 +1,13 @@
-"""Pure decision helper for the agentic tool loop bound."""
+"""Pure decision helpers for the agentic tool loop bound."""
+
+import json
+
+# A model repeating a byte-identical call that keeps failing is not converging on its
+# own. The first intervention is a nudge, because that is usually enough to break the
+# pattern; the hard stop exists because a nudge the model ignores costs the user the
+# rest of the session.
+REPEAT_NUDGE_AT = 3
+REPEAT_ABORT_AT = 5
 
 
 def should_continue_loop(max_turns: int, turn: int, interrupted: bool) -> bool:
@@ -26,3 +35,54 @@ def resolve_turn_outcome(truncated: bool, tool_calls: list, interrupted: bool) -
     if truncated:
         return "truncated"
     return "continue" if tool_calls else "done"
+
+
+def call_signature(name: str, arguments) -> str:
+    """Stable identity of a tool call, so a byte-identical retry is recognisable.
+
+    Arguments that will not serialise fall back to repr(): a coarser signature costs
+    at worst a missed intervention, while raising here would break the tool loop.
+    """
+    try:
+        return json.dumps([name, arguments], sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return repr((name, arguments))
+
+
+def update_failure_streak(streak: tuple, signature: str, failed: bool) -> tuple:
+    """Advance the consecutive-identical-failure streak, as (signature, count).
+
+    Any success, and any call that differs from the last one, resets it. Only an
+    unbroken run of the same failing call counts, so a model that is genuinely
+    exploring - a different argument, a different tool - is never interrupted.
+    """
+    if not failed:
+        return ("", 0)
+    previous, count = streak
+    if signature == previous:
+        return (signature, count + 1)
+    return (signature, 1)
+
+
+def repeat_intervention(count: int) -> str:
+    """Classify a streak length: "" to let it run, else "nudge" or "abort"."""
+    if count >= REPEAT_ABORT_AT:
+        return "abort"
+    if count >= REPEAT_NUDGE_AT:
+        return "nudge"
+    return ""
+
+
+def repeat_nudge(tool_name: str, count: int) -> str:
+    """Note appended to a repeated failure's result.
+
+    Addressed to the model, so it is deliberately not translated - this is prompt
+    text, not UI text.
+    """
+    return (
+        "\n\n[Loop guard: this exact {} call has now failed {} times in a row with "
+        "the same error. Retrying it unchanged will fail again. Change approach, or "
+        "tell the user what you are missing and ask them for it.]".format(
+            tool_name, count
+        )
+    )

--- a/freecad_ai/core/system_prompt.py
+++ b/freecad_ai/core/system_prompt.py
@@ -436,6 +436,22 @@ def build_system_prompt(mode: str = "plan", agents_md: str = "",
     except Exception:
         pass
 
+    # Instructions shipped by other installed modules (Mod/<Module>/ai/)
+    try:
+        from ..extensions.module_assets import load_module_instructions
+        module_instructions = load_module_instructions()
+        if module_instructions:
+            sections.append("## Workbench Instructions")
+            sections.append(
+                "Instructions supplied by installed workbenches. They describe "
+                "that workbench's own objects and tools, and take precedence "
+                "over general guidance when working in it."
+            )
+            sections.append(module_instructions)
+            sections.append("")
+    except Exception:
+        pass
+
     # AGENTS.md
     if not agents_md:
         agents_md = load_agents_md()

--- a/freecad_ai/core/system_prompt.py
+++ b/freecad_ai/core/system_prompt.py
@@ -10,12 +10,21 @@ Assembles a dynamic system prompt that includes:
 """
 
 from .context import get_document_context
+from ..branding import APP_NAME, IS_BRANDED, PRODUCT_NAME
 from ..extensions.agents_md import load_agents_md
 
-IDENTITY = """\
-You are FreeCAD AI, an expert assistant that helps users create and modify 3D models \
-in FreeCAD using Python scripting. You understand FreeCAD's API deeply and generate \
-correct, efficient Python code that runs in FreeCAD's built-in interpreter."""
+# On a branded host the model has no training signal for the brand name, so
+# anchor it to FreeCAD — the API it must actually generate code against. The
+# plain form is used on stock FreeCAD, where the anchor would be circular.
+_API_SENTENCE = (
+    f"{APP_NAME} is a CAD application built on FreeCAD and scripted with the "
+    f"FreeCAD Python API, which you understand deeply."
+) if IS_BRANDED else "You understand the FreeCAD Python API deeply."
+
+IDENTITY = f"""\
+You are {PRODUCT_NAME}, an expert assistant that helps users create and modify 3D \
+models in {APP_NAME} using Python scripting. {_API_SENTENCE} You generate correct, \
+efficient Python code that runs in {APP_NAME}'s built-in interpreter."""
 
 PLAN_MODE = """\
 ## Mode: Plan
@@ -25,19 +34,19 @@ You are in **Plan** mode. When the user asks you to create or modify geometry:
 - Do NOT execute code yourself — the user will review and execute it manually
 - If the user asks a question (not a modeling request), answer normally without code"""
 
-ACT_MODE = """\
+ACT_MODE = f"""\
 ## Mode: Act
 You are in **Act** mode. When the user asks you to create or modify geometry:
 - Generate Python code in a ```python fenced code block
-- The code will be automatically extracted and executed in FreeCAD
+- The code will be automatically extracted and executed in {APP_NAME}
 - Always include error handling (try/except) so failures are caught gracefully
 - After modifying geometry, call App.ActiveDocument.recompute()
 - If the user asks a question (not a modeling request), answer normally without code"""
 
-ACT_MODE_TOOLS = """\
+ACT_MODE_TOOLS = f"""\
 ## Mode: Act (with Tools)
 You are in **Act** mode with tool calling enabled. You have access to structured tools \
-that perform FreeCAD operations safely. Prefer using tools over generating raw code.
+that perform {APP_NAME} operations safely. Prefer using tools over generating raw code.
 
 **How to use tools:**
 - Use the available tools to create, modify, and query 3D geometry

--- a/freecad_ai/extensions/module_assets.py
+++ b/freecad_ai/extensions/module_assets.py
@@ -1,0 +1,161 @@
+"""Module assets -- lets other FreeCAD modules ship their own assistant assets.
+
+Any installed FreeCAD module may carry an ``ai/`` directory:
+
+    Mod/<AnyModule>/ai/
+        skills/<name>/SKILL.md    same layout as the built-in skills
+        tools/*.py                same contract as user extension tools
+        hooks/<name>/hook.py      same contract as user hooks
+        INSTRUCTIONS.md           appended to the system prompt
+
+This exists because the built-in/user split cannot express "this workbench
+brings its own assistant knowledge". A module that defines its own document
+types knows things the generic assistant cannot infer, and that knowledge
+belongs in the module's own repository -- versioned and tested alongside the
+code it describes, not copied by hand into the user config directory where the
+next reinstall or edit silently diverges from it.
+
+Precedence is deliberate: built-in < module < user. A module may extend the
+assistant, and the user always keeps the last word over both.
+
+Note the deliberate naming: "provider" is already taken in this codebase for
+LLM providers (see freecad_ai/llm/providers.py), so these are module *assets*.
+"""
+
+import os
+
+# Environment override: os.pathsep-separated list of asset directories. Each
+# entry is an "ai" directory itself (not a Mod/ root), so a development tree can
+# be pointed at without installing. Mirrors FREECAD_AI_CONFIG_DIR.
+ASSET_DIRS_ENV = "FREECAD_AI_ASSET_DIRS"
+
+# Subdirectory a module must carry for its assets to be discovered.
+ASSET_SUBDIR = "ai"
+
+# Filename a module may use to add instructions to the system prompt.
+INSTRUCTIONS_FILENAME = "INSTRUCTIONS.md"
+
+# Discovery walks every installed module on every call site, and
+# create_default_registry() runs on every message, so the scan is cached.
+_cache: list[str] | None = None
+
+
+def _mod_roots() -> list[str]:
+    """Return the Mod/ directories FreeCAD loads modules from.
+
+    Three bases, because no single one is right everywhere:
+
+    - getUserAppDataDir() holds modules the user installed themselves.
+    - getHomePath() is the application's own installation root, and is where a
+      packaged build puts the modules it ships.
+    - getResourceDir() is where a stock FreeCAD build keeps them.
+
+    The last two are not interchangeable. On a branded build getResourceDir()
+    can point at a data/ subdirectory holding only per-module Resources, while
+    the actual modules live under getHomePath()/Mod - probing only the resource
+    directory finds an empty or unrelated Mod there and silently discovers
+    nothing.
+    """
+    try:
+        import FreeCAD as App
+    except ImportError:
+        return []
+
+    roots = []
+    for base in (App.getUserAppDataDir(), App.getHomePath(), App.getResourceDir()):
+        if not base:
+            continue
+        candidate = os.path.join(base, "Mod")
+        if os.path.isdir(candidate) and candidate not in roots:
+            roots.append(candidate)
+    return roots
+
+
+def _env_dirs() -> list[str]:
+    """Return asset directories named by ASSET_DIRS_ENV."""
+    raw = os.environ.get(ASSET_DIRS_ENV, "")
+    if not raw:
+        return []
+    return [
+        os.path.abspath(part)
+        for part in raw.split(os.pathsep)
+        if part.strip() and os.path.isdir(part.strip())
+    ]
+
+
+def discover_asset_dirs(refresh: bool = False) -> list[str]:
+    """Return every module's ``ai/`` directory, deduplicated.
+
+    Sorted by module name within each Mod root so registration order is
+    reproducible across runs. Results are cached; pass ``refresh=True`` after
+    installing a module in a running session.
+    """
+    global _cache
+    if _cache is not None and not refresh:
+        return list(_cache)
+
+    found: list[str] = []
+
+    for root in _mod_roots():
+        try:
+            entries = sorted(os.listdir(root))
+        except OSError:
+            continue
+        for entry in entries:
+            ai_dir = os.path.join(root, entry, ASSET_SUBDIR)
+            if os.path.isdir(ai_dir) and ai_dir not in found:
+                found.append(ai_dir)
+
+    # Env entries last so a development tree overrides an installed copy.
+    for d in _env_dirs():
+        if d not in found:
+            found.append(d)
+
+    _cache = found
+    return list(found)
+
+
+def asset_subdirs(name: str, refresh: bool = False) -> list[str]:
+    """Return every existing ``<module>/ai/<name>`` directory.
+
+    ``name`` is one of "skills", "tools", "hooks".
+    """
+    dirs = []
+    for asset_dir in discover_asset_dirs(refresh=refresh):
+        sub = os.path.join(asset_dir, name)
+        if os.path.isdir(sub):
+            dirs.append(sub)
+    return dirs
+
+
+def owning_module(asset_dir: str) -> str:
+    """Return the name of the module that ships an asset directory."""
+    return os.path.basename(os.path.dirname(os.path.abspath(asset_dir)))
+
+
+def load_module_instructions() -> str:
+    """Return the concatenated INSTRUCTIONS.md of every module that ships one.
+
+    Each block is headed with the owning module's name so the model can tell
+    which workbench is speaking, and so a stale block is traceable to a module.
+    Modules that ship no instructions contribute nothing.
+    """
+    blocks = []
+    for asset_dir in discover_asset_dirs():
+        path = os.path.join(asset_dir, INSTRUCTIONS_FILENAME)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if content:
+            blocks.append(f"### {owning_module(asset_dir)}\n{content}")
+    return "\n\n".join(blocks)
+
+
+def reset_cache():
+    """Forget the cached scan. Used by tests and after installing a module."""
+    global _cache
+    _cache = None

--- a/freecad_ai/extensions/skill_validator.py
+++ b/freecad_ai/extensions/skill_validator.py
@@ -538,10 +538,12 @@ def _run_single_check(
                 import FreeCAD
                 import Part
             except ImportError:
+                from ..branding import APP_NAME
                 return CheckResult(
                     target=target, check=check, passed=False,
-                    expected=str(expected_area), actual="FreeCAD not available",
-                    message="section_area: FreeCAD not available",
+                    expected=str(expected_area),
+                    actual="{} not available".format(APP_NAME),
+                    message="section_area: {} not available".format(APP_NAME),
                 )
             direction = FreeCAD.Vector(*axis_map[axis_name])
             wires = obj.Shape.slice(direction, offset)

--- a/freecad_ai/extensions/skills.py
+++ b/freecad_ai/extensions/skills.py
@@ -1,6 +1,9 @@
 """Skills registry with execution support and slash command matching.
 
-Skills are user-level instruction/action sets stored under
+Skills are instruction/action sets loaded from three places, in ascending
+precedence: the built-in skills/ directory in this repo, the ai/skills/
+ai/skills/ directory of any other installed module (see
+extensions.module_assets), and
 ~/.config/FreeCAD/FreeCADAI/skills/. Each skill is a directory containing:
   - SKILL.md: LLM instructions for the skill (injected into prompt)
   - handler.py: (optional) Python handler with an execute() function
@@ -47,13 +50,26 @@ class SkillsRegistry:
     def _load_skills(self):
         """Scan skills directories and load skill definitions.
 
-        Scans both the built-in skills directory (in the repo) and the user
-        skills directory (~/.config/FreeCAD/FreeCADAI/skills/). User skills
-        take precedence over built-in skills with the same name.
+        Three tiers, scanned in ascending precedence: the built-in skills
+        directory (in the repo), any skills shipped by other installed
+        modules (Mod/<Module>/ai/skills/), and the user skills directory
+        (~/.config/FreeCAD/FreeCADAI/skills/). Later tiers overwrite earlier
+        ones by directory name, so the user always keeps the last word.
         """
-        # Load built-in first, then user (user overrides built-in)
-        for skills_dir in (BUILTIN_SKILLS_DIR, SKILLS_DIR):
+        for skills_dir in self._skill_dirs():
             self._scan_skills_dir(skills_dir)
+
+    @staticmethod
+    def _skill_dirs() -> list[str]:
+        """Skill directories in ascending precedence order."""
+        dirs = [BUILTIN_SKILLS_DIR]
+        try:
+            from .module_assets import asset_subdirs
+            dirs.extend(asset_subdirs("skills"))
+        except Exception:
+            pass  # Module asset discovery is optional
+        dirs.append(SKILLS_DIR)
+        return dirs
 
     def _scan_skills_dir(self, skills_dir: str):
         """Scan a single directory for skill definitions."""
@@ -282,39 +298,42 @@ class SkillsRegistry:
 
     @staticmethod
     def get_skill_status() -> list[dict]:
-        """Return status info for all skills across built-in and user dirs.
+        """Return status info for all skills across every source directory.
 
         Each entry: {"name", "description", "source", "has_user_copy",
-                     "is_modified", "builtin_path", "user_path"}
+                     "is_modified", "builtin_path", "module_path",
+                     "user_path"}
 
-        source: "built-in", "user", or "modified" (user copy differs from built-in)
+        source: "built-in", "module", "user", or "modified" (user copy
+        differs from the shipped version it shadows)
         """
         results = []
-        builtin_skills = {}
-        user_skills = {}
+        builtin_skills = _scan_skill_files(BUILTIN_SKILLS_DIR)
+        user_skills = _scan_skill_files(SKILLS_DIR)
 
-        # Scan built-in
-        if os.path.isdir(BUILTIN_SKILLS_DIR):
-            for entry in sorted(os.listdir(BUILTIN_SKILLS_DIR)):
-                skill_file = os.path.join(BUILTIN_SKILLS_DIR, entry, "SKILL.md")
-                if os.path.isfile(skill_file):
-                    builtin_skills[entry] = skill_file
+        module_skills = {}
+        try:
+            from .module_assets import asset_subdirs
+            for asset_dir in asset_subdirs("skills"):
+                module_skills.update(_scan_skill_files(asset_dir))
+        except Exception:
+            pass  # Module asset discovery is optional
 
-        # Scan user
-        if os.path.isdir(SKILLS_DIR):
-            for entry in sorted(os.listdir(SKILLS_DIR)):
-                skill_file = os.path.join(SKILLS_DIR, entry, "SKILL.md")
-                if os.path.isfile(skill_file):
-                    user_skills[entry] = skill_file
-
-        all_names = sorted(set(builtin_skills) | set(user_skills))
+        all_names = sorted(
+            set(builtin_skills) | set(module_skills) | set(user_skills)
+        )
 
         for name in all_names:
             b_path = builtin_skills.get(name)
+            p_path = module_skills.get(name)
             u_path = user_skills.get(name)
 
-            # Read description from whichever is active (user overrides built-in)
-            active_path = u_path or b_path
+            # The shipped version a user copy would be shadowing; another
+            # module wins over built-ins, matching _skill_dirs() order.
+            shipped_path = p_path or b_path
+
+            # Read description from whichever is active (user overrides shipped)
+            active_path = u_path or shipped_path
             description = ""
             try:
                 with open(active_path, "r", encoding="utf-8") as f:
@@ -332,11 +351,12 @@ class SkillsRegistry:
             except Exception:
                 pass
 
-            if b_path and u_path:
-                is_modified = _file_hash(b_path) != _file_hash(u_path)
-                source = "modified" if is_modified else "built-in"
-            elif b_path:
-                source = "built-in"
+            shipped_source = "module" if p_path else "built-in"
+            if shipped_path and u_path:
+                is_modified = _file_hash(shipped_path) != _file_hash(u_path)
+                source = "modified" if is_modified else shipped_source
+            elif shipped_path:
+                source = shipped_source
             else:
                 source = "user"
 
@@ -347,6 +367,7 @@ class SkillsRegistry:
                 "has_user_copy": u_path is not None,
                 "is_modified": source == "modified",
                 "builtin_path": b_path or "",
+                "module_path": p_path or "",
                 "user_path": u_path or "",
             })
 
@@ -354,20 +375,46 @@ class SkillsRegistry:
 
     @staticmethod
     def reset_to_builtin(name: str) -> bool:
-        """Delete the user copy of a skill, reverting to the built-in version.
+        """Delete the user copy of a skill, reverting to the shipped version.
 
-        Returns True if the user copy was deleted.
+        The shipped version is the built-in skill, or another module's skill
+        if one shadows it. Returns True if the user copy was deleted.
         """
         user_skill_dir = os.path.join(SKILLS_DIR, name)
-        builtin_skill = os.path.join(BUILTIN_SKILLS_DIR, name, "SKILL.md")
 
-        if not os.path.isfile(builtin_skill):
-            return False
+        if not os.path.isfile(os.path.join(BUILTIN_SKILLS_DIR, name, "SKILL.md")):
+            if not _module_skill_path(name):
+                return False
 
         if os.path.isdir(user_skill_dir):
             shutil.rmtree(user_skill_dir)
             return True
         return False
+
+
+def _scan_skill_files(skills_dir: str) -> dict:
+    """Map skill name -> SKILL.md path for one directory."""
+    found = {}
+    if not os.path.isdir(skills_dir):
+        return found
+    for entry in sorted(os.listdir(skills_dir)):
+        skill_file = os.path.join(skills_dir, entry, "SKILL.md")
+        if os.path.isfile(skill_file):
+            found[entry] = skill_file
+    return found
+
+
+def _module_skill_path(name: str) -> str:
+    """Return a module's SKILL.md path for `name`, or "" if none ships it."""
+    try:
+        from .module_assets import asset_subdirs
+        for asset_dir in asset_subdirs("skills"):
+            candidate = os.path.join(asset_dir, name, "SKILL.md")
+            if os.path.isfile(candidate):
+                return candidate
+    except Exception:
+        pass  # Module asset discovery is optional
+    return ""
 
 
 def _reference_summary(path: str) -> str:

--- a/freecad_ai/extensions/user_tools.py
+++ b/freecad_ai/extensions/user_tools.py
@@ -1,13 +1,15 @@
 """User extension tools — discover, validate, and register user-authored tool functions.
 
-Scans .py and .FCMacro files from USER_TOOLS_DIR, validates with ast,
-imports and introspects functions, and wraps each as a ToolDefinition.
+Scans .py and .FCMacro files from USER_TOOLS_DIR and any provider tool
+directories, validates with ast, imports and introspects functions, and wraps
+each as a ToolDefinition.
 """
 
 import ast
 import importlib.machinery
 import importlib.util
 import os
+import textwrap
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -20,9 +22,28 @@ _TYPE_MAP = {
     "int": "integer",
     "str": "string",
     "bool": "boolean",
+    "list[str]": "array",
+    "list[float]": "array",
+    "list[int]": "array",
+}
+
+# Array types additionally need "items" — strict providers (OpenAI's
+# marketplace API) reject an "array" property without it, see
+# tests/unit/test_registry.py::test_every_array_property_has_items.
+_ITEMS_MAP = {
+    "list[str]": {"type": "string"},
+    "list[float]": {"type": "number"},
+    "list[int]": {"type": "integer"},
 }
 
 SUPPORTED_TYPES = set(_TYPE_MAP.keys())
+
+# Module-level string a tool file may define to choose its own tool-name
+# prefix. Provider modules use it to namespace their tools by workbench
+# instead of inheriting the "user_" prefix.
+TOOL_PREFIX_ATTR = "__tool_prefix__"
+
+DEFAULT_TOOL_PREFIX = "user_"
 
 
 @dataclass
@@ -32,6 +53,7 @@ class FuncParam:
     type_name: str
     required: bool = True
     default: Any = None
+    description: str = ""
 
 
 @dataclass
@@ -49,6 +71,7 @@ class ValidationResult:
     functions: list[FuncInfo] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     error: str = ""
+    prefix: str = DEFAULT_TOOL_PREFIX
 
 
 def validate_file(path: str) -> ValidationResult:
@@ -60,7 +83,7 @@ def validate_file(path: str) -> ValidationResult:
     - Warns on missing docstrings, unsupported param types
     """
     try:
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             source = f.read()
     except OSError as e:
         return ValidationResult(valid=False, error=f"Cannot read file: {e}")
@@ -72,12 +95,18 @@ def validate_file(path: str) -> ValidationResult:
 
     functions: list[FuncInfo] = []
     warnings: list[str] = []
+    prefix = _extract_tool_prefix(tree)
 
     for node in ast.iter_child_nodes(tree):
         if not isinstance(node, ast.FunctionDef):
             continue
         if node.name.startswith("_"):
             continue
+
+        # Parse the docstring first — the model reads the tool description and
+        # per-parameter descriptions to decide how to call the tool, so both
+        # come from prose the author already wrote.
+        description, param_docs = _parse_docstring(node)
 
         # Extract type-hinted parameters
         params: list[FuncParam] = []
@@ -92,15 +121,9 @@ def validate_file(path: str) -> ValidationResult:
         for i, arg in enumerate(args.args):
             if arg.arg == "self":
                 continue
-            annotation = arg.annotation
-            if annotation is None:
+            type_name = _annotation_name(arg.annotation)
+            if not type_name:
                 continue  # skip untyped params
-
-            type_name = ""
-            if isinstance(annotation, ast.Name):
-                type_name = annotation.id
-            elif isinstance(annotation, ast.Attribute):
-                type_name = annotation.attr
 
             if type_name not in SUPPORTED_TYPES:
                 has_unsupported = True
@@ -122,19 +145,14 @@ def validate_file(path: str) -> ValidationResult:
                 type_name=type_name,
                 required=not has_default,
                 default=default_val,
+                description=param_docs.get(arg.arg, ""),
             ))
 
-        if not params:
-            continue  # no typed params — skip this function
-
-        # Extract docstring
-        description = ""
-        if (node.body
-                and isinstance(node.body[0], ast.Expr)
-                and isinstance(node.body[0].value, ast.Constant)
-                and isinstance(node.body[0].value.value, str)):
-            raw = node.body[0].value.value
-            description = raw.strip().split("\n")[0]
+        # A function that declares no parameters at all is a legitimate tool - "list
+        # what is available" needs no arguments. Only skip functions whose parameters
+        # exist but are all untyped, since there is no schema to build from those.
+        if not params and node.args.args:
+            continue
 
         if not description:
             warnings.append(f"{node.name}(): missing docstring")
@@ -150,9 +168,12 @@ def validate_file(path: str) -> ValidationResult:
             valid=False,
             warnings=warnings,
             error="No valid tool functions found (need public functions with type hints)",
+            prefix=prefix,
         )
 
-    return ValidationResult(valid=True, functions=functions, warnings=warnings)
+    return ValidationResult(
+        valid=True, functions=functions, warnings=warnings, prefix=prefix
+    )
 
 
 def load_user_tools(
@@ -204,7 +225,7 @@ def load_user_tools(
                 continue
 
             for func_info in vr.functions:
-                tool_name = f"user_{func_info.name}"
+                tool_name = f"{vr.prefix}{func_info.name}"
                 if tool_name in registered_names:
                     continue  # primary dir takes precedence
 
@@ -216,9 +237,10 @@ def load_user_tools(
                     ToolParam(
                         name=fp.name,
                         type=_TYPE_MAP[fp.type_name],
-                        description=f"Parameter: {fp.name}",
+                        description=fp.description or f"Parameter: {fp.name}",
                         required=fp.required,
                         default=fp.default,
+                        items=_ITEMS_MAP.get(fp.type_name),
                     )
                     for fp in func_info.params
                 ]
@@ -267,6 +289,94 @@ def _make_handler(func):
         except Exception as e:
             return ToolResult(success=False, output="", error=str(e))
     return handler
+
+
+def _annotation_name(annotation) -> str:
+    """Return a canonical type name for a parameter annotation.
+
+    Handles the plain scalar forms (``float``, ``module.Thing``) plus the
+    single-argument generic ``list[str]``, which is written back out in the
+    same ``list[x]`` spelling used as the _TYPE_MAP key.
+    """
+    if annotation is None:
+        return ""
+    if isinstance(annotation, ast.Name):
+        return annotation.id
+    if isinstance(annotation, ast.Attribute):
+        return annotation.attr
+    if isinstance(annotation, ast.Subscript):
+        container = _annotation_name(annotation.value)
+        item = _annotation_name(annotation.slice)
+        if container and item:
+            return f"{container}[{item}]"
+        return container
+    return ""
+
+
+def _parse_docstring(node: ast.FunctionDef) -> tuple[str, dict]:
+    """Split a function docstring into a description and per-parameter docs.
+
+    Recognises the Google-style ``Args:`` block used throughout this codebase.
+    The description keeps every line before ``Args:`` (not just the summary),
+    because a tool's description is the model's only account of what the tool
+    does and when to reach for it. ``Returns:``/``Raises:`` sections are
+    dropped — they describe the handler's return value, which the model sees
+    directly in the tool result.
+    """
+    raw = ast.get_docstring(node)
+    if not raw:
+        return "", {}
+
+    lines = textwrap.dedent(raw).strip().splitlines()
+    section = "description"
+    description_lines: list[str] = []
+    param_docs: dict[str, str] = {}
+    current_param = ""
+
+    for line in lines:
+        stripped = line.strip()
+        heading = stripped.rstrip(":").lower()
+        if stripped.endswith(":") and heading in ("args", "arguments", "parameters"):
+            section = "args"
+            current_param = ""
+            continue
+        if stripped.endswith(":") and heading in (
+            "returns", "return", "raises", "yields", "examples", "example", "note", "notes"
+        ):
+            section = "other"
+            current_param = ""
+            continue
+
+        if section == "description":
+            description_lines.append(stripped)
+        elif section == "args":
+            name, sep, text = stripped.partition(":")
+            # "name (type): text" is also valid Google style.
+            name = name.split("(")[0].strip()
+            if sep and name.isidentifier():
+                current_param = name
+                param_docs[current_param] = text.strip()
+            elif current_param and stripped:
+                # Continuation of the previous parameter's description.
+                param_docs[current_param] = (
+                    f"{param_docs[current_param]} {stripped}".strip()
+                )
+
+    description = "\n".join(description_lines).strip()
+    return description, param_docs
+
+
+def _extract_tool_prefix(tree: ast.Module) -> str:
+    """Return the module's __tool_prefix__ value, or the default."""
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == TOOL_PREFIX_ATTR:
+                value = _extract_constant(node.value)
+                if isinstance(value, str):
+                    return value
+    return DEFAULT_TOOL_PREFIX
 
 
 def _extract_constant(node: ast.expr) -> Any:

--- a/freecad_ai/hooks/registry.py
+++ b/freecad_ai/hooks/registry.py
@@ -25,6 +25,23 @@ def _get_disabled() -> list:
         return []
 
 
+def _hook_dirs() -> list:
+    """Hook directories in descending precedence order.
+
+    Unlike skills, the first directory to define a hook name wins (see the
+    dedup check in _load_hooks), so built-ins come first and the user
+    directory last.
+    """
+    dirs = [BUILTIN_HOOKS_DIR]
+    try:
+        from ..extensions.module_assets import asset_subdirs
+        dirs.extend(asset_subdirs("hooks"))
+    except Exception:
+        pass  # Module asset discovery is optional
+    dirs.append(HOOKS_DIR)
+    return dirs
+
+
 class HookRegistry:
     def __init__(self):
         self._hooks: dict[str, list[tuple[str, callable]]] = {}
@@ -36,7 +53,7 @@ class HookRegistry:
         info = []
         disabled = _get_disabled()
 
-        for hooks_dir in (BUILTIN_HOOKS_DIR, HOOKS_DIR):
+        for hooks_dir in _hook_dirs():
             if not os.path.isdir(hooks_dir):
                 continue
             for entry in sorted(os.listdir(hooks_dir)):

--- a/freecad_ai/i18n.py
+++ b/freecad_ai/i18n.py
@@ -7,6 +7,18 @@ except Exception:
     def translate(context, text):
         return text
 
+def translate_branded(context, text):
+    """translate() with the brand placeholders filled in.
+
+    Source strings use %1 for the host application name and %2 for this
+    product's name, matching the Qt convention the host uses in C++
+    (src/Gui/CommandStd.cpp, src/Gui/Assistant.cpp). FreeCAD.Qt.translate
+    returns a plain str, so Qt's QString.arg() is not available here.
+    """
+    from .branding import APP_NAME, PRODUCT_NAME
+    return translate(context, text).replace("%2", PRODUCT_NAME).replace("%1", APP_NAME)
+
+
 try:
     from PySide2.QtCore import QT_TRANSLATE_NOOP
 except Exception:

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -769,8 +769,9 @@ class LLMClient:
         if url.startswith("https") and not _HAS_SSL:
             raise LLMError(
                 "HTTPS is not available (Python _ssl module missing). "
-                "This can happen with snap-packaged FreeCAD. "
-                "Use Ollama (http://localhost:11434) or fix the snap's Python SSL support."
+                "This can happen when the host application ships a Python built "
+                "without SSL support (e.g. snap packages). "
+                "Use Ollama (http://localhost:11434) or fix that Python's SSL support."
             )
 
     def _get_retry_delay(self, error: urllib.error.HTTPError, attempt: int) -> float:

--- a/freecad_ai/mcp/client.py
+++ b/freecad_ai/mcp/client.py
@@ -19,11 +19,12 @@ from .transport import (
     StreamableHTTPClientTransport,
     _LOOPBACK_HOSTS,
 )
+from ..branding import PRODUCT_NAME
 
 logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = "2025-03-26"
-CLIENT_INFO = {"name": "FreeCAD AI", "version": "0.1.0"}
+CLIENT_INFO = {"name": PRODUCT_NAME, "version": "0.1.0"}
 
 
 @dataclass

--- a/freecad_ai/mcp/server.py
+++ b/freecad_ai/mcp/server.py
@@ -9,10 +9,11 @@ import logging
 from ..tools.registry import ToolRegistry
 from . import protocol
 from .transport import StdioServerTransport
+from ..branding import PRODUCT_NAME
 
 logger = logging.getLogger(__name__)
 
-SERVER_INFO = {"name": "FreeCAD AI", "version": "0.1.0"}
+SERVER_INFO = {"name": PRODUCT_NAME, "version": "0.1.0"}
 PROTOCOL_VERSION = "2025-03-26"
 
 

--- a/freecad_ai/tools/freecad_tools.py
+++ b/freecad_ai/tools/freecad_tools.py
@@ -8,6 +8,7 @@ import os
 
 from .registry import ToolParam, ToolDefinition, ToolResult
 from ..core.executor import execute_code
+from ..branding import APP_NAME
 
 
 def _coerce_str_list(value):
@@ -40,7 +41,7 @@ def _with_undo(label: str, func):
         return ToolResult(
             success=False,
             output="",
-            error="No active document — open a document in FreeCAD or select its tab.",
+            error=f"No active document — open a document in {APP_NAME} or select its tab.",
         )
     doc.openTransaction(label)
     try:
@@ -3048,7 +3049,7 @@ def _handle_list_documents() -> ToolResult:
 
 LIST_DOCUMENTS = ToolDefinition(
     name="list_documents",
-    description="List all open FreeCAD documents with object counts and active indicator.",
+    description=f"List all open {APP_NAME} documents with object counts and active indicator.",
     category="query",
     parameters=[],
     handler=_handle_list_documents,
@@ -3087,7 +3088,7 @@ def _handle_switch_document(document_name: str) -> ToolResult:
 
 SWITCH_DOCUMENT = ToolDefinition(
     name="switch_document",
-    description="Switch the active FreeCAD document by name or label.",
+    description=f"Switch the active {APP_NAME} document by name or label.",
     category="query",
     parameters=[
         ToolParam("document_name", "string", "Name or label of the document to activate"),
@@ -3613,10 +3614,10 @@ def _handle_run_macro(macro: str) -> ToolResult:
 RUN_MACRO = ToolDefinition(
     name="run_macro",
     description=(
-        "Run an EXISTING FreeCAD macro file and return its console output "
+        f"Run an EXISTING {APP_NAME} macro file and return its console output "
         "(stdout/stderr). Use this to execute a macro the user already has on "
         "disk, e.g. a test harness. In normal mode, pass a bare macro NAME "
-        "(without extension) that lives in FreeCAD's macro directory; file "
+        f"(without extension) that lives in {APP_NAME}'s macro directory; file "
         "paths are refused unless the user has enabled Dangerous mode. Use "
         "execute_code instead when you want to run code you are writing inline."
     ),

--- a/freecad_ai/tools/macro_runner.py
+++ b/freecad_ai/tools/macro_runner.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 
 import os
 
+from ..branding import APP_NAME
+
 _DANGEROUS_HINT = (
     "Refused: in safe mode run_macro accepts only a bare macro name resolved "
-    "from FreeCAD's macro directories. Enable Dangerous mode to run arbitrary "
-    "file paths."
+    "from {}'s macro directories. Enable Dangerous mode to run arbitrary "
+    "file paths.".format(APP_NAME)
 )
 
 

--- a/freecad_ai/tools/optimize_tools.py
+++ b/freecad_ai/tools/optimize_tools.py
@@ -12,6 +12,7 @@ import time
 from typing import Optional
 
 from .registry import ToolDefinition, ToolParam, ToolResult
+from ..branding import PRODUCT_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ STRATEGY_INSTRUCTIONS = {
 # ── Prompt template for LLM skill modification ──────────────────────────
 
 MODIFICATION_PROMPT = """\
-You are improving a FreeCAD AI SKILL.md file based on test results.
+You are improving a {product_name} SKILL.md file based on test results.
 
 ## Current SKILL.md
 
@@ -160,6 +161,7 @@ def _ask_llm_for_modification(skill_content, iteration, score, results_text,
 
     client = create_client_from_config()
     prompt = MODIFICATION_PROMPT.format(
+        product_name=PRODUCT_NAME,
         skill_content=skill_content,
         iteration=iteration,
         score=score,
@@ -170,7 +172,8 @@ def _ask_llm_for_modification(skill_content, iteration, score, results_text,
     try:
         response = client.send(
             [{"role": "user", "content": prompt}],
-            system="You are a FreeCAD AI skill optimizer. Return only the modified SKILL.md.",
+            system=f"You are a {PRODUCT_NAME} skill optimizer. "
+                   "Return only the modified SKILL.md.",
         )
     except Exception as e:
         logger.error("LLM modification request failed: %s", e)

--- a/freecad_ai/tools/setup.py
+++ b/freecad_ai/tools/setup.py
@@ -20,7 +20,7 @@ def create_default_registry(include_mcp: bool = True, extra_tools: list | None =
     for tool in ALL_TOOLS:
         registry.register(tool)
 
-    # Load user extension tools
+    # Load user extension tools, plus any shipped by other installed modules
     try:
         from ..config import USER_TOOLS_DIR, get_config
         from ..extensions.user_tools import load_user_tools
@@ -32,6 +32,11 @@ def create_default_registry(include_mcp: bool = True, extra_tools: list | None =
             )
             if os.path.isdir(fc_macro_dir):
                 extra_dirs.append(fc_macro_dir)
+        try:
+            from ..extensions.module_assets import asset_subdirs
+            extra_dirs.extend(asset_subdirs("tools"))
+        except Exception:
+            pass  # Module asset discovery is optional
         user_tools = load_user_tools(
             USER_TOOLS_DIR,
             disabled=cfg.user_tools_disabled,

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -1016,6 +1016,7 @@ class ChatDockWidget(QDockWidget):
             translate("ChatDockWidget", "Plan"),
             translate("ChatDockWidget", "Act"),
         ])
+        self.mode_combo.setMinimumWidth(80)
         cfg = get_config()
         self.mode_combo.setCurrentIndex(0 if cfg.mode == "plan" else 1)
         self.mode_combo.currentIndexChanged.connect(self._on_mode_changed)
@@ -1024,7 +1025,7 @@ class ChatDockWidget(QDockWidget):
 
         # Viewport capture toggle
         self._capture_btn = QPushButton(translate("ChatDockWidget", "Capture"))
-        self._capture_btn.setMaximumWidth(70)
+        self._capture_btn.setMinimumWidth(self._capture_btn.sizeHint().width())
         self._capture_btn.setToolTip(translate("ChatDockWidget", "Viewport capture: off"))
         self._capture_btn.clicked.connect(self._cycle_capture_mode)
         header.addWidget(self._capture_btn)
@@ -1041,7 +1042,7 @@ class ChatDockWidget(QDockWidget):
 
         # Settings button
         settings_btn = QPushButton(translate("ChatDockWidget", "Settings"))
-        settings_btn.setMaximumWidth(80)
+        settings_btn.setMinimumWidth(settings_btn.sizeHint().width())
         settings_btn.clicked.connect(self._open_settings)
         header.addWidget(settings_btn)
 
@@ -1094,7 +1095,6 @@ class ChatDockWidget(QDockWidget):
         btn_layout.setSpacing(2)
 
         self._attach_btn = QPushButton(translate("ChatDockWidget", "Attach"))
-        self._attach_btn.setMaximumHeight(20)
         self._attach_btn.setToolTip(translate("ChatDockWidget", "Attach a file (image, text, or document)"))
         self._attach_btn.clicked.connect(self._attach_file)
         btn_layout.addWidget(self._attach_btn)
@@ -1116,18 +1116,18 @@ class ChatDockWidget(QDockWidget):
         footer = QHBoxLayout()
 
         new_chat_btn = QPushButton(translate("ChatDockWidget", "+ New Chat"))
-        new_chat_btn.setMaximumWidth(100)
+        new_chat_btn.setMinimumWidth(new_chat_btn.sizeHint().width())
         new_chat_btn.clicked.connect(self._new_chat)
         footer.addWidget(new_chat_btn)
 
         load_chat_btn = QPushButton(translate("ChatDockWidget", "Load"))
-        load_chat_btn.setMaximumWidth(60)
+        load_chat_btn.setMinimumWidth(load_chat_btn.sizeHint().width())
         load_chat_btn.setToolTip(translate("ChatDockWidget", "Load a previous chat session"))
         load_chat_btn.clicked.connect(self._load_chat)
         footer.addWidget(load_chat_btn)
 
         save_log_btn = QPushButton(translate("ChatDockWidget", "Save Log"))
-        save_log_btn.setMaximumWidth(80)
+        save_log_btn.setMinimumWidth(save_log_btn.sizeHint().width())
         save_log_btn.setToolTip(translate("ChatDockWidget", "Save session log for debugging"))
         save_log_btn.clicked.connect(self._save_session_log)
         footer.addWidget(save_log_btn)

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -13,7 +13,8 @@ import json
 import time
 
 from .compat import QtWidgets, QtCore, QtGui
-from ..i18n import translate
+from ..i18n import translate, translate_branded
+from ..branding import APP_NAME, PRODUCT_NAME
 
 QDockWidget = QtWidgets.QDockWidget
 QWidget = QtWidgets.QWidget
@@ -139,7 +140,7 @@ def _freecad_log(msg: str):
     """Print a line to FreeCAD's Report View, if FreeCAD is available."""
     try:
         import FreeCAD as _App
-        _App.Console.PrintMessage("[FreeCAD AI] {}\n".format(msg))
+        _App.Console.PrintMessage("[{}] {}\n".format(PRODUCT_NAME, msg))
     except Exception:
         pass
 
@@ -811,7 +812,7 @@ class ChatDockWidget(QDockWidget):
     """Main chat dock widget for FreeCAD AI."""
 
     def __init__(self, parent=None):
-        super().__init__(translate("ChatDockWidget", "FreeCAD AI"), parent)
+        super().__init__(PRODUCT_NAME, parent)
         self.setObjectName("FreeCADAIChatDock")
         self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
 
@@ -1006,7 +1007,7 @@ class ChatDockWidget(QDockWidget):
         # ── Header bar ──
         header = QHBoxLayout()
 
-        title = QLabel("<b>{}</b>".format(translate("ChatDockWidget", "FreeCAD AI")))
+        title = QLabel("<b>{}</b>".format(PRODUCT_NAME))
         header.addWidget(title)
         header.addStretch()
 
@@ -1034,9 +1035,9 @@ class ChatDockWidget(QDockWidget):
         self.danger_toggle = QtWidgets.QCheckBox(
             translate("ChatDockWidget", "⚠ Dangerous mode"))
         self.danger_toggle.setToolTip(
-            translate("ChatDockWidget",
-                      "Disable code safety checks and allow running macros from any path. "
-                      "Session-only — resets when FreeCAD restarts."))
+            translate_branded("ChatDockWidget",
+                              "Disable code safety checks and allow running macros from any path. "
+                              "Session-only — resets when %1 restarts."))
         self.danger_toggle.toggled.connect(self._on_danger_toggled)
         header.addWidget(self.danger_toggle)
 
@@ -1165,15 +1166,15 @@ class ChatDockWidget(QDockWidget):
             box = QtWidgets.QMessageBox(self)
             box.setIcon(QtWidgets.QMessageBox.Warning)
             box.setWindowTitle(translate("ChatDockWidget", "Enable Dangerous mode?"))
-            box.setText(translate(
+            box.setText(translate_branded(
                 "ChatDockWidget",
-                "Dangerous mode disables the safety checks built into FreeCAD AI."))
-            box.setInformativeText(translate(
+                "Dangerous mode disables the safety checks built into %2."))
+            box.setInformativeText(translate_branded(
                 "ChatDockWidget",
                 "While active:\n"
                 "• AI-run code may call shell commands, delete files, and touch "
                 "anything your user account can.\n"
-                "• A macro with an infinite loop will FREEZE FreeCAD with no "
+                "• A macro with an infinite loop will FREEZE %1 with no "
                 "recovery — unsaved work will be lost.\n"
                 "• Generated code runs against your live document without the "
                 "headless sandbox pre-check.\n\n"
@@ -1972,8 +1973,8 @@ class ChatDockWidget(QDockWidget):
                 try:
                     import FreeCAD as _App
                     _App.Console.PrintMessage(
-                        "[FreeCAD AI] Reranker ({}): {} of {} tools -> {}\n".format(
-                            cfg.rerank_method, len(ranked), len(pairs),
+                        "[{}] Reranker ({}): {} of {} tools -> {}\n".format(
+                            PRODUCT_NAME, cfg.rerank_method, len(ranked), len(pairs),
                             ", ".join(ranked))
                     )
                 except Exception:
@@ -2341,7 +2342,7 @@ class ChatDockWidget(QDockWidget):
             doc = App.ActiveDocument
         except ImportError:
             self._append_html(render_message("system",
-                "FreeCAD not available \u2014 cannot validate."))
+                "{} not available \u2014 cannot validate.".format(APP_NAME)))
             return
 
         if not doc:

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -36,7 +36,14 @@ QTextCursor = QtGui.QTextCursor
 from ..config import LOGS_DIR, get_config, prune_oldest_files, save_current_config
 from ..core.conversation import Conversation
 from ..core.executor import extract_code_blocks, extract_truncated_block, execute_code
-from ..core.loop_control import resolve_turn_outcome, should_continue_loop
+from ..core.loop_control import (
+    call_signature,
+    repeat_intervention,
+    repeat_nudge,
+    resolve_turn_outcome,
+    should_continue_loop,
+    update_failure_streak,
+)
 from ..core.input_history import InputHistory
 from .message_view import (
     _get_theme_colors,
@@ -299,6 +306,10 @@ class _LLMWorker(QThread):
         messages = list(self.messages)
 
         turn = 0
+        # (signature, count) of the current run of byte-identical failing calls,
+        # and the tool that tripped the hard stop once one does.
+        failure_streak = ("", 0)
+        looping_tool = ""
         while should_continue_loop(self._max_tool_turns, turn, self.isInterruptionRequested()):
             text_parts = []
             thinking_parts = []
@@ -417,6 +428,20 @@ class _LLMWorker(QThread):
                 error = result.get("error", "")
                 result_text = output if success else f"Error: {error}"
 
+                # Nothing else in this loop notices a model re-sending the same
+                # failing call, so it repeats until the turn limit. Nudge first,
+                # since that usually breaks the pattern; stop if it does not.
+                failure_streak = update_failure_streak(
+                    failure_streak,
+                    call_signature(tc.name, tc.arguments),
+                    not success,
+                )
+                intervention = repeat_intervention(failure_streak[1])
+                if intervention:
+                    result_text += repeat_nudge(tc.name, failure_streak[1])
+                if intervention == "abort":
+                    looping_tool = tc.name
+
                 # Track timing for summary
                 self._tool_timeline.append({
                     "name": tc.name, "success": success,
@@ -464,6 +489,20 @@ class _LLMWorker(QThread):
                     for tc, r in zip(tool_calls, tool_result_messages)
                 ],
             })
+
+            if looping_tool:
+                stop_msg = "\n\n[{}]".format(
+                    translate(
+                        "ChatDockWidget",
+                        "Stopped: the same {} call kept failing unchanged. "
+                        "The last error is above.",
+                    ).format(looping_tool)
+                )
+                self._full_response += stop_msg
+                self.token_received.emit(stop_msg)
+                self.response_finished.emit(self._full_response)
+                return
+
             turn += 1
 
         # If a tool was interrupted mid-wait, the user already saw a tool-failure

--- a/freecad_ai/ui/code_review_dialog.py
+++ b/freecad_ai/ui/code_review_dialog.py
@@ -9,7 +9,7 @@ LLM for self-correction.
 
 from .compat import QtWidgets, QtCore, QtGui
 from .message_view import _get_theme_colors, refresh_theme_cache
-from ..i18n import translate
+from ..i18n import translate, translate_branded
 
 QDialog = QtWidgets.QDialog
 QVBoxLayout = QtWidgets.QVBoxLayout
@@ -177,9 +177,9 @@ class CodeReviewDialog(QDialog):
         btn_layout.addWidget(self.edit_btn)
 
         self.check_btn = QPushButton(translate("CodeReviewDialog", "Check"))
-        self.check_btn.setToolTip(translate(
+        self.check_btn.setToolTip(translate_branded(
             "CodeReviewDialog",
-            "Validate the code in a headless FreeCAD sandbox against a copy "
+            "Validate the code in a headless %1 sandbox against a copy "
             "of the current document without modifying anything."))
         self.check_btn.clicked.connect(self._check)
         btn_layout.addWidget(self.check_btn)

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -14,7 +14,8 @@ Provides a GUI for configuring:
 import os
 
 from .compat import QtWidgets, QtCore, QtGui
-from ..i18n import translate
+from ..i18n import translate, translate_branded
+from ..branding import PRODUCT_NAME
 
 QDialog = QtWidgets.QDialog
 QWidget = QtWidgets.QWidget
@@ -174,7 +175,7 @@ class SettingsDialog(QDialog):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setWindowTitle(translate("SettingsDialog", "FreeCAD AI Settings"))
+        self.setWindowTitle(translate_branded("SettingsDialog", "%2 Settings"))
         self.setMinimumWidth(500)
         self.setMinimumHeight(400)
         self.resize(650, 700)
@@ -359,11 +360,11 @@ class SettingsDialog(QDialog):
         self.keep_dock_check = QCheckBox(
             translate("SettingsDialog", "Keep chat panel open when switching workbenches")
         )
-        self.keep_dock_check.setToolTip(translate(
+        self.keep_dock_check.setToolTip(translate_branded(
             "SettingsDialog",
-            "When enabled, the FreeCAD AI chat panel stays docked and usable "
+            "When enabled, the %2 chat panel stays docked and usable "
             "in other workbenches instead of hiding when you leave the "
-            "FreeCAD AI workbench."))
+            "%2 workbench."))
         behavior_layout.addWidget(self.keep_dock_check)
 
         # Thinking mode
@@ -677,15 +678,15 @@ class SettingsDialog(QDialog):
         # Editor group — affects Edit/New buttons in User Tools and Hooks below.
         editor_group = QGroupBox(translate("SettingsDialog", "Editor"))
         editor_layout = QVBoxLayout()
-        self.use_external_editor_cb = QCheckBox(translate(
+        self.use_external_editor_cb = QCheckBox(translate_branded(
             "SettingsDialog",
             "Open hooks and user tools in the OS-default editor "
-            "(instead of FreeCAD's docked script editor)"))
-        self.use_external_editor_cb.setToolTip(translate(
+            "(instead of %1's docked script editor)"))
+        self.use_external_editor_cb.setToolTip(translate_branded(
             "SettingsDialog",
             "When enabled, files open via the OS file association "
             "(xdg-open / Launch Services) so the Settings dialog can stay open. "
-            "When disabled, files open in FreeCAD's docked Gui::PythonEditor — "
+            "When disabled, files open in %1's docked Gui::PythonEditor — "
             "which requires closing this dialog first."))
         editor_layout.addWidget(self.use_external_editor_cb)
         editor_group.setLayout(editor_layout)
@@ -724,7 +725,7 @@ class SettingsDialog(QDialog):
         user_tools_layout.addLayout(ut_btn_layout)
 
         self.scan_macros_cb = QCheckBox(
-            translate("SettingsDialog", "Also scan FreeCAD macro directory")
+            translate_branded("SettingsDialog", "Also scan %1 macro directory")
         )
         user_tools_layout.addWidget(self.scan_macros_cb)
 
@@ -1417,7 +1418,7 @@ class SettingsDialog(QDialog):
         # Log to FreeCAD console
         try:
             import FreeCAD
-            FreeCAD.Console.PrintMessage(f"FreeCAD AI: {vision_msg}\n")
+            FreeCAD.Console.PrintMessage(f"{PRODUCT_NAME}: {vision_msg}\n")
         except ImportError:
             pass
 
@@ -1447,7 +1448,7 @@ class SettingsDialog(QDialog):
             self.test_status.setText(self.test_status.text() + "\n" + line)
             try:
                 import FreeCAD
-                FreeCAD.Console.PrintMessage(f"FreeCAD AI: {line}\n")
+                FreeCAD.Console.PrintMessage(f"{PRODUCT_NAME}: {line}\n")
             except ImportError:
                 pass
 
@@ -1841,9 +1842,9 @@ class SettingsDialog(QDialog):
         choice = QMessageBox.question(
             self,
             translate("SettingsDialog", "Open Script Editor"),
-            translate(
+            translate_branded(
                 "SettingsDialog",
-                "FreeCAD's script editor is docked behind this dialog. "
+                "%1's script editor is docked behind this dialog. "
                 "The dialog must close so you can reach it.\n\n"
                 "Save your pending settings changes first?"),
             QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -177,7 +177,7 @@ class SettingsDialog(QDialog):
         self.setWindowTitle(translate("SettingsDialog", "FreeCAD AI Settings"))
         self.setMinimumWidth(500)
         self.setMinimumHeight(400)
-        self.resize(540, 700)
+        self.resize(650, 700)
         self._test_thread = None
         self._last_default_prompt = ""
         self._rerank_last_model = ""

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -1932,6 +1932,9 @@ class SettingsDialog(QDialog):
             elif source == "user":
                 icon = "\u2606"  # ☆
                 tag = "user"
+            elif source == "module":
+                icon = "\u2713"  # ✓
+                tag = "module"
             else:
                 icon = "\u2713"  # ✓
                 tag = "built-in"
@@ -1949,8 +1952,10 @@ class SettingsDialog(QDialog):
         can_reset = False
         if 0 <= idx < len(self._skills_status):
             info = self._skills_status[idx]
-            # Can reset if there's a user copy AND a built-in exists
-            can_reset = info["has_user_copy"] and bool(info["builtin_path"])
+            # Can reset if there's a user copy AND a shipped version to fall
+            # back to — either built-in or one shipped by another module.
+            shipped = info["builtin_path"] or info.get("module_path", "")
+            can_reset = info["has_user_copy"] and bool(shipped)
         self._skills_reset_btn.setEnabled(can_reset)
 
     def _reset_skill_to_builtin(self):

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package format="1">
-    <name>RioD AI</name>
-    <description>AI-powered assistant for 3D modeling in RioD. Supports multiple LLM providers with Plan/Act modes, structured tool calling, skills, and MCP integration.</description>
+    <name>FreeCAD AI</name>
+    <description>AI-powered assistant for 3D modeling in FreeCAD. Supports multiple LLM providers with Plan/Act modes, structured tool calling, skills, and MCP integration.</description>
     <version>0.21.1-alpha</version>
     <date>2026-08-27</date>
     <maintainer email="alfred@mickautsch.de">Alfred Mickautsch</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package format="1">
-    <name>FreeCAD AI</name>
-    <description>AI-powered assistant for 3D modeling in FreeCAD. Supports multiple LLM providers with Plan/Act modes, structured tool calling, skills, and MCP integration.</description>
+    <name>RioD AI</name>
+    <description>AI-powered assistant for 3D modeling in RioD. Supports multiple LLM providers with Plan/Act modes, structured tool calling, skills, and MCP integration.</description>
     <version>0.21.1-alpha</version>
     <date>2026-07-22</date>
     <maintainer email="alfred@mickautsch.de">Alfred Mickautsch</maintainer>

--- a/resources/panels/FreeCADAIPrefs.ui
+++ b/resources/panels/FreeCADAIPrefs.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>RioD AI</string>
+   <string>FreeCAD AI</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/resources/panels/FreeCADAIPrefs.ui
+++ b/resources/panels/FreeCADAIPrefs.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>FreeCAD AI</string>
+   <string>RioD AI</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/tests/unit/test_branding.py
+++ b/tests/unit/test_branding.py
@@ -1,0 +1,190 @@
+"""Tests for the runtime branding lookup."""
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _reload_branding(monkeypatch, config_values, raises=False):
+    """Reload freecad_ai.branding against a stubbed FreeCAD module.
+
+    Passing config_values=None removes FreeCAD entirely, which is what a
+    headless run outside the host looks like.
+    """
+    if config_values is None:
+        monkeypatch.setitem(sys.modules, "FreeCAD", None)
+    else:
+        fake = types.ModuleType("FreeCAD")
+
+        def config_get(key):
+            if raises:
+                raise RuntimeError("boom")
+            return config_values.get(key, "")
+
+        fake.ConfigGet = config_get
+        monkeypatch.setitem(sys.modules, "FreeCAD", fake)
+
+    import freecad_ai.branding as branding
+    return importlib.reload(branding)
+
+
+@pytest.fixture(autouse=True)
+def restore_branding():
+    """Leave the real module state behind for every other test module.
+
+    The names are module-level constants, so anything that captured them at
+    import time has to be reloaded too, or a branded value leaks sideways
+    into unrelated tests.
+    """
+    yield
+    import freecad_ai.branding as branding
+    importlib.reload(branding)
+    import freecad_ai.core.system_prompt as sp
+    importlib.reload(sp)
+
+
+class TestAppNameResolution:
+    def test_reads_exe_name(self, monkeypatch):
+        b = _reload_branding(monkeypatch, {"ExeName": "RioD", "Application": "RioD"})
+        assert b.APP_NAME == "RioD"
+        assert b.PRODUCT_NAME == "RioD AI"
+        assert b.IS_BRANDED is True
+
+    def test_falls_through_to_application(self, monkeypatch):
+        """An unbranded ExeName still lets the Application key win."""
+        b = _reload_branding(monkeypatch, {"ExeName": "", "Application": "RioD"})
+        assert b.APP_NAME == "RioD"
+
+    def test_strips_whitespace(self, monkeypatch):
+        b = _reload_branding(monkeypatch, {"ExeName": "  RioD \n"})
+        assert b.APP_NAME == "RioD"
+
+    def test_empty_config_falls_back(self, monkeypatch):
+        """ConfigGet returns "" for unknown keys rather than raising."""
+        b = _reload_branding(monkeypatch, {})
+        assert b.APP_NAME == "FreeCAD"
+        assert b.PRODUCT_NAME == "FreeCAD AI"
+        assert b.IS_BRANDED is False
+
+    def test_config_get_raising_falls_back(self, monkeypatch):
+        b = _reload_branding(monkeypatch, {"ExeName": "RioD"}, raises=True)
+        assert b.APP_NAME == "FreeCAD"
+
+    def test_no_freecad_module_falls_back(self, monkeypatch):
+        """Headless: pytest, console scripts, plain REPL."""
+        b = _reload_branding(monkeypatch, None)
+        assert b.APP_NAME == "FreeCAD"
+        assert b.IS_BRANDED is False
+
+
+class TestTranslateBranded:
+    def test_substitutes_both_placeholders(self, monkeypatch):
+        _reload_branding(monkeypatch, {"ExeName": "RioD"})
+        import freecad_ai.i18n as i18n
+        out = i18n.translate_branded("Ctx", "%2 runs inside %1.")
+        assert out == "RioD AI runs inside RioD."
+
+    def test_leaves_text_without_placeholders_alone(self, monkeypatch):
+        _reload_branding(monkeypatch, {"ExeName": "RioD"})
+        import freecad_ai.i18n as i18n
+        assert i18n.translate_branded("Ctx", "Open AI Chat") == "Open AI Chat"
+
+    def test_repeated_placeholder(self, monkeypatch):
+        _reload_branding(monkeypatch, {"ExeName": "RioD"})
+        import freecad_ai.i18n as i18n
+        out = i18n.translate_branded("Ctx", "Leave the %2 workbench to hide %2.")
+        assert out == "Leave the RioD AI workbench to hide RioD AI."
+
+
+class TestInitGuiUnderExecScoping:
+    """FreeCAD exec()s InitGui.py with SEPARATE globals and locals mappings.
+
+    Top-level bindings land in locals, but class and function bodies resolve
+    free names through globals — so a module-level ``from ... import X`` is
+    invisible inside any method, and using it there raises NameError at
+    startup. Every brand lookup in InitGui.py must therefore be a local
+    import. runpy/import-based checks pass one shared dict and do NOT catch
+    this.
+    """
+
+    def _exec_initgui(self, monkeypatch, app_name="RioD"):
+        _reload_branding(monkeypatch, {"ExeName": app_name})
+
+        recorded = {"toolbars": [], "menus": [], "commands": {}, "prefs_page": None,
+                    "workbench": None}
+
+        class _Workbench:
+            def appendToolbar(self, name, cmds):
+                recorded["toolbars"].append(name)
+
+            def appendMenu(self, name, cmds):
+                recorded["menus"].append(name)
+
+        gui = types.ModuleType("FreeCADGui")
+        gui.Workbench = _Workbench
+        gui.addLanguagePath = lambda p: None
+        gui.updateLocale = lambda: None
+        gui.addIconPath = lambda p: None
+        gui.addPreferencePage = lambda ui, group: recorded.__setitem__("prefs_page", group)
+        gui.addCommand = lambda name, obj: recorded["commands"].__setitem__(name, obj)
+        gui.addWorkbench = lambda wb: recorded.__setitem__("workbench", wb)
+        monkeypatch.setitem(sys.modules, "FreeCADGui", gui)
+
+        # Resolve resource lookups so every guarded branch actually runs.
+        import freecad_ai.paths as paths
+        monkeypatch.setattr(paths, "get_prefs_ui_path", lambda: "prefs.ui")
+        monkeypatch.setattr(paths, "get_icon_path", lambda: "icon.svg")
+        monkeypatch.setattr(paths, "get_translations_path", lambda: "translations")
+        monkeypatch.setattr(paths, "get_icons_dir", lambda: "icons")
+
+        src = open(os.path.join(PROJECT_ROOT, "InitGui.py"), encoding="utf-8").read()
+        g = {"__name__": "__main__", "__builtins__": __builtins__}
+        exec(compile(src, "InitGui.py", "exec"), g, {})
+        return recorded
+
+    def test_no_name_error_and_everything_branded(self, monkeypatch):
+        rec = self._exec_initgui(monkeypatch)
+        wb = rec["workbench"]
+        wb.Initialize()
+
+        assert wb.MenuText == "RioD AI"
+        assert rec["toolbars"] == ["RioD AI"]
+        assert rec["menus"] == ["RioD AI"]
+        assert rec["prefs_page"] == "RioD AI"
+
+        assert set(rec["commands"]) == {
+            "FreeCADAI_OpenChat", "FreeCADAI_OpenSettings", "FreeCADAI_ToggleKeepDock",
+        }
+        for cmd in rec["commands"].values():
+            res = cmd.GetResources()
+            assert res["GroupName"] == "RioD AI"
+            assert "FreeCAD" not in res["ToolTip"]
+
+    def test_command_ids_are_not_rebranded(self, monkeypatch):
+        """Command IDs persist in user keyboard shortcuts — they must not move."""
+        rec = self._exec_initgui(monkeypatch)
+        assert all(name.startswith("FreeCADAI_") for name in rec["commands"])
+
+
+class TestSystemPromptAnchor:
+    def test_branded_prompt_anchors_to_freecad(self, monkeypatch):
+        """The model has no training signal for the brand — keep the API anchor."""
+        _reload_branding(monkeypatch, {"ExeName": "RioD"})
+        import freecad_ai.core.system_prompt as sp
+        importlib.reload(sp)
+        assert "You are RioD AI" in sp.IDENTITY
+        assert "built on FreeCAD" in sp.IDENTITY
+        assert "FreeCAD Python API" in sp.IDENTITY
+
+    def test_unbranded_prompt_drops_circular_anchor(self, monkeypatch):
+        _reload_branding(monkeypatch, {})
+        import freecad_ai.core.system_prompt as sp
+        importlib.reload(sp)
+        assert "You are FreeCAD AI" in sp.IDENTITY
+        assert "built on FreeCAD" not in sp.IDENTITY
+        assert "You understand the FreeCAD Python API deeply." in sp.IDENTITY

--- a/tests/unit/test_branding.py
+++ b/tests/unit/test_branding.py
@@ -50,19 +50,19 @@ def restore_branding():
 
 class TestAppNameResolution:
     def test_reads_exe_name(self, monkeypatch):
-        b = _reload_branding(monkeypatch, {"ExeName": "RioD", "Application": "RioD"})
-        assert b.APP_NAME == "RioD"
-        assert b.PRODUCT_NAME == "RioD AI"
+        b = _reload_branding(monkeypatch, {"ExeName": "Acme", "Application": "Acme"})
+        assert b.APP_NAME == "Acme"
+        assert b.PRODUCT_NAME == "Acme AI"
         assert b.IS_BRANDED is True
 
     def test_falls_through_to_application(self, monkeypatch):
         """An unbranded ExeName still lets the Application key win."""
-        b = _reload_branding(monkeypatch, {"ExeName": "", "Application": "RioD"})
-        assert b.APP_NAME == "RioD"
+        b = _reload_branding(monkeypatch, {"ExeName": "", "Application": "Acme"})
+        assert b.APP_NAME == "Acme"
 
     def test_strips_whitespace(self, monkeypatch):
-        b = _reload_branding(monkeypatch, {"ExeName": "  RioD \n"})
-        assert b.APP_NAME == "RioD"
+        b = _reload_branding(monkeypatch, {"ExeName": "  Acme \n"})
+        assert b.APP_NAME == "Acme"
 
     def test_empty_config_falls_back(self, monkeypatch):
         """ConfigGet returns "" for unknown keys rather than raising."""
@@ -72,7 +72,7 @@ class TestAppNameResolution:
         assert b.IS_BRANDED is False
 
     def test_config_get_raising_falls_back(self, monkeypatch):
-        b = _reload_branding(monkeypatch, {"ExeName": "RioD"}, raises=True)
+        b = _reload_branding(monkeypatch, {"ExeName": "Acme"}, raises=True)
         assert b.APP_NAME == "FreeCAD"
 
     def test_no_freecad_module_falls_back(self, monkeypatch):
@@ -84,21 +84,21 @@ class TestAppNameResolution:
 
 class TestTranslateBranded:
     def test_substitutes_both_placeholders(self, monkeypatch):
-        _reload_branding(monkeypatch, {"ExeName": "RioD"})
+        _reload_branding(monkeypatch, {"ExeName": "Acme"})
         import freecad_ai.i18n as i18n
         out = i18n.translate_branded("Ctx", "%2 runs inside %1.")
-        assert out == "RioD AI runs inside RioD."
+        assert out == "Acme AI runs inside Acme."
 
     def test_leaves_text_without_placeholders_alone(self, monkeypatch):
-        _reload_branding(monkeypatch, {"ExeName": "RioD"})
+        _reload_branding(monkeypatch, {"ExeName": "Acme"})
         import freecad_ai.i18n as i18n
         assert i18n.translate_branded("Ctx", "Open AI Chat") == "Open AI Chat"
 
     def test_repeated_placeholder(self, monkeypatch):
-        _reload_branding(monkeypatch, {"ExeName": "RioD"})
+        _reload_branding(monkeypatch, {"ExeName": "Acme"})
         import freecad_ai.i18n as i18n
         out = i18n.translate_branded("Ctx", "Leave the %2 workbench to hide %2.")
-        assert out == "Leave the RioD AI workbench to hide RioD AI."
+        assert out == "Leave the Acme AI workbench to hide Acme AI."
 
 
 class TestInitGuiUnderExecScoping:
@@ -112,7 +112,7 @@ class TestInitGuiUnderExecScoping:
     this.
     """
 
-    def _exec_initgui(self, monkeypatch, app_name="RioD"):
+    def _exec_initgui(self, monkeypatch, app_name="Acme"):
         _reload_branding(monkeypatch, {"ExeName": app_name})
 
         recorded = {"toolbars": [], "menus": [], "commands": {}, "prefs_page": None,
@@ -152,17 +152,18 @@ class TestInitGuiUnderExecScoping:
         wb = rec["workbench"]
         wb.Initialize()
 
-        assert wb.MenuText == "RioD AI"
-        assert rec["toolbars"] == ["RioD AI"]
-        assert rec["menus"] == ["RioD AI"]
-        assert rec["prefs_page"] == "RioD AI"
+        assert wb.MenuText == "Acme AI"
+        assert rec["toolbars"] == ["Acme AI"]
+        assert rec["menus"] == ["Acme AI"]
+        assert rec["prefs_page"] == "Acme AI"
 
         assert set(rec["commands"]) == {
             "FreeCADAI_OpenChat", "FreeCADAI_OpenSettings", "FreeCADAI_ToggleKeepDock",
+            "FreeCADAI_ToggleMCPServer",
         }
         for cmd in rec["commands"].values():
             res = cmd.GetResources()
-            assert res["GroupName"] == "RioD AI"
+            assert res["GroupName"] == "Acme AI"
             assert "FreeCAD" not in res["ToolTip"]
 
     def test_command_ids_are_not_rebranded(self, monkeypatch):
@@ -174,10 +175,10 @@ class TestInitGuiUnderExecScoping:
 class TestSystemPromptAnchor:
     def test_branded_prompt_anchors_to_freecad(self, monkeypatch):
         """The model has no training signal for the brand — keep the API anchor."""
-        _reload_branding(monkeypatch, {"ExeName": "RioD"})
+        _reload_branding(monkeypatch, {"ExeName": "Acme"})
         import freecad_ai.core.system_prompt as sp
         importlib.reload(sp)
-        assert "You are RioD AI" in sp.IDENTITY
+        assert "You are Acme AI" in sp.IDENTITY
         assert "built on FreeCAD" in sp.IDENTITY
         assert "FreeCAD Python API" in sp.IDENTITY
 

--- a/tests/unit/test_loop_control.py
+++ b/tests/unit/test_loop_control.py
@@ -1,4 +1,12 @@
-from freecad_ai.core.loop_control import should_continue_loop
+from freecad_ai.core.loop_control import (
+    REPEAT_ABORT_AT,
+    REPEAT_NUDGE_AT,
+    call_signature,
+    repeat_intervention,
+    repeat_nudge,
+    should_continue_loop,
+    update_failure_streak,
+)
 
 
 def test_bounded_continues_until_limit():
@@ -15,3 +23,81 @@ def test_endless_always_continues():
 def test_interrupt_stops_regardless():
     assert should_continue_loop(30, 0, True) is False
     assert should_continue_loop(0, 0, True) is False
+
+
+class TestCallSignature:
+    def test_identical_calls_share_a_signature(self):
+        a = call_signature("execute_code", {"code": "print(1)"})
+        b = call_signature("execute_code", {"code": "print(1)"})
+        assert a == b
+
+    def test_key_order_does_not_matter(self):
+        """The model may serialise the same arguments in either order."""
+        a = call_signature("t", {"x": 1, "y": 2})
+        b = call_signature("t", {"y": 2, "x": 1})
+        assert a == b
+
+    def test_different_arguments_differ(self):
+        a = call_signature("execute_code", {"code": "print(1)"})
+        b = call_signature("execute_code", {"code": "print(2)"})
+        assert a != b
+
+    def test_same_arguments_to_a_different_tool_differ(self):
+        assert call_signature("a", {"x": 1}) != call_signature("b", {"x": 1})
+
+    def test_unserialisable_arguments_do_not_raise(self):
+        """A coarse signature is acceptable; an exception here would break the loop."""
+        assert call_signature("t", {"obj": object()})
+
+
+class TestFailureStreak:
+    def test_a_success_clears_the_streak(self):
+        streak = update_failure_streak(("sig", 4), "sig", failed=False)
+        assert streak == ("", 0)
+
+    def test_repeated_failure_accumulates(self):
+        streak = ("", 0)
+        for expected in (1, 2, 3):
+            streak = update_failure_streak(streak, "sig", failed=True)
+            assert streak == ("sig", expected)
+
+    def test_a_different_failing_call_restarts_the_count(self):
+        """Exploring counts as progress even when every attempt fails."""
+        streak = update_failure_streak(("sig", 4), "other", failed=True)
+        assert streak == ("other", 1)
+
+
+class TestIntervention:
+    def test_early_failures_are_left_alone(self):
+        assert repeat_intervention(0) == ""
+        assert repeat_intervention(REPEAT_NUDGE_AT - 1) == ""
+
+    def test_nudge_then_abort(self):
+        assert repeat_intervention(REPEAT_NUDGE_AT) == "nudge"
+        assert repeat_intervention(REPEAT_ABORT_AT - 1) == "nudge"
+        assert repeat_intervention(REPEAT_ABORT_AT) == "abort"
+        assert repeat_intervention(REPEAT_ABORT_AT + 25) == "abort"
+
+    def test_the_nudge_names_the_tool_and_the_count(self):
+        text = repeat_nudge("execute_code", 3)
+        assert "execute_code" in text
+        assert "3" in text
+
+
+def test_the_session_that_motivated_this():
+    """A real session sent one byte-identical execute_code call 30 times.
+
+    Replaying it: the guard nudges partway in and stops the loop well before the
+    turn limit, instead of letting it run until the user gives up and hits stop.
+    """
+    call = {"code": "types = App.Type.getTypeIdList()"}
+    streak = ("", 0)
+    outcomes = []
+    for _ in range(30):
+        streak = update_failure_streak(
+            streak, call_signature("execute_code", call), failed=True
+        )
+        outcomes.append(repeat_intervention(streak[1]))
+
+    assert outcomes.index("nudge") == REPEAT_NUDGE_AT - 1
+    assert outcomes.index("abort") == REPEAT_ABORT_AT - 1

--- a/tests/unit/test_module_assets.py
+++ b/tests/unit/test_module_assets.py
@@ -1,0 +1,335 @@
+"""Tests for module asset discovery — modules shipping their own AI assets."""
+
+import os
+
+import pytest
+
+from freecad_ai.extensions import module_assets
+
+
+@pytest.fixture(autouse=True)
+def reset_asset_cache():
+    """Discovery is cached process-wide; clear it around every test."""
+    module_assets.reset_cache()
+    yield
+    module_assets.reset_cache()
+
+
+@pytest.fixture
+def fake_mod_tree(tmp_path, monkeypatch):
+    """Build a Mod/ tree with two asset-bearing modules and one plain module."""
+    mod = tmp_path / "Mod"
+    for name in ("AlphaWB", "BetaWB"):
+        (mod / name / "ai" / "skills").mkdir(parents=True)
+        (mod / name / "ai" / "tools").mkdir(parents=True)
+    (mod / "PlainWB").mkdir(parents=True)  # no ai/ dir — ships no assets
+
+    monkeypatch.setattr(module_assets, "_mod_roots", lambda: [str(mod)])
+    return mod
+
+
+class TestDiscovery:
+    def test_finds_asset_dirs(self, fake_mod_tree):
+        found = module_assets.discover_asset_dirs()
+        assert [os.path.basename(os.path.dirname(p)) for p in found] == [
+            "AlphaWB",
+            "BetaWB",
+        ]
+
+    def test_module_without_ai_dir_is_skipped(self, fake_mod_tree):
+        found = module_assets.discover_asset_dirs()
+        assert not any("PlainWB" in p for p in found)
+
+    def test_no_freecad_yields_nothing(self, monkeypatch):
+        """Discovery is silent outside FreeCAD rather than raising."""
+        monkeypatch.delenv(module_assets.ASSET_DIRS_ENV, raising=False)
+        assert module_assets.discover_asset_dirs() == []
+
+    def test_env_var_adds_dirs(self, tmp_path, monkeypatch):
+        dev_tree = tmp_path / "checkout" / "ai"
+        dev_tree.mkdir(parents=True)
+        monkeypatch.setenv(module_assets.ASSET_DIRS_ENV, str(dev_tree))
+        monkeypatch.setattr(module_assets, "_mod_roots", lambda: [])
+
+        assert module_assets.discover_asset_dirs() == [str(dev_tree)]
+
+    def test_env_var_accepts_multiple_paths(self, tmp_path, monkeypatch):
+        first = tmp_path / "one" / "ai"
+        second = tmp_path / "two" / "ai"
+        first.mkdir(parents=True)
+        second.mkdir(parents=True)
+        monkeypatch.setenv(
+            module_assets.ASSET_DIRS_ENV,
+            os.pathsep.join([str(first), str(second)]),
+        )
+        monkeypatch.setattr(module_assets, "_mod_roots", lambda: [])
+
+        assert module_assets.discover_asset_dirs() == [str(first), str(second)]
+
+    def test_nonexistent_env_paths_are_dropped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(
+            module_assets.ASSET_DIRS_ENV, str(tmp_path / "does-not-exist")
+        )
+        monkeypatch.setattr(module_assets, "_mod_roots", lambda: [])
+
+        assert module_assets.discover_asset_dirs() == []
+
+    def test_result_is_cached(self, fake_mod_tree):
+        first = module_assets.discover_asset_dirs()
+        (fake_mod_tree / "GammaWB" / "ai").mkdir(parents=True)
+
+        assert module_assets.discover_asset_dirs() == first
+        assert len(module_assets.discover_asset_dirs(refresh=True)) == 3
+
+    def test_asset_subdirs_filters_missing(self, fake_mod_tree):
+        (fake_mod_tree / "AlphaWB" / "ai" / "hooks").mkdir()
+
+        hooks = module_assets.asset_subdirs("hooks")
+        assert len(hooks) == 1
+        assert "AlphaWB" in hooks[0]
+        assert len(module_assets.asset_subdirs("skills")) == 2
+
+    def test_owning_module(self, fake_mod_tree):
+        asset_dir = module_assets.discover_asset_dirs()[0]
+        assert module_assets.owning_module(asset_dir) == "AlphaWB"
+
+
+class TestInstructions:
+    def test_collects_and_labels_instructions(self, fake_mod_tree):
+        (fake_mod_tree / "AlphaWB" / "ai" / "INSTRUCTIONS.md").write_text(
+            "Prefer alpha_* tools.", encoding="utf-8"
+        )
+        (fake_mod_tree / "BetaWB" / "ai" / "INSTRUCTIONS.md").write_text(
+            "Beta objects need a Program first.", encoding="utf-8"
+        )
+
+        text = module_assets.load_module_instructions()
+        assert "### AlphaWB" in text
+        assert "Prefer alpha_* tools." in text
+        assert "### BetaWB" in text
+        assert text.index("AlphaWB") < text.index("BetaWB")
+
+    def test_no_instructions_yields_empty(self, fake_mod_tree):
+        assert module_assets.load_module_instructions() == ""
+
+    def test_empty_file_contributes_nothing(self, fake_mod_tree):
+        (fake_mod_tree / "AlphaWB" / "ai" / "INSTRUCTIONS.md").write_text(
+            "   \n", encoding="utf-8"
+        )
+        assert module_assets.load_module_instructions() == ""
+
+
+class TestSkillsIntegration:
+    def test_module_skills_load(self, fake_mod_tree, tmp_path, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+
+        skill = fake_mod_tree / "AlphaWB" / "ai" / "skills" / "alpha-thing"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            "---\ndescription: Build an alpha thing\n---\n\n# Alpha\n",
+            encoding="utf-8",
+        )
+        user_dir = tmp_path / "user-skills"
+        user_dir.mkdir()
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(user_dir))
+
+        registry = skills_mod.SkillsRegistry()
+        loaded = registry.get_skill("alpha-thing")
+        assert loaded is not None
+        assert loaded.description == "Build an alpha thing"
+        assert loaded.trigger == "/alpha-thing"
+
+    def test_user_skill_shadows_module(self, fake_mod_tree, tmp_path, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+
+        module_skill = fake_mod_tree / "AlphaWB" / "ai" / "skills" / "shared"
+        module_skill.mkdir()
+        (module_skill / "SKILL.md").write_text(
+            "---\ndescription: From the module\n---\n", encoding="utf-8"
+        )
+
+        user_dir = tmp_path / "user-skills"
+        (user_dir / "shared").mkdir(parents=True)
+        (user_dir / "shared" / "SKILL.md").write_text(
+            "---\ndescription: From the user\n---\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(user_dir))
+
+        registry = skills_mod.SkillsRegistry()
+        assert registry.get_skill("shared").description == "From the user"
+
+    def test_status_reports_module_source(self, fake_mod_tree, tmp_path, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+
+        module_skill = fake_mod_tree / "AlphaWB" / "ai" / "skills" / "alpha-thing"
+        module_skill.mkdir()
+        (module_skill / "SKILL.md").write_text(
+            "---\ndescription: Build an alpha thing\n---\n", encoding="utf-8"
+        )
+        user_dir = tmp_path / "user-skills"
+        user_dir.mkdir()
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(user_dir))
+
+        entry = next(
+            info
+            for info in skills_mod.SkillsRegistry.get_skill_status()
+            if info["name"] == "alpha-thing"
+        )
+        assert entry["source"] == "module"
+        assert entry["module_path"].endswith("SKILL.md")
+        assert entry["builtin_path"] == ""
+        assert entry["has_user_copy"] is False
+
+    def test_status_flags_modified_module_skill(
+        self, fake_mod_tree, tmp_path, monkeypatch
+    ):
+        import freecad_ai.extensions.skills as skills_mod
+
+        module_skill = fake_mod_tree / "AlphaWB" / "ai" / "skills" / "shared"
+        module_skill.mkdir()
+        (module_skill / "SKILL.md").write_text("original\n", encoding="utf-8")
+
+        user_dir = tmp_path / "user-skills"
+        (user_dir / "shared").mkdir(parents=True)
+        (user_dir / "shared" / "SKILL.md").write_text("edited\n", encoding="utf-8")
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(user_dir))
+
+        entry = next(
+            info
+            for info in skills_mod.SkillsRegistry.get_skill_status()
+            if info["name"] == "shared"
+        )
+        assert entry["source"] == "modified"
+        assert entry["is_modified"] is True
+
+    def test_reset_reverts_to_module_copy(self, fake_mod_tree, tmp_path, monkeypatch):
+        import freecad_ai.extensions.skills as skills_mod
+
+        module_skill = fake_mod_tree / "AlphaWB" / "ai" / "skills" / "shared"
+        module_skill.mkdir()
+        (module_skill / "SKILL.md").write_text("original\n", encoding="utf-8")
+
+        user_dir = tmp_path / "user-skills"
+        (user_dir / "shared").mkdir(parents=True)
+        (user_dir / "shared" / "SKILL.md").write_text("edited\n", encoding="utf-8")
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(user_dir))
+
+        assert skills_mod.SkillsRegistry.reset_to_builtin("shared") is True
+        assert not (user_dir / "shared").exists()
+
+    def test_reset_refuses_when_nothing_ships_the_skill(self, tmp_path, monkeypatch):
+        """A purely-user skill has no shipped version to fall back to."""
+        import freecad_ai.extensions.skills as skills_mod
+
+        monkeypatch.setattr(module_assets, "_mod_roots", lambda: [])
+        user_dir = tmp_path / "user-skills"
+        (user_dir / "mine").mkdir(parents=True)
+        (user_dir / "mine" / "SKILL.md").write_text("mine\n", encoding="utf-8")
+        monkeypatch.setattr(skills_mod, "SKILLS_DIR", str(user_dir))
+
+        assert skills_mod.SkillsRegistry.reset_to_builtin("mine") is False
+        assert (user_dir / "mine").exists()
+
+
+class TestToolsIntegration:
+    def test_module_tools_register(self, fake_mod_tree, tmp_path, monkeypatch):
+        import freecad_ai.config as config_mod
+
+        (fake_mod_tree / "AlphaWB" / "ai" / "tools" / "alpha_tools.py").write_text(
+            '__tool_prefix__ = "alpha_"\n'
+            "\n"
+            "def make_widget(size: float) -> str:\n"
+            '    """Make a widget."""\n'
+            '    return "made"\n',
+            encoding="utf-8",
+        )
+        empty = tmp_path / "no-user-tools"
+        empty.mkdir()
+        monkeypatch.setattr(config_mod, "USER_TOOLS_DIR", str(empty))
+
+        from freecad_ai.tools.setup import create_default_registry
+
+        registry = create_default_registry(include_mcp=False)
+        assert registry.get("alpha_make_widget") is not None
+        assert registry.get("user_make_widget") is None
+
+
+class TestHooksIntegration:
+    def test_module_hooks_load(self, fake_mod_tree, tmp_path, monkeypatch):
+        import freecad_ai.hooks.registry as hooks_mod
+
+        hook_dir = fake_mod_tree / "AlphaWB" / "ai" / "hooks" / "alpha-guard"
+        hook_dir.mkdir(parents=True)
+        (hook_dir / "hook.py").write_text(
+            "def on_pre_tool_use(context):\n"
+            '    return {"block": True, "reason": "nope"}\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(hooks_mod, "HOOKS_DIR", str(tmp_path / "no-user-hooks"))
+
+        registry = hooks_mod.HookRegistry()
+        result = registry.fire("pre_tool_use", {"tool_name": "x"})
+        assert result.get("block") is True
+
+
+class TestModRoots:
+    """_mod_roots is the one part discovery cannot fake, so it gets its own tests.
+
+    A branded build can return a getResourceDir() that is not the module root - RioD's
+    points at a data/ subdirectory holding only per-module Resources - so probing that
+    alone finds nothing and the whole feature silently does nothing.
+    """
+
+    @staticmethod
+    def _fake_freecad(monkeypatch, *, home="", resource="", user=""):
+        import sys
+        import types
+
+        fake = types.ModuleType("FreeCAD")
+        fake.getHomePath = lambda: home
+        fake.getResourceDir = lambda: resource
+        fake.getUserAppDataDir = lambda: user
+        monkeypatch.setitem(sys.modules, "FreeCAD", fake)
+
+    def test_home_path_is_probed(self, tmp_path, monkeypatch):
+        # The case that matters on a packaged build: only getHomePath is right.
+        (tmp_path / "install" / "Mod").mkdir(parents=True)
+        (tmp_path / "install" / "data").mkdir()
+        self._fake_freecad(
+            monkeypatch,
+            home=str(tmp_path / "install"),
+            resource=str(tmp_path / "install" / "data"),
+        )
+
+        assert module_assets._mod_roots() == [str(tmp_path / "install" / "Mod")]
+
+    def test_all_three_bases_are_probed(self, tmp_path, monkeypatch):
+        for name in ("user", "home", "resource"):
+            (tmp_path / name / "Mod").mkdir(parents=True)
+        self._fake_freecad(
+            monkeypatch,
+            user=str(tmp_path / "user"),
+            home=str(tmp_path / "home"),
+            resource=str(tmp_path / "resource"),
+        )
+
+        roots = module_assets._mod_roots()
+        assert roots == [
+            str(tmp_path / "user" / "Mod"),
+            str(tmp_path / "home" / "Mod"),
+            str(tmp_path / "resource" / "Mod"),
+        ]
+
+    def test_duplicate_bases_are_collapsed(self, tmp_path, monkeypatch):
+        # A stock build can return the same directory for two of them.
+        (tmp_path / "shared" / "Mod").mkdir(parents=True)
+        self._fake_freecad(
+            monkeypatch, home=str(tmp_path / "shared"), resource=str(tmp_path / "shared")
+        )
+
+        assert module_assets._mod_roots() == [str(tmp_path / "shared" / "Mod")]
+
+    def test_missing_and_empty_bases_are_skipped(self, tmp_path, monkeypatch):
+        self._fake_freecad(monkeypatch, home=str(tmp_path / "nope"), resource="")
+
+        assert module_assets._mod_roots() == []

--- a/tests/unit/test_module_assets.py
+++ b/tests/unit/test_module_assets.py
@@ -275,7 +275,7 @@ class TestHooksIntegration:
 class TestModRoots:
     """_mod_roots is the one part discovery cannot fake, so it gets its own tests.
 
-    A branded build can return a getResourceDir() that is not the module root - RioD's
+    A branded build can return a getResourceDir() that is not the module root - App's
     points at a data/ subdirectory holding only per-module Resources - so probing that
     alone finds nothing and the whole feature silently does nothing.
     """

--- a/tests/unit/test_user_tools.py
+++ b/tests/unit/test_user_tools.py
@@ -315,3 +315,243 @@ class TestScanMacros:
         assert len(tools) == 1
         result = tools[0].handler(x=1)
         assert result.output == "primary"
+
+
+class TestSequenceParams:
+    def test_list_types_become_arrays_with_items(self, tmp_path):
+        """list[...] params emit "array" plus the "items" strict providers need."""
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "seq.py").write_text(
+            "def pick(names: list[str], sizes: list[float], counts: list[int]) -> str:\n"
+            '    """Pick things."""\n'
+            '    return "ok"\n'
+        )
+        tool = load_user_tools(str(tmp_path))[0]
+        params = {p.name: p for p in tool.parameters}
+
+        assert params["names"].type == "array"
+        assert params["names"].items == {"type": "string"}
+        assert params["sizes"].items == {"type": "number"}
+        assert params["counts"].items == {"type": "integer"}
+
+    def test_scalar_params_have_no_items(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "scalar.py").write_text(
+            'def one(size: float) -> str:\n    """One."""\n    return "ok"\n'
+        )
+        tool = load_user_tools(str(tmp_path))[0]
+        assert tool.parameters[0].items is None
+
+    def test_list_param_schema_is_strict_compliant(self, tmp_path):
+        """The same guard test_registry applies to built-ins, for user tools."""
+        from freecad_ai.extensions.user_tools import load_user_tools
+        from freecad_ai.tools.registry import _params_to_json_schema
+
+        (tmp_path / "seq.py").write_text(
+            'def pick(names: list[str]) -> str:\n    """Pick."""\n    return "ok"\n'
+        )
+        schema = _params_to_json_schema(load_user_tools(str(tmp_path))[0].parameters)
+        assert schema["properties"]["names"] == {
+            "type": "array",
+            "description": "Parameter: names",
+            "items": {"type": "string"},
+        }
+
+    def test_unsupported_generics_warn_and_are_dropped(self, tmp_path):
+        """An unsupported generic names itself in the warning, not "None"."""
+        from freecad_ai.extensions.user_tools import validate_file
+
+        f = tmp_path / "weird.py"
+        f.write_text(
+            "def my_tool(data: dict[str, int], odd: tuple[int], size: float) -> str:\n"
+            '    """Process."""\n'
+            '    return "ok"\n'
+        )
+        result = validate_file(str(f))
+        assert result.valid  # size is still usable
+        assert result.warnings == [
+            "my_tool(): param 'data' has unsupported type 'dict'",
+            "my_tool(): param 'odd' has unsupported type 'tuple[int]'",
+        ]
+        assert [p.name for p in result.functions[0].params] == ["size"]
+
+    def test_list_arg_reaches_the_function(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "seq.py").write_text(
+            "def join_names(names: list[str]) -> str:\n"
+            '    """Join."""\n'
+            '    return ",".join(names)\n'
+        )
+        tool = load_user_tools(str(tmp_path))[0]
+        result = tool.handler(names=["a", "b"])
+        assert result.success
+        assert result.output == "a,b"
+
+
+class TestToolPrefix:
+    def test_default_prefix(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(
+            'def thing(x: int) -> str:\n    """Thing."""\n    return "ok"\n'
+        )
+        assert load_user_tools(str(tmp_path))[0].name == "user_thing"
+
+    def test_module_can_choose_its_prefix(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(
+            '__tool_prefix__ = "acme_"\n\n'
+            'def thing(x: int) -> str:\n    """Thing."""\n    return "ok"\n'
+        )
+        assert load_user_tools(str(tmp_path))[0].name == "acme_thing"
+
+    def test_empty_prefix_keeps_the_bare_name(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(
+            '__tool_prefix__ = ""\n\n'
+            'def thing(x: int) -> str:\n    """Thing."""\n    return "ok"\n'
+        )
+        assert load_user_tools(str(tmp_path))[0].name == "thing"
+
+    def test_non_string_prefix_falls_back_to_default(self, tmp_path):
+        from freecad_ai.extensions.user_tools import validate_file
+
+        f = tmp_path / "t.py"
+        f.write_text(
+            "__tool_prefix__ = 42\n\n"
+            'def thing(x: int) -> str:\n    """Thing."""\n    return "ok"\n'
+        )
+        assert validate_file(str(f)).prefix == "user_"
+
+
+class TestDocstringParsing:
+    SOURCE = (
+        "def build(width: float, tags: list[str], deep: bool = False) -> str:\n"
+        '    """Build a thing from a profile.\n'
+        "\n"
+        "    Use this when the caller already knows the profile width; it does\n"
+        "    not compute one.\n"
+        "\n"
+        "    Args:\n"
+        "        width: Profile width in mm. Must be positive.\n"
+        "        tags (list[str]): Labels to attach, in order.\n"
+        "        deep: Whether to recurse into children.\n"
+        "\n"
+        "    Returns:\n"
+        "        A summary string.\n"
+        '    """\n'
+        '    return "ok"\n'
+    )
+
+    def test_description_keeps_full_prose_before_args(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(self.SOURCE)
+        tool = load_user_tools(str(tmp_path))[0]
+
+        assert tool.description.startswith("Build a thing from a profile.")
+        assert "does\nnot compute one." in tool.description
+        assert "Args:" not in tool.description
+        assert "A summary string" not in tool.description
+
+    def test_args_block_supplies_param_descriptions(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(self.SOURCE)
+        params = {p.name: p for p in load_user_tools(str(tmp_path))[0].parameters}
+
+        assert params["width"].description == "Profile width in mm. Must be positive."
+        assert params["tags"].description == "Labels to attach, in order."
+        assert params["deep"].description == "Whether to recurse into children."
+
+    def test_continuation_lines_join_the_previous_param(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(
+            "def build(width: float) -> str:\n"
+            '    """Build.\n'
+            "\n"
+            "    Args:\n"
+            "        width: Profile width in mm,\n"
+            "            measured across the flange.\n"
+            '    """\n'
+            '    return "ok"\n'
+        )
+        param = load_user_tools(str(tmp_path))[0].parameters[0]
+        assert param.description == "Profile width in mm, measured across the flange."
+
+    def test_undocumented_param_keeps_the_placeholder(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(
+            "def build(width: float, height: float) -> str:\n"
+            '    """Build.\n'
+            "\n"
+            "    Args:\n"
+            "        width: The width.\n"
+            '    """\n'
+            '    return "ok"\n'
+        )
+        params = {p.name: p for p in load_user_tools(str(tmp_path))[0].parameters}
+        assert params["height"].description == "Parameter: height"
+
+    def test_single_line_docstring_still_works(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(
+            'def build(width: float) -> str:\n    """Build a thing."""\n    return "ok"\n'
+        )
+        tool = load_user_tools(str(tmp_path))[0]
+        assert tool.description == "Build a thing."
+        assert tool.parameters[0].description == "Parameter: width"
+
+
+class TestZeroArgumentTools:
+    ZERO_ARG = (
+        'def list_things() -> str:\n'
+        '    """List the things."""\n'
+        '    return "a, b"\n'
+    )
+
+    def test_a_function_with_no_parameters_is_a_tool(self, tmp_path):
+        # A "list what is available" tool is a real tool and takes no arguments.
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(self.ZERO_ARG)
+        tools = load_user_tools(str(tmp_path))
+
+        assert [t.name for t in tools] == ["user_list_things"]
+        assert tools[0].parameters == []
+        assert tools[0].description == "List the things."
+
+    def test_zero_argument_tool_executes(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+
+        (tmp_path / "t.py").write_text(self.ZERO_ARG)
+        result = load_user_tools(str(tmp_path))[0].handler()
+
+        assert result.success
+        assert result.output == "a, b"
+
+    def test_zero_argument_schema_is_valid(self, tmp_path):
+        from freecad_ai.extensions.user_tools import load_user_tools
+        from freecad_ai.tools.registry import _params_to_json_schema
+
+        (tmp_path / "t.py").write_text(self.ZERO_ARG)
+        schema = _params_to_json_schema(load_user_tools(str(tmp_path))[0].parameters)
+
+        assert schema == {"type": "object", "properties": {}}
+
+    def test_only_untyped_params_is_still_skipped(self, tmp_path):
+        # Without annotations there is no schema to build, so it cannot be a tool.
+        from freecad_ai.extensions.user_tools import validate_file
+
+        f = tmp_path / "t.py"
+        f.write_text('def helper(x, y):\n    """Helper."""\n    return x\n')
+
+        assert not validate_file(str(f)).valid


### PR DESCRIPTION
The addon is host-agnostic by design and resolves names through FreeCAD.ConfigGet, but ToggleMCPServerCommand - added after that work - hardcoded "FreeCAD AI" in its group name, tooltip, console messages and error dialog, so a branded host printed the wrong product into its own report view; it now uses PRODUCT_NAME and translate_branded like its three sibling commands. The manifest, preferences page title and overview also carried a downstream vendor's name and now state the addon's own, and test_branding keeps its coverage with a made-up fixture brand rather than a real vendor's, plus the command-set assertion it had been missing since FreeCADAI_ToggleMCPServer was added.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>