### PR TITLE
feat(#59): optional bearer-token auth for the MCP server

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -215,7 +215,8 @@ class ToggleMCPServerCommand:
                 "ToggleMCPServerCommand",
                 "Start or stop the MCP server, letting external clients such "
                 "as Claude Code drive this FreeCAD session. The server has no "
-                "authentication; set its address in AI Settings."),
+                "authentication unless a bearer token is configured; set its "
+                "address and token in AI Settings."),
             # False = starts unticked. FreeCAD treats this as the initial
             # state, not as "may this action be checked"; True showed a ticked
             # button on a fresh session with no server running.
@@ -225,7 +226,7 @@ class ToggleMCPServerCommand:
     def Activated(self, index=0):
         from freecad_ai.mcp.gui_server import (
             get_server_controller, resolve_allowed_hosts,
-            resolve_server_address)
+            resolve_auth_token, resolve_server_address)
         controller = get_server_controller()
 
         if controller.is_running():
@@ -243,7 +244,9 @@ class ToggleMCPServerCommand:
             # Settings dialog strips it. Unhandled, that leaves the button
             # mid-state behind a console traceback nothing surfaces.
             allowed_hosts = resolve_allowed_hosts(cfg)
-            url = controller.start(host, port, allowed_hosts=allowed_hosts)
+            auth_token = resolve_auth_token(cfg)
+            url = controller.start(host, port, allowed_hosts=allowed_hosts,
+                                   auth_token=auth_token)
         except (OSError, ValueError) as exc:
             self._report_failure(host, port, exc)
             self._sync_action()  # a failed start must leave the button unticked
@@ -251,6 +254,10 @@ class ToggleMCPServerCommand:
 
         App.Console.PrintMessage(
             "FreeCAD AI: MCP server listening on %s\n" % url)
+        if auth_token:
+            App.Console.PrintMessage(
+                "FreeCAD AI: MCP server requires a bearer token "
+                "(Authorization: Bearer ...)\n")
         window = Gui.getMainWindow()
         if window:
             window.statusBar().showMessage(

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Three ways to start it, differing in who owns the FreeCAD process:
     'exec 3>&1 1>&2 && /path/to/FreeCAD.AppImage -c /path/to/freecad-ai/mcp_server_entry.py'
   ```
 
-> **The MCP server has no authentication.** Anything that can reach the address it is bound to can run FreeCAD tools, including arbitrary Python. On the `127.0.0.1` default that means any process on your machine. Tracked in [#59](https://github.com/ghbalf/freecad-ai/issues/59).
+> **The MCP server is unauthenticated by default.** Anything that can reach the address it is bound to can run FreeCAD tools, including arbitrary Python. On the `127.0.0.1` default that means any process on your machine. Set a bearer token in the **AI Settings** MCP Servers section (or `MCP_AUTH_TOKEN`) to require `Authorization: Bearer <token>` on every request; clients pass it as a header (e.g. `claude mcp add --transport http freecad http://127.0.0.1:3000/mcp -H "Authorization: Bearer <token>"`).
 
 Note that Claude Code loads MCP tools **at session start** — a server added mid-session won't appear until the next launch.
 

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -415,9 +415,10 @@ class AppConfig:
     # Each entry: {"name": str, "command": str, "args": list, "env": dict, "enabled": bool}
     # Address the addon listens on when acting AS an MCP server (the toolbar
     # toggle and mcp_server_http.py). Host is deliberately unrestricted,
-    # including non-loopback: the server has no authentication (issue #59), so
-    # the Settings dialog warns about the exposure rather than pretending a
-    # restricted field made it safe. MCP_HOST / MCP_PORT override both.
+    # including non-loopback: the server has no authentication unless a
+    # bearer token is configured below (issue #59), so the Settings dialog
+    # warns about the exposure rather than pretending a restricted field made
+    # it safe. MCP_HOST / MCP_PORT override both.
     mcp_server_host: str = "127.0.0.1"
     mcp_server_port: int = 3000
     # Host headers the server answers to. Empty means "let the transport pick
@@ -426,6 +427,10 @@ class AppConfig:
     # deliberate opt-in to a wider policy, e.g. naming the LAN address or
     # container hostname clients actually dial. MCP_ALLOWED_HOSTS overrides.
     mcp_server_allowed_hosts: list = field(default_factory=list)
+    # Bearer token every MCP request must present (issue #59). Empty (the
+    # default) leaves the server unauthenticated, same as before this field
+    # existed. MCP_AUTH_TOKEN overrides.
+    mcp_server_auth_token: str = ""
     user_tools_disabled: list = field(default_factory=list)
     scan_freecad_macros: bool = False
     # Dangerous mode: relaxes executor safety layers (static pattern blocking,

--- a/freecad_ai/mcp/gui_server.py
+++ b/freecad_ai/mcp/gui_server.py
@@ -78,12 +78,27 @@ def resolve_allowed_hosts(cfg=None):
     hosts = [h.strip() for h in hosts if h and h.strip()]
     if any(h == "*" for h in hosts):
         raise ValueError(
-            "'*' is not accepted in the MCP allowed-hosts list. The server "
-            "has no authentication (issue #59), and this allowlist is the "
-            "only thing keeping a wildcard bind from serving arbitrary "
-            "Python to anything that can reach it. Name the concrete hosts "
-            "clients dial instead.")
+            "'*' is not accepted in the MCP allowed-hosts list. Unless a "
+            "bearer token is configured (MCP_AUTH_TOKEN or the AI Settings "
+            "dialog), this allowlist is the only thing keeping a wildcard "
+            "bind from serving arbitrary Python to anything that can reach "
+            "it. Name the concrete hosts clients dial instead.")
     return hosts or None
+
+
+def resolve_auth_token(cfg=None):
+    """Return the bearer token every request must present, or ``None`` to
+    leave the server unauthenticated: the historical default (#59).
+
+    Env beats config, matching MCP_HOST / MCP_PORT / MCP_ALLOWED_HOSTS. An
+    empty string from either source means "no token configured", not "an
+    empty token is required": the transport must never be handed a token it
+    would enforce against a header nobody can send.
+    """
+    token = os.environ.get("MCP_AUTH_TOKEN")
+    if not token and cfg is not None:
+        token = getattr(cfg, "mcp_server_auth_token", "")
+    return token or None
 
 
 def _default_backend():
@@ -121,7 +136,7 @@ class ServerController:
     def url(self):
         return self._url if self.is_running() else None
 
-    def start(self, host, port, allowed_hosts=None):
+    def start(self, host, port, allowed_hosts=None, auth_token=None):
         """Start serving and return the URL.
 
         Raises OSError if the bind fails, or if ``host`` is a wildcard address
@@ -145,7 +160,8 @@ class ServerController:
         from .transport import HTTPServerTransport
 
         transport = HTTPServerTransport(host=host, port=port,
-                                        allowed_hosts=allowed_hosts)
+                                        allowed_hosts=allowed_hosts,
+                                        auth_token=auth_token)
         transport.bind()  # raises OSError on the caller's thread — the point
 
         if self._registry is None or self._executor is None:

--- a/freecad_ai/mcp/gui_server.py
+++ b/freecad_ai/mcp/gui_server.py
@@ -78,11 +78,10 @@ def resolve_allowed_hosts(cfg=None):
     hosts = [h.strip() for h in hosts if h and h.strip()]
     if any(h == "*" for h in hosts):
         raise ValueError(
-            "'*' is not accepted in the MCP allowed-hosts list. Unless a "
-            "bearer token is configured (MCP_AUTH_TOKEN or the AI Settings "
-            "dialog), this allowlist is the only thing keeping a wildcard "
-            "bind from serving arbitrary Python to anything that can reach "
-            "it. Name the concrete hosts clients dial instead.")
+            "'*' is not accepted in the MCP allowed-hosts list. This "
+            "allowlist is the only thing keeping a wildcard bind from "
+            "serving arbitrary Python to anything that can reach it. Name "
+            "the concrete hosts clients dial instead.")
     return hosts or None
 
 
@@ -94,11 +93,27 @@ def resolve_auth_token(cfg=None):
     empty string from either source means "no token configured", not "an
     empty token is required": the transport must never be handed a token it
     would enforce against a header nobody can send.
+
+    Raises ValueError on a non-ASCII token: ``hmac.compare_digest`` (used to
+    check it on every request) raises ``TypeError`` on a non-ASCII operand,
+    so a token that cannot be compared must fail loudly here, at start-up,
+    rather than on every request the server ever receives.
     """
     token = os.environ.get("MCP_AUTH_TOKEN")
     if not token and cfg is not None:
         token = getattr(cfg, "mcp_server_auth_token", "")
-    return token or None
+    token = token or None
+    if token is not None:
+        try:
+            token.encode("ascii")
+        except UnicodeEncodeError:
+            raise ValueError(
+                "The MCP bearer token must be ASCII: it is compared with "
+                "hmac.compare_digest() on every request, which raises "
+                "TypeError on a non-ASCII operand. Use the Settings "
+                "dialog's Generate button, or set MCP_AUTH_TOKEN to an "
+                "ASCII value.")
+    return token
 
 
 def _default_backend():

--- a/freecad_ai/mcp/transport.py
+++ b/freecad_ai/mcp/transport.py
@@ -5,6 +5,7 @@ StdioServerTransport — reads stdin / writes stdout (server side).
 HTTPServerTransport — serves MCP over HTTP: Streamable HTTP and HTTP+SSE.
 """
 
+import hmac
 import json
 import logging
 import subprocess
@@ -556,10 +557,17 @@ class HTTPServerTransport:
     does, so this blocks browser drive-by tool invocation without breaking the
     documented local client. ``allowed_hosts``/``allowed_origins`` widen the
     policy for advanced (e.g. deliberately LAN-exposed) deployments.
+
+    Neither check is access control: any local process can send a loopback
+    ``Host`` and no ``Origin``, so anything already running on the machine can
+    call every tool. ``auth_token``, when set, closes that gap by also
+    requiring ``Authorization: Bearer <token>`` on every request (#59).
+    Unset (the default) leaves the server exactly as before: no token is
+    required, matching every currently documented start-up recipe.
     """
 
     def __init__(self, host: str = "127.0.0.1", port: int = 3000,
-                 allowed_hosts=None, allowed_origins=()):
+                 allowed_hosts=None, allowed_origins=(), auth_token=None):
         self._host = host
         self._port = port
         self._handler: Callable[[dict], dict | None] | None = None
@@ -568,6 +576,10 @@ class HTTPServerTransport:
         self._httpd = None
         self._serving = False
         self._lifecycle_lock = threading.Lock()
+        # Falsy (None or "") means "no token configured": never enforce an
+        # empty token, which would reject every request with no way to admit
+        # one.
+        self._auth_token = auth_token or None
         if allowed_hosts is None:
             if host.lower() in _WILDCARD_BIND_HOSTS:
                 raise OSError(
@@ -591,13 +603,36 @@ class HTTPServerTransport:
             return value[1:].split("]", 1)[0].lower()
         return value.split(":", 1)[0].lower()
 
-    def _request_allowed(self, host_header, origin_header) -> bool:
-        """Authorize a request by its Host (DNS-rebinding) and Origin (CSRF)."""
+    def _request_allowed(self, host_header, origin_header,
+                          authorization_header=None) -> bool:
+        """Authorize a request by Host (DNS-rebinding), Origin (CSRF), and,
+        when configured, a bearer token (access control, #59)."""
         if self._hostname_of(host_header) not in self._allowed_hosts:
             return False
         if origin_header is not None and origin_header not in self._allowed_origins:
             return False
+        if self._auth_token is not None:
+            if not hmac.compare_digest(
+                    self._bearer_token_of(authorization_header),
+                    self._auth_token):
+                return False
         return True
+
+    @staticmethod
+    def _bearer_token_of(authorization_header) -> str:
+        """Extract the token from an ``Authorization: Bearer <token>`` header.
+
+        Returns ``""`` for a missing header or any other scheme, which
+        ``hmac.compare_digest`` then compares against the real token in
+        constant time: a plain ``==`` would leak the token's length and
+        prefix through response timing.
+        """
+        if not authorization_header:
+            return ""
+        scheme, _, value = authorization_header.partition(" ")
+        if scheme.lower() != "bearer":
+            return ""
+        return value.strip()
 
     def bind(self):
         """Create and bind the listening socket. Raises OSError if unavailable.
@@ -702,7 +737,8 @@ class HTTPServerTransport:
 
             def _authorized(self):
                 if transport._request_allowed(
-                    self.headers.get("Host"), self.headers.get("Origin")
+                    self.headers.get("Host"), self.headers.get("Origin"),
+                    self.headers.get("Authorization")
                 ):
                     return True
                 self.send_error(403)

--- a/freecad_ai/mcp/transport.py
+++ b/freecad_ai/mcp/transport.py
@@ -607,16 +607,44 @@ class HTTPServerTransport:
                           authorization_header=None) -> bool:
         """Authorize a request by Host (DNS-rebinding), Origin (CSRF), and,
         when configured, a bearer token (access control, #59)."""
+        return self._classify_request(
+            host_header, origin_header, authorization_header) == "ok"
+
+    def _classify_request(self, host_header, origin_header,
+                           authorization_header=None) -> str:
+        """Like ``_request_allowed``, but distinguishes *why* a request is
+        denied so the HTTP handler can answer 403 vs 401.
+
+        "denied": Host/Origin rejected the request (DNS-rebinding/CSRF),
+        meaning this caller is not allowed here at all, regardless of
+        credentials. "unauthorized": a bearer token is configured and the
+        one presented is missing or wrong, meaning the caller may retry
+        with a credential. "ok": request may proceed.
+        """
         if self._hostname_of(host_header) not in self._allowed_hosts:
-            return False
+            return "denied"
         if origin_header is not None and origin_header not in self._allowed_origins:
+            return "denied"
+        if self._auth_token is not None and not self._token_matches(authorization_header):
+            return "unauthorized"
+        return "ok"
+
+    def _token_matches(self, authorization_header) -> bool:
+        """Constant-time compare of the presented bearer token.
+
+        ``hmac.compare_digest`` raises ``TypeError`` when either ``str``
+        argument contains a non-ASCII character. HTTP headers are decoded
+        latin-1 by ``http.client.parse_headers``, so any byte >= 0x80 in
+        ``Authorization`` produces exactly that: an unauthenticated caller
+        could otherwise crash the handler thread on every request, with no
+        response sent at all.
+        """
+        try:
+            return hmac.compare_digest(
+                self._bearer_token_of(authorization_header),
+                self._auth_token)
+        except TypeError:
             return False
-        if self._auth_token is not None:
-            if not hmac.compare_digest(
-                    self._bearer_token_of(authorization_header),
-                    self._auth_token):
-                return False
-        return True
 
     @staticmethod
     def _bearer_token_of(authorization_header) -> str:
@@ -736,11 +764,19 @@ class HTTPServerTransport:
                 return self.path.split("?")[0].rstrip("/")
 
             def _authorized(self):
-                if transport._request_allowed(
+                status = transport._classify_request(
                     self.headers.get("Host"), self.headers.get("Origin"),
-                    self.headers.get("Authorization")
-                ):
+                    self.headers.get("Authorization"))
+                if status == "ok":
                     return True
+                if status == "unauthorized":
+                    # Missing/wrong bearer token: distinct from a Host/Origin
+                    # rejection so a client can tell "present a credential"
+                    # from "you are not allowed here at all" (#59 review).
+                    self.send_response(401)
+                    self.send_header("WWW-Authenticate", "Bearer")
+                    self.end_headers()
+                    return False
                 self.send_error(403)
                 return False
 

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -740,7 +740,10 @@ class SettingsDialog(QDialog):
             "Listing hosts is what makes a non-loopback bind reachable, so "
             "name only the addresses clients actually dial. \"*\" is not "
             "accepted \u2014 without a token, this list is the only thing "
-            "limiting who can reach the server."))
+            "limiting who can reach the server.\n\n"
+            "Host, port, allowed hosts, and the bearer token only take "
+            "effect the next time the MCP server starts. Saving here does "
+            "not reconfigure one that is already running."))
         mcp_server_warning.setWordWrap(True)
         mcp_layout.addWidget(mcp_server_warning)
 

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -12,6 +12,7 @@ Provides a GUI for configuring:
 """
 
 import os
+import secrets
 
 from .compat import QtWidgets, QtCore, QtGui
 from ..i18n import translate
@@ -702,21 +703,44 @@ class SettingsDialog(QDialog):
             translate("SettingsDialog", "Allowed Host headers:"),
             self.mcp_server_allowed_hosts_edit)
 
+        # Optional bearer token (#59). Empty (the default) leaves the server
+        # unauthenticated, exactly as before this field existed. "Generate"
+        # fills in a fresh secrets.token_urlsafe(32) value on demand.
+        auth_token_row = QWidget()
+        auth_token_row_layout = QHBoxLayout()
+        auth_token_row_layout.setContentsMargins(0, 0, 0, 0)
+        self.mcp_server_auth_token_edit = QLineEdit()
+        self.mcp_server_auth_token_edit.setPlaceholderText(
+            translate("SettingsDialog", "none \u2014 authentication disabled"))
+        auth_token_row_layout.addWidget(self.mcp_server_auth_token_edit)
+        generate_token_btn = QPushButton(translate("SettingsDialog", "Generate"))
+        generate_token_btn.clicked.connect(self._generate_mcp_auth_token)
+        auth_token_row_layout.addWidget(generate_token_btn)
+        clear_token_btn = QPushButton(translate("SettingsDialog", "Clear"))
+        clear_token_btn.clicked.connect(
+            lambda: self.mcp_server_auth_token_edit.setText(""))
+        auth_token_row_layout.addWidget(clear_token_btn)
+        auth_token_row.setLayout(auth_token_row_layout)
+        server_form.addRow(
+            translate("SettingsDialog", "Bearer token:"), auth_token_row)
+
         mcp_layout.addLayout(server_form)
 
         # Unconditional, not shown only for non-loopback values: the loopback
         # default is already reachable by every local process, so hiding the
-        # warning there would imply the default is authenticated. It is not.
+        # warning there would imply the default is authenticated. It is not,
+        # unless a bearer token above is set.
         mcp_server_warning = QLabel(translate(
             "SettingsDialog",
-            "The MCP server has no authentication. Anything that can reach "
-            "this address can run FreeCAD tools, including arbitrary Python. "
-            "Keep it on 127.0.0.1 unless you understand the exposure.\n\n"
+            "Without a bearer token, anything that can reach this address "
+            "can run FreeCAD tools, including arbitrary Python. Keep it on "
+            "127.0.0.1 unless you understand the exposure, or set a bearer "
+            "token above.\n\n"
             "Leave Allowed Host headers empty for loopback-only access. "
             "Listing hosts is what makes a non-loopback bind reachable, so "
             "name only the addresses clients actually dial. \"*\" is not "
-            "accepted \u2014 with no authentication, this list is the only "
-            "thing limiting who can reach the server."))
+            "accepted \u2014 without a token, this list is the only thing "
+            "limiting who can reach the server."))
         mcp_server_warning.setWordWrap(True)
         mcp_layout.addWidget(mcp_server_warning)
 
@@ -953,6 +977,7 @@ class SettingsDialog(QDialog):
         self.mcp_server_port_edit.setText(str(cfg.mcp_server_port))
         self.mcp_server_allowed_hosts_edit.setText(
             ", ".join(cfg.mcp_server_allowed_hosts or []))
+        self.mcp_server_auth_token_edit.setText(cfg.mcp_server_auth_token or "")
 
         # Editor preference
         self.use_external_editor_cb.setChecked(cfg.use_external_editor)
@@ -1226,6 +1251,7 @@ class SettingsDialog(QDialog):
             self.mcp_server_port_edit.text())
         cfg.mcp_server_allowed_hosts = self._parse_allowed_hosts(
             self.mcp_server_allowed_hosts_edit.text())
+        cfg.mcp_server_auth_token = self.mcp_server_auth_token_edit.text().strip()
         cfg.use_external_editor = self.use_external_editor_cb.isChecked()
         cfg.scan_freecad_macros = self.scan_macros_cb.isChecked()
 
@@ -1611,6 +1637,17 @@ class SettingsDialog(QDialog):
         if not 1 <= port <= 65535:
             return host, DEFAULT_PORT
         return host, port
+
+    def _generate_mcp_auth_token(self):
+        """Fill the bearer-token field with a fresh random token.
+
+        Same shape the issue proposes (``secrets.token_urlsafe(32)``), run on
+        demand rather than automatically on every server start: an
+        auto-generated token would change on each restart with no stable
+        place for the user to read it back from, whereas this field is that
+        place: it stays whatever the user last set until they change it.
+        """
+        self.mcp_server_auth_token_edit.setText(secrets.token_urlsafe(32))
 
     def _add_mcp_server(self):
         """Show a dialog to add a new MCP server configuration."""

--- a/mcp_server_http.py
+++ b/mcp_server_http.py
@@ -31,8 +31,10 @@ Environment variables:
     MCP_ALLOWED_HOSTS — comma-separated Host headers the server answers to
                         (default: loopback only). Needed when binding a
                         non-loopback address: clients send the address they
-                        dialled, so it must be named here. "*" is refused —
-                        the server has no authentication.
+                        dialled, so it must be named here. "*" is refused.
+    MCP_AUTH_TOKEN: optional bearer token. Unset (the default) leaves the
+                    server unauthenticated, as before. When set, every
+                    request must carry "Authorization: Bearer <token>".
 """
 
 import os
@@ -58,6 +60,7 @@ if not FreeCAD.ActiveDocument:
 from freecad_ai.mcp.gui_server import (
     get_server_controller,
     resolve_allowed_hosts,
+    resolve_auth_token,
     resolve_server_address,
 )
 
@@ -71,9 +74,14 @@ except Exception:
 
 host, port = resolve_server_address(_cfg)
 allowed_hosts = resolve_allowed_hosts(_cfg)
+auth_token = resolve_auth_token(_cfg)
 
 # start() binds before returning, so this line can no longer announce a
 # server that never came up.
-url = get_server_controller().start(host, port, allowed_hosts=allowed_hosts)
+url = get_server_controller().start(host, port, allowed_hosts=allowed_hosts,
+                                    auth_token=auth_token)
 
 print(f"MCP server running on {url}", flush=True)
+if auth_token:
+    print("MCP server requires a bearer token (Authorization: Bearer ...)",
+          flush=True)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1245,3 +1245,19 @@ def test_mcp_server_allowed_hosts_defaults_to_empty():
     """
     from freecad_ai.config import AppConfig
     assert AppConfig().mcp_server_allowed_hosts == []
+
+
+def test_mcp_server_auth_token_defaults_to_empty():
+    """Empty means "no token configured", which leaves the server exactly as
+    unauthenticated as before this field existed (#59): opt-in, not on by
+    default.
+    """
+    from freecad_ai.config import AppConfig
+    assert AppConfig().mcp_server_auth_token == ""
+
+
+def test_mcp_server_auth_token_roundtrip():
+    from freecad_ai.config import AppConfig
+    cfg = AppConfig(mcp_server_auth_token="s3cr3t")
+    restored = AppConfig.from_dict(cfg.to_dict())
+    assert restored.mcp_server_auth_token == "s3cr3t"

--- a/tests/unit/test_mcp_gui_server.py
+++ b/tests/unit/test_mcp_gui_server.py
@@ -17,6 +17,7 @@ from freecad_ai.mcp.gui_server import (
     ServerController,
     get_server_controller,
     resolve_allowed_hosts,
+    resolve_auth_token,
     resolve_server_address,
 )
 
@@ -137,6 +138,64 @@ def test_allowed_hosts_rejects_a_wildcard_entry_from_config(monkeypatch):
     cfg = type("Cfg", (), {"mcp_server_allowed_hosts": ["*"]})()
     with pytest.raises(ValueError, match=r"\*"):
         resolve_allowed_hosts(cfg)
+
+
+# --- auth-token resolution --------------------------------------------------
+#
+# Unset must resolve to None, not "". The transport's own auth_token is None
+# branch is what leaves the server unauthenticated, and "" would either be
+# handed through as a token nobody can ever present (see the transport-level
+# test for why that must not happen) or rely on every caller normalising it.
+
+def test_auth_token_is_none_when_nothing_is_configured(monkeypatch):
+    monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
+    assert resolve_auth_token(None) is None
+
+
+def test_auth_token_is_none_when_the_config_value_is_empty(monkeypatch):
+    monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
+    cfg = type("Cfg", (), {"mcp_server_auth_token": ""})()
+    assert resolve_auth_token(cfg) is None
+
+
+def test_auth_token_prefers_config_over_default(monkeypatch):
+    monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
+    cfg = type("Cfg", (), {"mcp_server_auth_token": "from-config"})()
+    assert resolve_auth_token(cfg) == "from-config"
+
+
+def test_auth_token_prefers_env_over_config(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_TOKEN", "from-env")
+    cfg = type("Cfg", (), {"mcp_server_auth_token": "from-config"})()
+    assert resolve_auth_token(cfg) == "from-env"
+
+
+# --- auth token reaches the transport ---------------------------------------
+
+def test_start_with_an_auth_token_requires_it_on_the_transport():
+    controller = _controller()
+    port = _free_port()
+    try:
+        controller.start("127.0.0.1", port, auth_token="s3cr3t")
+        transport = controller._transport
+        assert transport._request_allowed(
+            "127.0.0.1:%d" % port, None, None) is False
+        assert transport._request_allowed(
+            "127.0.0.1:%d" % port, None, "Bearer s3cr3t") is True
+    finally:
+        controller.stop()
+
+
+def test_start_without_an_auth_token_keeps_the_server_unauthenticated():
+    controller = _controller()
+    port = _free_port()
+    try:
+        controller.start("127.0.0.1", port)
+        transport = controller._transport
+        assert transport._request_allowed(
+            "127.0.0.1:%d" % port, None, None) is True
+    finally:
+        controller.stop()
 
 
 # --- allowed hosts reach the transport -------------------------------------

--- a/tests/unit/test_mcp_gui_server.py
+++ b/tests/unit/test_mcp_gui_server.py
@@ -170,6 +170,22 @@ def test_auth_token_prefers_env_over_config(monkeypatch):
     assert resolve_auth_token(cfg) == "from-env"
 
 
+def test_non_ascii_auth_token_from_config_raises_at_resolve_time(monkeypatch):
+    # hmac.compare_digest() raises TypeError on a non-ASCII str operand, so a
+    # token that cannot be compared must fail loudly here rather than crash
+    # the handler thread on every request the server ever receives.
+    monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
+    cfg = type("Cfg", (), {"mcp_server_auth_token": "tökén"})()
+    with pytest.raises(ValueError):
+        resolve_auth_token(cfg)
+
+
+def test_non_ascii_auth_token_from_env_raises_at_resolve_time(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_TOKEN", "tökén")
+    with pytest.raises(ValueError):
+        resolve_auth_token(None)
+
+
 # --- auth token reaches the transport ---------------------------------------
 
 def test_start_with_an_auth_token_requires_it_on_the_transport():

--- a/tests/unit/test_mcp_sse_transport.py
+++ b/tests/unit/test_mcp_sse_transport.py
@@ -213,6 +213,28 @@ def test_empty_string_token_disables_auth_rather_than_requiring_an_empty_one():
     assert transport._request_allowed("127.0.0.1:3000", None, None) is True
 
 
+def test_non_ascii_authorization_header_is_rejected_not_crashed():
+    # hmac.compare_digest() raises TypeError on a non-ASCII str operand, and
+    # HTTP headers are decoded latin-1, so any byte >= 0x80 in Authorization
+    # used to reach compare_digest() and crash the handler thread with no
+    # response sent at all rather than a clean rejection.
+    transport = SSEServerTransport(auth_token="s3cr3t")
+    assert transport._request_allowed(
+        "127.0.0.1:3000", None, "Bearer t\xf6k\xe9n") is False
+
+
+def test_classify_request_distinguishes_denied_from_unauthorized():
+    # Host/Origin failing is "not allowed here at all" (403), while a
+    # missing or wrong token is "present a credential" (401); the HTTP
+    # handler needs to tell these apart even though _request_allowed
+    # collapses both to False (#59 review).
+    transport = SSEServerTransport(auth_token="s3cr3t")
+    assert transport._classify_request("evil.example:3000", None, "Bearer s3cr3t") == "denied"
+    assert transport._classify_request("127.0.0.1:3000", None, None) == "unauthorized"
+    assert transport._classify_request("127.0.0.1:3000", None, "Bearer wrong") == "unauthorized"
+    assert transport._classify_request("127.0.0.1:3000", None, "Bearer s3cr3t") == "ok"
+
+
 def test_host_and_origin_checks_still_apply_alongside_a_token():
     # The token is an additional gate, not a replacement for the existing
     # DNS-rebinding/CSRF checks.
@@ -279,7 +301,10 @@ def test_live_request_with_a_token_configured_requires_it():
         )
         with pytest.raises(urllib.error.HTTPError) as exc:
             urllib.request.urlopen(no_token, timeout=5)
-        assert exc.value.code == 403
+        # 401, not 403: a missing/wrong token is "present a credential", a
+        # Host/Origin rejection is "not allowed here at all" (#59 review).
+        assert exc.value.code == 401
+        assert exc.value.headers.get("WWW-Authenticate") == "Bearer"
 
         wrong_token = urllib.request.Request(
             f"http://127.0.0.1:{port}/messages",
@@ -290,7 +315,22 @@ def test_live_request_with_a_token_configured_requires_it():
         )
         with pytest.raises(urllib.error.HTTPError) as exc:
             urllib.request.urlopen(wrong_token, timeout=5)
-        assert exc.value.code == 403
+        assert exc.value.code == 401
+        assert exc.value.headers.get("WWW-Authenticate") == "Bearer"
+
+        non_ascii_token = urllib.request.Request(
+            f"http://127.0.0.1:{port}/messages",
+            data=b'{"jsonrpc":"2.0","id":1,"method":"ping"}',
+            headers={"Content-Type": "application/json",
+                     "Authorization": "Bearer t\xf6k\xe9n"},
+            method="POST",
+        )
+        # A non-ASCII Authorization header used to crash the handler thread
+        # (hmac.compare_digest raises TypeError on non-ASCII str operands,
+        # and headers are decoded latin-1) rather than answer at all.
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(non_ascii_token, timeout=5)
+        assert exc.value.code == 401
 
         right_token = urllib.request.Request(
             f"http://127.0.0.1:{port}/messages",

--- a/tests/unit/test_mcp_sse_transport.py
+++ b/tests/unit/test_mcp_sse_transport.py
@@ -160,6 +160,69 @@ def test_wildcard_bind_host_allowed_with_explicit_allowed_hosts():
     assert transport._request_allowed("fileserver.local:3000", None) is True
 
 
+# ---------------------------------------------------------------------------
+# Optional bearer token (#59): access control on top of the Host/Origin
+# checks above, which are DNS-rebinding/CSRF guards, not authentication.
+# ---------------------------------------------------------------------------
+
+def test_no_token_configured_keeps_prior_behaviour():
+    # Host/Origin alone still authorize the request when auth_token is unset
+    # (the default), matching every currently documented start-up recipe.
+    transport = SSEServerTransport()
+    assert transport._request_allowed("127.0.0.1:3000", None) is True
+    assert transport._request_allowed("127.0.0.1:3000", None, None) is True
+
+
+def test_token_configured_rejects_a_request_with_no_authorization_header():
+    transport = SSEServerTransport(auth_token="s3cr3t")
+    assert transport._request_allowed("127.0.0.1:3000", None, None) is False
+
+
+def test_token_configured_accepts_the_matching_bearer_header():
+    transport = SSEServerTransport(auth_token="s3cr3t")
+    assert transport._request_allowed(
+        "127.0.0.1:3000", None, "Bearer s3cr3t") is True
+
+
+def test_token_configured_rejects_a_wrong_token():
+    transport = SSEServerTransport(auth_token="s3cr3t")
+    assert transport._request_allowed(
+        "127.0.0.1:3000", None, "Bearer wrong") is False
+
+
+def test_token_configured_rejects_a_non_bearer_scheme():
+    transport = SSEServerTransport(auth_token="s3cr3t")
+    assert transport._request_allowed(
+        "127.0.0.1:3000", None, "Basic s3cr3t") is False
+
+
+def test_token_check_is_case_insensitive_on_the_scheme():
+    # RFC 7235 auth-schemes are case-insensitive; a strict "Bearer" match
+    # would reject a spec-compliant "bearer" from a client that lowercases it.
+    transport = SSEServerTransport(auth_token="s3cr3t")
+    assert transport._request_allowed(
+        "127.0.0.1:3000", None, "bearer s3cr3t") is True
+
+
+def test_empty_string_token_disables_auth_rather_than_requiring_an_empty_one():
+    # An empty token can never be presented by any client (there is no header
+    # value that parses to ""), so treating "" as "enforce an empty token"
+    # would make the endpoint permanently unreachable. "" must mean disabled,
+    # same as None.
+    transport = SSEServerTransport(auth_token="")
+    assert transport._request_allowed("127.0.0.1:3000", None, None) is True
+
+
+def test_host_and_origin_checks_still_apply_alongside_a_token():
+    # The token is an additional gate, not a replacement for the existing
+    # DNS-rebinding/CSRF checks.
+    transport = SSEServerTransport(auth_token="s3cr3t")
+    assert transport._request_allowed(
+        "evil.example:3000", None, "Bearer s3cr3t") is False
+    assert transport._request_allowed(
+        "127.0.0.1:3000", "https://evil.example", "Bearer s3cr3t") is False
+
+
 def test_cross_origin_post_rejected_and_no_wildcard_cors_header():
     transport = SSEServerTransport(host="127.0.0.1", port=0)
     transport._handler = lambda msg: {
@@ -193,6 +256,51 @@ def test_cross_origin_post_rejected_and_no_wildcard_cors_header():
         resp = urllib.request.urlopen(native, timeout=5)
         assert resp.status == 202
         assert resp.headers.get("Access-Control-Allow-Origin") is None
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_live_request_with_a_token_configured_requires_it():
+    transport = SSEServerTransport(host="127.0.0.1", port=0, auth_token="s3cr3t")
+    transport._handler = lambda msg: {
+        "jsonrpc": "2.0", "id": msg.get("id"), "result": {}
+    }
+    server = transport._make_server()
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        no_token = urllib.request.Request(
+            f"http://127.0.0.1:{port}/messages",
+            data=b'{"jsonrpc":"2.0","id":1,"method":"ping"}',
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(no_token, timeout=5)
+        assert exc.value.code == 403
+
+        wrong_token = urllib.request.Request(
+            f"http://127.0.0.1:{port}/messages",
+            data=b'{"jsonrpc":"2.0","id":1,"method":"ping"}',
+            headers={"Content-Type": "application/json",
+                     "Authorization": "Bearer wrong"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(wrong_token, timeout=5)
+        assert exc.value.code == 403
+
+        right_token = urllib.request.Request(
+            f"http://127.0.0.1:{port}/messages",
+            data=b'{"jsonrpc":"2.0","id":1,"method":"ping"}',
+            headers={"Content-Type": "application/json",
+                     "Authorization": "Bearer s3cr3t"},
+            method="POST",
+        )
+        resp = urllib.request.urlopen(right_token, timeout=5)
+        assert resp.status == 202
     finally:
         server.shutdown()
         server.server_close()
@@ -350,25 +458,27 @@ def test_http_entry_point_delegates_to_the_shared_controller(monkeypatch):
     started = []
 
     class _FakeController:
-        def start(self, host, port, allowed_hosts=None):
-            started.append((host, port, allowed_hosts))
+        def start(self, host, port, allowed_hosts=None, auth_token=None):
+            started.append((host, port, allowed_hosts, auth_token))
             return "http://%s:%d/sse" % (host, port)
 
     import freecad_ai.mcp.gui_server as gui_server
     monkeypatch.setattr(gui_server, "get_server_controller",
                         lambda: _FakeController())
 
-    # Pin all three so the assertion cannot depend on the developer's
+    # Pin all four so the assertion cannot depend on the developer's
     # config.json or environment.
     monkeypatch.setenv("MCP_HOST", "127.0.0.1")
     monkeypatch.setenv("MCP_PORT", "3131")
     monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
 
     exec(compile(source, "mcp_server_http.py", "exec"), {})
 
-    # allowed_hosts stays None with nothing configured, so the transport keeps
-    # deriving its own default — and with it the wildcard-bind rejection.
-    assert started == [("127.0.0.1", 3131, None)]
+    # allowed_hosts stays None and auth_token stays None with nothing
+    # configured, so the transport keeps deriving its own default (and with
+    # it the wildcard-bind rejection) and stays unauthenticated.
+    assert started == [("127.0.0.1", 3131, None, None)]
 
 
 def test_http_entry_point_forwards_the_allowed_hosts_env_var(monkeypatch):
@@ -384,8 +494,8 @@ def test_http_entry_point_forwards_the_allowed_hosts_env_var(monkeypatch):
     started = []
 
     class _FakeController:
-        def start(self, host, port, allowed_hosts=None):
-            started.append((host, port, allowed_hosts))
+        def start(self, host, port, allowed_hosts=None, auth_token=None):
+            started.append((host, port, allowed_hosts, auth_token))
             return "http://%s:%d/sse" % (host, port)
 
     import freecad_ai.mcp.gui_server as gui_server
@@ -395,11 +505,43 @@ def test_http_entry_point_forwards_the_allowed_hosts_env_var(monkeypatch):
     monkeypatch.setenv("MCP_HOST", "192.168.1.50")
     monkeypatch.setenv("MCP_PORT", "3131")
     monkeypatch.setenv("MCP_ALLOWED_HOSTS", "fileserver.local, 192.168.1.50")
+    monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
 
     exec(compile(source, "mcp_server_http.py", "exec"), {})
 
     assert started == [("192.168.1.50", 3131,
-                        ["fileserver.local", "192.168.1.50"])]
+                        ["fileserver.local", "192.168.1.50"], None)]
+
+
+def test_http_entry_point_forwards_the_auth_token_env_var(monkeypatch):
+    """MCP_AUTH_TOKEN must reach the transport, not just parse cleanly."""
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    source = (repo_root / "mcp_server_http.py").read_text()
+
+    fake_freecad = types.ModuleType("FreeCAD")
+    fake_freecad.ActiveDocument = object()
+    fake_freecad.newDocument = lambda name: None
+    monkeypatch.setitem(sys.modules, "FreeCAD", fake_freecad)
+
+    started = []
+
+    class _FakeController:
+        def start(self, host, port, allowed_hosts=None, auth_token=None):
+            started.append((host, port, allowed_hosts, auth_token))
+            return "http://%s:%d/sse" % (host, port)
+
+    import freecad_ai.mcp.gui_server as gui_server
+    monkeypatch.setattr(gui_server, "get_server_controller",
+                        lambda: _FakeController())
+
+    monkeypatch.setenv("MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv("MCP_PORT", "3131")
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.setenv("MCP_AUTH_TOKEN", "s3cr3t")
+
+    exec(compile(source, "mcp_server_http.py", "exec"), {})
+
+    assert started == [("127.0.0.1", 3131, None, "s3cr3t")]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The MCP server authorizes requests by Host and Origin header alone (`_request_allowed` in `freecad_ai/mcp/transport.py`). Those checks stop DNS rebinding and browser CSRF, but neither is access control: any local process can send a loopback `Host` and no `Origin`, so anything already running on the machine, or anything that can reach a non-loopback bind, can drive FreeCAD's tools with no credential at all.

This adds an optional bearer token, matching the shape already proposed in the issue: `secrets.token_urlsafe(32)`, checked with `hmac.compare_digest()` so a wrong guess cannot be timed. Unset (the default) leaves the server exactly as before, since every currently documented start-up recipe assumes no token.

- `HTTPServerTransport(auth_token=...)` requires `Authorization: Bearer <token>` on top of the existing Host/Origin checks, not instead of them.
- `AppConfig.mcp_server_auth_token` and `MCP_AUTH_TOKEN` (env wins) carry the token through both start-up routes: the toolbar toggle (`InitGui.py`) and the headless entry point (`mcp_server_http.py`), the same precedence `MCP_HOST`/`MCP_PORT`/`MCP_ALLOWED_HOSTS` already use.
- The Settings dialog gets a token field with Generate (fills in a fresh `token_urlsafe(32)` value) and Clear buttons.

Verification:
- New unit tests in `test_mcp_sse_transport.py`, `test_mcp_gui_server.py`, and `test_config.py` cover: no-token behavior unchanged, missing/wrong/non-Bearer/case-insensitive-scheme headers, an end-to-end request against a live server, and that the token is additive to the Host/Origin checks rather than a replacement.
- `_request_allowed` has exactly one caller in production code (`_authorized`) and `HTTPServerTransport(...)` has exactly one construction site (`ServerController.start`); both are updated, so nothing bypasses the new check.
- Full `tests/unit/` suite in a clean `python:3.12-slim` container: 1176 passed, 16 skipped, 17 failed. The 17 failures are byte-identical on an unmodified `master` in the same container (missing PySide2/PySide6, unrelated to this change).
- Not checked: behavior against a real FreeCAD GUI session, since these are the addon's own headless unit tests and the repo's CI is the same local suite (no GitHub Actions configured here).

Fixes #59
