### PR TITLE
feat: connection profiles and per-utility models (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Connection profiles.** LLM connection settings are now named profiles.
+  Define as many as you like — `ollama-local` and `ollama-remote` can
+  coexist with different URLs and keys — and switch between them from the
+  Settings dialog without losing anything.
+- **Per-utility models.** Context compaction, skill evaluation, tool
+  optimisation and tool reranking each choose a profile, or inherit the
+  active one. Run chat on a large cloud model and the throwaway work on a
+  cheap or local one.
+
+### Changed
+
+- The reranker's four-field provider override is replaced by a profile.
+  Existing overrides migrate automatically into a profile named `rerank`.
+- The reranker's **Test reranker** button now probes whichever profile
+  reranking is set to (or the active profile, if left on inherit), instead
+  of its own four fields.
+
+### Fixed
+
+- Switching provider in the Settings dialog no longer overwrites a
+  Base URL you had edited (#75). Connection settings live in the profile,
+  and programmatic dropdown moves no longer fire the preset handler.
+- Cancelling the Settings dialog now discards profile changes. Adding,
+  renaming, deleting or editing a profile previously took effect
+  immediately, and Test Connection could flush the change to disk before
+  you ever pressed OK.
+- Sampling parameters edited in Settings now take effect. For a
+  configuration carried over from an earlier version, editing temperature
+  or any other parameter was silently discarded: the value was written to
+  the global per-model defaults, which the profile's own parameters then
+  overrode.
+- Test Connection now succeeds for a profile that leaves its API key blank
+  to inherit the vendor-wide default, matching what normal chat use
+  already did.
+
 ## [0.23.1-alpha] - 2026-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Define as many as you like — `ollama-local` and `ollama-remote` can
   coexist with different URLs and keys — and switch between them from the
   Settings dialog without losing anything.
+- Saving a profile with an empty **Base URL** now asks first, naming the
+  profiles concerned. Such a profile fails with a bare connection error at
+  request time, and profile resolution deliberately does not substitute the
+  provider's preset URL behind your back — so the dialog says so instead.
 - **Per-utility models.** Context compaction, skill evaluation, tool
   optimisation and tool reranking each choose a profile, or inherit the
   active one. Run chat on a large cloud model and the throwaway work on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   optimisation and tool reranking each choose a profile, or inherit the
   active one. Run chat on a large cloud model and the throwaway work on a
   cheap or local one.
+- A **Use this profile for chat** checkbox in the Settings dialog says
+  which profile chat runs on, and the profile dropdown marks it
+  `(active)`. Selecting a profile in the dropdown only opens it for
+  editing — browsing what your profiles hold never re-points chat.
 
 ### Changed
 
@@ -28,18 +32,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Switching provider in the Settings dialog no longer overwrites a
-  Base URL you had edited (#75). Connection settings live in the profile,
-  and programmatic dropdown moves no longer fire the preset handler.
+- Switching between profiles in the Settings dialog is lossless (#75).
+  Each profile keeps its own base URL, key, model and parameters, so
+  browsing to another profile and back leaves your edits intact and no
+  profile can overwrite another's settings. Pointing a profile at a
+  *different vendor* still loads that vendor's preset URL and model, as it
+  always has — that is an explicit "point this profile elsewhere".
 - Cancelling the Settings dialog now discards profile changes. Adding,
   renaming, deleting or editing a profile previously took effect
   immediately, and Test Connection could flush the change to disk before
   you ever pressed OK.
-- Sampling parameters edited in Settings now take effect. For a
-  configuration carried over from an earlier version, editing temperature
-  or any other parameter was silently discarded: the value was written to
-  the global per-model defaults, which the profile's own parameters then
-  overrode.
+- Sampling parameters edited in Settings now take effect, including
+  **Remove**. For a configuration carried over from an earlier version,
+  edits were silently discarded and removed rows came back: parameters
+  lived in two places at once, a per-model dict in `config.json` and the
+  profile, and the dialog could only reach one of them. The profile is now
+  the only source; the per-model dict is left in `config.json`, unread.
+- Clearing a profile's API key now actually clears it. Upgrading copied
+  the key into a second, per-vendor slot that no part of the dialog could
+  edit, so a key cleared to rotate a leaked credential stayed on disk and
+  kept being sent — with Test Connection reporting OK. That slot is no
+  longer written on upgrade; it remains available as a hand-written
+  per-vendor default in `config.json`.
 - Test Connection now succeeds for a profile that leaves its API key blank
   to inherit the vendor-wide default, matching what normal chat use
   already did.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,26 @@ To populate the stores once:
 | Zhipu | Yes | GLM models (z.ai international) |
 | Custom | Varies | Any OpenAI-compatible endpoint |
 
+### Connection profiles
+
+Connection settings — provider, base URL, API key, model, sampling parameters —
+are stored as named **profiles**, not a single flat set. You can define as many
+as you like, including several for the same vendor: `ollama-local` and
+`ollama-remote` can coexist with different URLs and keys, and switching between
+profiles in the Settings dialog never touches the ones you're not looking at.
+A profile's API key can be left blank to fall back to a vendor-wide default
+key, so one Anthropic key can serve several Anthropic profiles.
+
+Beyond the active profile chat uses, four utility jobs each pick their own
+profile from a dropdown in Settings: context compaction, skill evaluation,
+tool optimisation, and tool reranking. Left on **inherit**, a utility runs on
+whatever profile is currently active; pointed at a specific profile, it always
+uses that one — for example, running chat on a capable cloud model while
+compaction and reranking run on a cheap or local one.
+
+Existing configurations migrate to this shape automatically the first time
+you load them — there is nothing to do by hand.
+
 ### Model Parameters
 
 The **Model Parameters** table in Settings lets you set arbitrary sampling parameters (temperature, top_p, top_k, etc.) that are sent with each API request. Parameters are saved per model name — when you switch models, the saved parameters for that model are loaded automatically.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ as you like, including several for the same vendor: `ollama-local` and
 `ollama-remote` can coexist with different URLs and keys, and switching between
 profiles in the Settings dialog never touches the ones you're not looking at.
 A profile's API key can be left blank to fall back to a vendor-wide default
-key, so one Anthropic key can serve several Anthropic profiles.
+key, so one Anthropic key can serve several Anthropic profiles. Those defaults
+live in the `provider_keys` object in `config.json` and are set by hand — the
+Settings dialog edits a profile's own key, and clearing that field clears it.
 
 Beyond the active profile chat uses, four utility jobs each pick their own
 profile from a dropdown in Settings: context compaction, skill evaluation,
@@ -197,7 +199,7 @@ you load them — there is nothing to do by hand.
 
 ### Model Parameters
 
-The **Model Parameters** table in Settings lets you set arbitrary sampling parameters (temperature, top_p, top_k, etc.) that are sent with each API request. Parameters belong to the profile you are editing, so two profiles never share them — even when they name the same model — and removing a row removes the parameter. The per-model defaults written by earlier versions are still in `config.json` but are no longer read; on upgrade the entry for your current model is copied into your profile once.
+The **Model Parameters** table in Settings lets you set arbitrary sampling parameters (temperature, top_p, top_k, etc.) that are sent with each API request. Parameters belong to the profile you are editing, so two profiles never share them — even when they name the same model — and removing a row removes the parameter. Removing *every* row is different: a profile with no parameters of its own falls back to the provider's recommended defaults, which is what you will see the next time you open Settings. The per-model defaults written by earlier versions are still in `config.json` but are no longer read; on upgrade the entry for your current model is copied into your profile once.
 
 Click **Load Defaults** to reset to the provider's recommended values. For most providers the only default is `temperature: 0.3`. Moonshot ships with pre-configured values required by Kimi-K2.5.
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ you load them — there is nothing to do by hand.
 
 ### Model Parameters
 
-The **Model Parameters** table in Settings lets you set arbitrary sampling parameters (temperature, top_p, top_k, etc.) that are sent with each API request. Parameters are saved per model name — when you switch models, the saved parameters for that model are loaded automatically.
+The **Model Parameters** table in Settings lets you set arbitrary sampling parameters (temperature, top_p, top_k, etc.) that are sent with each API request. Parameters belong to the profile you are editing, so two profiles never share them — changing temperature on one leaves the other alone, and changing a profile's model keeps that profile's parameters. Per-model defaults from earlier versions are kept in `config.json` and still apply for any parameter a profile does not set itself.
 
 Click **Load Defaults** to reset to the provider's recommended values. For most providers the only default is `temperature: 0.3`. Moonshot ships with pre-configured values required by Kimi-K2.5.
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ you load them — there is nothing to do by hand.
 
 ### Model Parameters
 
-The **Model Parameters** table in Settings lets you set arbitrary sampling parameters (temperature, top_p, top_k, etc.) that are sent with each API request. Parameters belong to the profile you are editing, so two profiles never share them — changing temperature on one leaves the other alone, and changing a profile's model keeps that profile's parameters. Per-model defaults from earlier versions are kept in `config.json` and still apply for any parameter a profile does not set itself.
+The **Model Parameters** table in Settings lets you set arbitrary sampling parameters (temperature, top_p, top_k, etc.) that are sent with each API request. Parameters belong to the profile you are editing, so two profiles never share them — even when they name the same model — and removing a row removes the parameter. The per-model defaults written by earlier versions are still in `config.json` but are no longer read; on upgrade the entry for your current model is copied into your profile once.
 
 Click **Load Defaults** to reset to the provider's recommended values. For most providers the only default is `temperature: 0.3`. Moonshot ships with pre-configured values required by Kimi-K2.5.
 

--- a/docs/superpowers/plans/2026-09-06-connection-profiles.md
+++ b/docs/superpowers/plans/2026-09-06-connection-profiles.md
@@ -1,0 +1,1819 @@
+# Connection Profiles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Store LLM connection settings as named profiles so each call site — chat, compaction, skill evaluation, tool optimisation, reranking — can run on its own provider and model.
+
+**Architecture:** `ProviderConfig` gains a `params` field and becomes the profile type. `AppConfig` stores `profiles: {label: ProviderConfig}` plus an `active_profile` label, and exposes `provider` as a **property** returning the active profile. Because every one of the 44 existing `cfg.provider.*` reads and writes means "the active chat connection", that property keeps them all correct with no edit. A single `create_client(cfg, utility=...)` in `llm/client.py` replaces all five `create_client_from_config()` calls and the bespoke reranker builder.
+
+**Tech Stack:** Python 3.11, dataclasses, PySide6 (via `freecad_ai/ui/compat.py`), pytest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-09-06-connection-profiles-design.md`
+
+## Global Constraints
+
+- **No external dependencies.** Standard library only.
+- **Never hard-import PySide2 or PySide6.** Import Qt through `freecad_ai/ui/compat.py`.
+- **Use flat Qt enum forms** (`QLineEdit.Password`, not `QLineEdit.EchoMode.Password`) for PySide2/PySide6 compatibility.
+- **New `AppConfig` defaults must preserve prior-version behavior.** An untouched `config.json` must behave exactly as it did before.
+- **Run tests as** `env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q`. A shell `PYTHONPATH` shadows the venv's pluggy and crashes pytest; `test_document_attach.py` segfaults under Qt on clean master too.
+- **Baseline is 1196 passing.** Any task that reduces this has broken something.
+- **Branch:** `design/connection-profiles`, rebased onto master **after PR #73 merges** (it edits `config.py` and `settings_dialog.py`).
+- Utility identifiers are exactly `"compaction"`, `"skill_eval"`, `"tool_optimize"`, `"rerank"`.
+
+---
+
+## Deviations from the spec
+
+Three findings during planning. Each preserves the spec's user-visible behavior while changing how it is built. **Get maintainer sign-off before executing.**
+
+**1. Profiles store concrete values, not empty-means-default.** The spec had `base_url: str = ""  # empty -> preset default`. Concrete values match how `ProviderConfig` works today, let `cfg.provider` be a live handle on the active profile, and avoid silently re-pointing a user's saved URL when a preset changes upstream — which is the #12/#75 failure mode the whole design exists to end. The API-key fallback to `provider_keys` survives unchanged, because it resolves at client-construction time rather than at read time.
+
+**2. `cfg.provider` becomes a property instead of being deleted.** The spec said the flat fields "are no longer read". There are 44 such sites; every one means the active chat connection. A property serves them all and shrinks the diff from 44 edits to 1. The `provider` key still appears in saved JSON (Task 3) so the spec's downgrade-safety promise holds.
+
+**3. `create_client()` takes per-call-site overrides.** The spec's signature was `create_client(cfg, utility)`. The reranker needs `max_tokens=1024`, `temperature=0.0`, `thinking="off"` — properties of the *job*, not the connection. Keyword overrides carry them.
+
+A fourth item the spec missed entirely, needing **no** work thanks to finding 2: the FreeCAD parameter-store bridge (`config.py:631-674`, the Edit → Preferences mirror) reads and writes `cfg.provider.*`. Through the property it transparently edits the active profile, which is the correct meaning. Task 1 pins this with a test.
+
+---
+
+### Task 1: Profile storage and the active-profile property
+
+**Files:**
+- Modify: `freecad_ai/config.py:373-390` (`ProviderConfig`, `AppConfig` head)
+- Test: `tests/unit/test_profiles.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ProviderConfig.params: dict`; `AppConfig.profiles: dict[str, ProviderConfig]`; `AppConfig.active_profile: str`; `AppConfig.provider_keys: dict[str, str]`; `AppConfig.utility_profiles: dict[str, str]`; `AppConfig.provider` property returning `ProviderConfig`; `AppConfig.__post_init__`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_profiles.py`:
+
+```python
+"""Named connection profiles.
+
+A profile is a ProviderConfig (vendor, url, key, model) plus its own params
+dict. AppConfig holds them in a label-keyed dict; ``cfg.provider`` is a
+property returning the active one, so the 44 existing ``cfg.provider.*``
+sites keep meaning "the active chat connection".
+
+Note the two different names in play: ``profile.name`` is the *vendor*
+(inherited from ProviderConfig, e.g. "ollama"), while a profile's own
+*label* is its key in ``cfg.profiles`` (e.g. "ollama-remote").
+"""
+
+from freecad_ai.config import AppConfig, ProviderConfig
+
+
+class TestDefaultProfile:
+    def test_bare_appconfig_has_exactly_one_profile(self):
+        cfg = AppConfig()
+        assert len(cfg.profiles) == 1
+
+    def test_active_profile_names_that_profile(self):
+        cfg = AppConfig()
+        assert cfg.active_profile in cfg.profiles
+
+    def test_provider_property_returns_the_active_profile(self):
+        cfg = AppConfig()
+        assert cfg.provider is cfg.profiles[cfg.active_profile]
+
+    def test_default_profile_matches_prior_provider_defaults(self):
+        """Prior-version behavior: a fresh config is still Anthropic."""
+        cfg = AppConfig()
+        assert cfg.provider.name == "anthropic"
+        assert cfg.provider.base_url == "https://api.anthropic.com"
+        assert cfg.provider.model == "claude-sonnet-4-6"
+
+    def test_writes_through_the_property_reach_the_profile(self):
+        """The param-store bridge and settings dialog both assign through
+        cfg.provider.*; those writes must land in the stored profile."""
+        cfg = AppConfig()
+        cfg.provider.model = "gemma4:27b"
+        assert cfg.profiles[cfg.active_profile].model == "gemma4:27b"
+
+
+class TestSwitchingActiveProfile:
+    def test_provider_follows_active_profile(self):
+        cfg = AppConfig()
+        cfg.profiles["local"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1", model="qwen3:8b")
+        cfg.active_profile = "local"
+        assert cfg.provider.model == "qwen3:8b"
+
+    def test_editing_one_profile_leaves_the_other_intact(self):
+        """The #75 shape: browsing between connections destroys nothing."""
+        cfg = AppConfig()
+        original = cfg.active_profile
+        cfg.profiles["remote"] = ProviderConfig(
+            name="ollama", base_url="https://gpu.example.net/v1", model="qwen3:32b")
+        cfg.active_profile = "remote"
+        cfg.provider.base_url = "https://gpu.example.net/v1/edited"
+        cfg.active_profile = original
+        cfg.active_profile = "remote"
+        assert cfg.provider.base_url == "https://gpu.example.net/v1/edited"
+        assert cfg.profiles[original].name == "anthropic"
+
+
+class TestProfileParams:
+    def test_params_default_empty(self):
+        assert ProviderConfig().params == {}
+
+    def test_two_profiles_have_independent_params(self):
+        """Retires #30 structurally: there is no shared params namespace."""
+        a = ProviderConfig(model="m", params={"temperature": 0.8})
+        b = ProviderConfig(model="m", params={"temperature": 0.1})
+        assert a.params == {"temperature": 0.8}
+        assert b.params == {"temperature": 0.1}
+
+
+class TestUtilityMapping:
+    def test_utility_profiles_default_empty(self):
+        """Empty means every utility inherits the active profile — the
+        prior-version behavior."""
+        assert AppConfig().utility_profiles == {}
+
+    def test_provider_keys_default_empty(self):
+        assert AppConfig().provider_keys == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profiles.py -q`
+Expected: FAIL — `AttributeError: 'AppConfig' object has no attribute 'profiles'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `freecad_ai/config.py`, add `params` to `ProviderConfig`:
+
+```python
+@dataclass
+class ProviderConfig:
+    """One named connection: vendor, endpoint, credential, model, params.
+
+    ``name`` is the *vendor* key into PROVIDER_PRESETS. A profile's own
+    label is its key in ``AppConfig.profiles``, not a field here.
+    """
+    name: str = "anthropic"
+    api_key: str = ""
+    base_url: str = "https://api.anthropic.com"
+    model: str = "claude-sonnet-4-6"
+    params: dict = field(default_factory=dict)
+
+    def apply_preset(self, provider_name: str):
+        """Apply a provider preset, updating base_url and model to defaults."""
+        preset = PROVIDER_PRESETS.get(provider_name, {})
+        self.name = provider_name
+        self.base_url = preset.get("base_url", self.base_url)
+        self.model = preset.get("default_model", self.model)
+```
+
+Replace the `provider` field on `AppConfig` (line 390) with profile storage. Delete the `provider: ProviderConfig = field(...)` line and put these four fields in its place:
+
+```python
+    profiles: dict = field(default_factory=dict)      # label -> ProviderConfig
+    active_profile: str = ""                          # label chat uses
+    provider_keys: dict = field(default_factory=dict) # vendor -> default api key
+    utility_profiles: dict = field(default_factory=dict)  # utility -> label
+```
+
+Add to `AppConfig`, after the field block:
+
+```python
+    def __post_init__(self):
+        self._ensure_profile()
+
+    def _ensure_profile(self) -> None:
+        """Guarantee at least one profile and a valid active label.
+
+        A config must never leave the dialog unusable, so an empty or
+        dangling ``active_profile`` resolves rather than raising. Cheap
+        and idempotent, so the ``provider`` property can call it on every
+        access and never hand back a KeyError.
+        """
+        if not self.profiles:
+            default = ProviderConfig()
+            self.profiles = {default.name: default}
+            self.active_profile = default.name
+        if self.active_profile not in self.profiles:
+            self.active_profile = next(iter(self.profiles))
+
+    @property
+    def provider(self) -> ProviderConfig:
+        """The active profile.
+
+        Every ``cfg.provider.*`` read and write in the codebase means "the
+        active chat connection", so they all keep working through here.
+        Reads AND writes: the FreeCAD parameter-store bridge assigns to
+        ``cfg.provider.model`` etc., and those land in the stored profile.
+        """
+        self._ensure_profile()
+        return self.profiles[self.active_profile]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profiles.py -q`
+Expected: PASS (13 tests)
+
+- [ ] **Step 5: Pin the parameter-store bridge**
+
+The bridge is the reason the property must be writable. Append to `tests/unit/test_profiles.py`:
+
+```python
+class TestParamStoreBridgeWritesReachTheProfile:
+    def test_apply_overrides_pattern_edits_active_profile(self):
+        """_apply_param_store_overrides assigns cfg.provider.model /
+        .base_url / .api_key / .name. Simulate those assignments and
+        assert they land in the active profile rather than a temporary."""
+        cfg = AppConfig()
+        cfg.provider.name = "ollama"
+        cfg.provider.model = "qwen3:8b"
+        cfg.provider.base_url = "http://localhost:11434/v1"
+        cfg.provider.api_key = "sk-test"
+        stored = cfg.profiles[cfg.active_profile]
+        assert (stored.name, stored.model, stored.base_url, stored.api_key) == (
+            "ollama", "qwen3:8b", "http://localhost:11434/v1", "sk-test")
+```
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profiles.py -q`
+Expected: PASS (14 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add freecad_ai/config.py tests/unit/test_profiles.py
+git commit -m "feat(config): store connections as named profiles
+
+ProviderConfig gains a params dict and becomes the profile type.
+AppConfig holds profiles by label with an active_profile pointer;
+cfg.provider is now a property onto the active one, so existing
+cfg.provider.* readers and writers are unchanged."
+```
+
+---
+
+### Task 2: Migrate old-shape configs on load
+
+**Files:**
+- Modify: `freecad_ai/config.py:531-538` (`AppConfig.from_dict`)
+- Test: `tests/unit/test_profiles_migration.py` (create)
+
+**Interfaces:**
+- Consumes: `AppConfig.profiles`, `AppConfig.active_profile`, `AppConfig.provider_keys`, `AppConfig.utility_profiles`, `ProviderConfig.params` from Task 1.
+- Produces: `AppConfig.from_dict(data: dict) -> AppConfig` handling both shapes.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_profiles_migration.py`:
+
+```python
+"""Old-shape config.json files load into profiles without behavior change.
+
+Migration is where the risk concentrates: a wrong call here silently
+mangles a config a user has been running for months.
+"""
+
+from freecad_ai.config import AppConfig, ProviderConfig
+
+
+def _old_shape(**extra):
+    """A config.json as written by v0.23.1-alpha and earlier."""
+    data = {
+        "provider": {
+            "name": "ollama",
+            "api_key": "sk-main",
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen3:32b",
+        },
+        "model_params": {"qwen3:32b": {"temperature": 0.8, "top_p": 0.9}},
+        "max_tokens": 8192,
+    }
+    data.update(extra)
+    return data
+
+
+class TestPlainMigration:
+    def test_creates_one_profile_labelled_by_vendor(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert list(cfg.profiles) == ["ollama"]
+
+    def test_that_profile_is_active(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.active_profile == "ollama"
+
+    def test_connection_fields_survive(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.provider.name == "ollama"
+        assert cfg.provider.api_key == "sk-main"
+        assert cfg.provider.base_url == "http://localhost:11434/v1"
+        assert cfg.provider.model == "qwen3:32b"
+
+    def test_model_params_seed_the_profile_params(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.provider.params == {"temperature": 0.8, "top_p": 0.9}
+
+    def test_model_params_dict_is_left_intact(self):
+        """profile.params layers ON TOP of model_params; it does not
+        replace it, and other models' entries must not be disturbed."""
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.model_params == {"qwen3:32b": {"temperature": 0.8, "top_p": 0.9}}
+
+    def test_api_key_also_seeds_the_provider_default(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.provider_keys["ollama"] == "sk-main"
+
+    def test_no_utility_overrides_without_a_rerank_model(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.utility_profiles == {}
+
+    def test_unrelated_fields_still_load(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.max_tokens == 8192
+
+
+class TestRerankOverrideMigration:
+    def _cfg(self):
+        return AppConfig.from_dict(_old_shape(
+            rerank_llm_provider_name="",
+            rerank_llm_base_url="",
+            rerank_llm_api_key="",
+            rerank_llm_model="gemma3:4b",
+            rerank_params={"temperature": 0.1, "top_k": 20},
+        ))
+
+    def test_creates_a_second_profile(self):
+        assert set(self._cfg().profiles) == {"ollama", "rerank"}
+
+    def test_rerank_utility_points_at_it(self):
+        assert self._cfg().utility_profiles == {"rerank": "rerank"}
+
+    def test_empty_override_fields_inherit_from_the_main_profile(self):
+        """The old builder used `or` fallbacks per field; an empty
+        provider/url/key meant "same as main". Migration must bake that in."""
+        rr = self._cfg().profiles["rerank"]
+        assert rr.name == "ollama"
+        assert rr.base_url == "http://localhost:11434/v1"
+        assert rr.api_key == "sk-main"
+
+    def test_override_model_is_kept(self):
+        assert self._cfg().profiles["rerank"].model == "gemma3:4b"
+
+    def test_rerank_params_become_the_profile_params(self):
+        assert self._cfg().profiles["rerank"].params == {
+            "temperature": 0.1, "top_k": 20}
+
+    def test_full_override_keeps_its_own_vendor(self):
+        cfg = AppConfig.from_dict(_old_shape(
+            rerank_llm_provider_name="openai",
+            rerank_llm_base_url="https://api.openai.com/v1",
+            rerank_llm_api_key="sk-rr",
+            rerank_llm_model="gpt-4o-mini",
+        ))
+        rr = cfg.profiles["rerank"]
+        assert (rr.name, rr.base_url, rr.api_key) == (
+            "openai", "https://api.openai.com/v1", "sk-rr")
+
+
+class TestEdgeCases:
+    def test_new_shape_config_is_left_alone(self):
+        """Idempotence: loading an already-migrated config must not
+        re-migrate it from the stale legacy mirror."""
+        cfg = AppConfig.from_dict({
+            "profiles": {
+                "cloud": {"name": "anthropic", "api_key": "sk-a",
+                          "base_url": "https://api.anthropic.com",
+                          "model": "claude-sonnet-4-6", "params": {}},
+                "local": {"name": "ollama", "api_key": "",
+                          "base_url": "http://localhost:11434/v1",
+                          "model": "qwen3:8b", "params": {"top_k": 40}},
+            },
+            "active_profile": "local",
+            "utility_profiles": {"compaction": "local"},
+            "provider": {"name": "stale", "api_key": "", "base_url": "",
+                         "model": "stale-model"},
+        })
+        assert set(cfg.profiles) == {"cloud", "local"}
+        assert cfg.active_profile == "local"
+        assert cfg.provider.model == "qwen3:8b"
+        assert cfg.utility_profiles == {"compaction": "local"}
+
+    def test_custom_provider_with_empty_preset_fields_migrates(self):
+        cfg = AppConfig.from_dict({
+            "provider": {"name": "custom", "api_key": "k",
+                         "base_url": "https://gw.example.net/v1",
+                         "model": "my-model"},
+        })
+        assert cfg.active_profile == "custom"
+        assert cfg.provider.base_url == "https://gw.example.net/v1"
+
+    def test_empty_dict_yields_a_usable_default(self):
+        cfg = AppConfig.from_dict({})
+        assert len(cfg.profiles) == 1
+        assert cfg.provider.name == "anthropic"
+
+    def test_unknown_keys_are_still_ignored(self):
+        cfg = AppConfig.from_dict(_old_shape(nonsense_key=1))
+        assert not hasattr(cfg, "nonsense_key")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profiles_migration.py -q`
+Expected: FAIL — `KeyError: 'ollama'` / `assert [] == ['ollama']`; `from_dict` still builds a `provider` object that no longer has a field to land in.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `AppConfig.from_dict` in `freecad_ai/config.py`:
+
+```python
+    @classmethod
+    def from_dict(cls, data: dict) -> "AppConfig":
+        data = dict(data)  # never mutate the caller's parsed JSON
+        legacy_provider = data.pop("provider", None)
+
+        raw_profiles = data.pop("profiles", None)
+        profiles = {
+            label: ProviderConfig(**p)
+            for label, p in (raw_profiles or {}).items()
+        }
+
+        known = {f.name for f in cls.__dataclass_fields__.values()} - {"profiles"}
+        filtered = {k: v for k, v in data.items() if k in known}
+        cfg = cls(profiles=profiles, **filtered)
+
+        if not raw_profiles:
+            cls._migrate_flat_provider(cfg, legacy_provider or {}, data)
+        return cfg
+
+    @staticmethod
+    def _migrate_flat_provider(cfg: "AppConfig", legacy: dict, data: dict) -> None:
+        """Turn a pre-profiles config into one or two profiles.
+
+        Only runs when the JSON carries no ``profiles`` key, so it is a
+        one-time upgrade rather than something that fights an already
+        migrated file on every load.
+        """
+        main = ProviderConfig(**{
+            k: v for k, v in legacy.items()
+            if k in {"name", "api_key", "base_url", "model"}
+        })
+        main.params = dict(cfg.model_params.get(main.model, {}))
+        cfg.profiles = {main.name: main}
+        cfg.active_profile = main.name
+        if main.api_key:
+            cfg.provider_keys[main.name] = main.api_key
+
+        # The old reranker override inherited each empty field from the
+        # main provider (chat_widget._build_rerank_llm_client). Bake those
+        # `or` fallbacks into a standalone profile.
+        if data.get("rerank_llm_model"):
+            cfg.profiles["rerank"] = ProviderConfig(
+                name=data.get("rerank_llm_provider_name") or main.name,
+                base_url=data.get("rerank_llm_base_url") or main.base_url,
+                api_key=data.get("rerank_llm_api_key") or main.api_key,
+                model=data["rerank_llm_model"],
+                params=dict(data.get("rerank_params") or {}),
+            )
+            cfg.utility_profiles["rerank"] = "rerank"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profiles_migration.py tests/unit/test_profiles.py -q`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add freecad_ai/config.py tests/unit/test_profiles_migration.py
+git commit -m "feat(config): migrate flat provider config into profiles
+
+One-time upgrade, keyed off the absence of a profiles key. The old
+reranker override becomes a 'rerank' profile with its per-field
+inherit-from-main fallbacks resolved."
+```
+
+---
+
+### Task 3: Keep writing the legacy keys for one release
+
+**Files:**
+- Modify: `freecad_ai/config.py:528-529` (`AppConfig.to_dict`)
+- Test: `tests/unit/test_profiles_migration.py` (append)
+
+**Interfaces:**
+- Consumes: `AppConfig.provider` property (Task 1), `AppConfig.from_dict` (Task 2).
+- Produces: `AppConfig.to_dict() -> dict` emitting both shapes.
+
+`provider` is now a property, so `asdict()` no longer emits it — a save would drop the legacy key immediately. The spec promises it survives one release so a user who downgrades gets their settings back. This task restores that.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_profiles_migration.py`:
+
+```python
+from dataclasses import asdict  # noqa: E402
+
+
+class TestLegacyMirrorOnSave:
+    def test_save_still_emits_a_provider_key(self):
+        """Downgrade safety: an older version reads `provider` and finds
+        the user's live connection, not an empty dialog."""
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.to_dict()["provider"]["model"] == "qwen3:32b"
+
+    def test_mirror_tracks_the_active_profile(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        cfg.profiles["cloud"] = ProviderConfig(
+            name="anthropic", model="claude-sonnet-4-6")
+        cfg.active_profile = "cloud"
+        assert cfg.to_dict()["provider"]["name"] == "anthropic"
+
+    def test_profiles_are_serialised(self):
+        d = AppConfig.from_dict(_old_shape()).to_dict()
+        assert d["profiles"]["ollama"]["model"] == "qwen3:32b"
+        assert d["active_profile"] == "ollama"
+
+    def test_round_trip_is_stable(self):
+        first = AppConfig.from_dict(_old_shape())
+        second = AppConfig.from_dict(first.to_dict())
+        assert second.active_profile == first.active_profile
+        assert second.provider.model == first.provider.model
+        assert second.provider.params == first.provider.params
+
+    def test_round_trip_preserves_a_rerank_override(self):
+        first = AppConfig.from_dict(_old_shape(
+            rerank_llm_model="gemma3:4b",
+            rerank_params={"temperature": 0.1},
+        ))
+        second = AppConfig.from_dict(first.to_dict())
+        assert second.utility_profiles == {"rerank": "rerank"}
+        assert second.profiles["rerank"].model == "gemma3:4b"
+        assert second.profiles["rerank"].params == {"temperature": 0.1}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profiles_migration.py -k Legacy -q`
+Expected: FAIL — `KeyError: 'provider'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `AppConfig.to_dict` in `freecad_ai/config.py`:
+
+```python
+    def to_dict(self) -> dict:
+        """Serialise, including a legacy ``provider`` mirror.
+
+        ``provider`` is a property now, so asdict() skips it. We write it
+        anyway for one release: a user who installs this version and then
+        downgrades gets their connection back instead of a blank dialog.
+        Drop this mirror — and the rerank_llm_*/rerank_params fields —
+        one release after profiles ship.
+        """
+        data = asdict(self)
+        data["provider"] = {
+            "name": self.provider.name,
+            "api_key": self.provider.api_key,
+            "base_url": self.provider.base_url,
+            "model": self.provider.model,
+        }
+        return data
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profiles_migration.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Run the whole suite — this is the first point the change is visible everywhere**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q`
+Expected: PASS. `test_config.py` and `test_api_key_resolution.py` exercise `cfg.provider` heavily and are the likely first casualties — if they fail, the property or the migration is wrong, not the tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add freecad_ai/config.py tests/unit/test_profiles_migration.py
+git commit -m "feat(config): keep writing the legacy provider key on save
+
+provider is a property now so asdict() skips it; write it explicitly
+for one release so a downgrade recovers the user's connection."
+```
+
+---
+
+### Task 4: The `create_client` resolver
+
+**Files:**
+- Modify: `freecad_ai/llm/client.py:898-911` (`create_client_from_config`)
+- Test: `tests/unit/test_create_client.py` (create)
+
+**Interfaces:**
+- Consumes: `AppConfig.profiles`, `.active_profile`, `.provider_keys`, `.utility_profiles`, `.model_params`, `ProviderConfig.params`.
+- Produces: `create_client(cfg=None, utility=None, *, max_tokens=None, temperature=None, thinking=None) -> LLMClient` and `resolve_profile(cfg, utility=None) -> ProviderConfig`. `create_client_from_config()` stays as a zero-argument alias.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_create_client.py`:
+
+```python
+"""One resolver builds every LLM client.
+
+Each call site names a utility; an unmapped utility inherits the active
+profile, which is what every call site did before profiles existed.
+"""
+
+import pytest
+
+from freecad_ai.config import AppConfig, ProviderConfig
+from freecad_ai.llm.client import create_client, resolve_profile
+
+
+def _cfg():
+    cfg = AppConfig()
+    cfg.profiles = {
+        "cloud": ProviderConfig(name="anthropic", api_key="sk-cloud",
+                                base_url="https://api.anthropic.com",
+                                model="claude-sonnet-4-6"),
+        "local": ProviderConfig(name="ollama", api_key="",
+                                base_url="http://localhost:11434/v1",
+                                model="qwen3:8b", params={"top_k": 40}),
+    }
+    cfg.active_profile = "cloud"
+    return cfg
+
+
+class TestUtilityRouting:
+    def test_no_utility_uses_the_active_profile(self):
+        assert create_client(_cfg()).model == "claude-sonnet-4-6"
+
+    def test_unmapped_utility_inherits_the_active_profile(self):
+        assert create_client(_cfg(), "compaction").model == "claude-sonnet-4-6"
+
+    def test_mapped_utility_uses_its_own_profile(self):
+        cfg = _cfg()
+        cfg.utility_profiles["compaction"] = "local"
+        client = create_client(cfg, "compaction")
+        assert client.model == "qwen3:8b"
+        assert client.base_url == "http://localhost:11434/v1"
+
+    def test_one_utility_override_does_not_move_the_others(self):
+        cfg = _cfg()
+        cfg.utility_profiles["compaction"] = "local"
+        assert create_client(cfg, "rerank").model == "claude-sonnet-4-6"
+
+    def test_empty_mapping_means_inherit(self):
+        cfg = _cfg()
+        cfg.utility_profiles["rerank"] = ""
+        assert create_client(cfg, "rerank").model == "claude-sonnet-4-6"
+
+    def test_dangling_profile_name_falls_back_to_active(self):
+        """Never leave the user unable to chat because a profile was
+        deleted while a utility still pointed at it."""
+        cfg = _cfg()
+        cfg.utility_profiles["rerank"] = "deleted-profile"
+        assert create_client(cfg, "rerank").model == "claude-sonnet-4-6"
+
+    def test_same_provider_different_model_is_expressible(self):
+        """The original request: cheap model for compaction, same vendor."""
+        cfg = _cfg()
+        cfg.profiles["cheap"] = ProviderConfig(
+            name="anthropic", api_key="sk-cloud",
+            base_url="https://api.anthropic.com", model="claude-haiku-4-5")
+        cfg.utility_profiles["compaction"] = "cheap"
+        chat = create_client(cfg)
+        compact = create_client(cfg, "compaction")
+        assert chat.provider_name == compact.provider_name == "anthropic"
+        assert chat.model == "claude-sonnet-4-6"
+        assert compact.model == "claude-haiku-4-5"
+
+
+class TestApiKeyFallback:
+    def test_profile_key_wins(self):
+        cfg = _cfg()
+        cfg.provider_keys["anthropic"] = "sk-vendor"
+        assert create_client(cfg).api_key == "sk-cloud"
+
+    def test_empty_profile_key_falls_through_to_the_vendor_default(self):
+        cfg = _cfg()
+        cfg.active_profile = "local"
+        cfg.provider_keys["ollama"] = "sk-gateway"
+        assert create_client(cfg).api_key == "sk-gateway"
+
+    def test_both_empty_yields_empty(self):
+        cfg = _cfg()
+        cfg.active_profile = "local"
+        assert create_client(cfg).api_key == ""
+
+    def test_two_profiles_on_one_vendor_can_hold_different_keys(self):
+        """Why keys live in the profile: ollama-local needs none while
+        ollama-remote sits behind an authenticating gateway."""
+        cfg = _cfg()
+        cfg.profiles["remote"] = ProviderConfig(
+            name="ollama", api_key="sk-remote",
+            base_url="https://gpu.example.net/v1", model="qwen3:32b")
+        cfg.active_profile = "local"
+        assert create_client(cfg).api_key == ""
+        cfg.active_profile = "remote"
+        assert create_client(cfg).api_key == "sk-remote"
+
+
+class TestParamLayering:
+    def test_model_params_apply(self):
+        cfg = _cfg()
+        cfg.model_params = {"claude-sonnet-4-6": {"temperature": 0.7}}
+        assert create_client(cfg).model_params["temperature"] == 0.7
+
+    def test_profile_params_override_model_params(self):
+        cfg = _cfg()
+        cfg.model_params = {"qwen3:8b": {"top_k": 10, "top_p": 0.9}}
+        cfg.active_profile = "local"
+        params = create_client(cfg).model_params
+        assert params["top_k"] == 40      # profile wins
+        assert params["top_p"] == 0.9     # model_params still contributes
+
+    def test_one_profile_params_never_leak_into_another(self):
+        """Issue #30, now structural."""
+        cfg = _cfg()
+        cfg.utility_profiles["rerank"] = "local"
+        assert create_client(cfg, "rerank").model_params["top_k"] == 40
+        assert "top_k" not in create_client(cfg).model_params
+
+
+class TestCallSiteOverrides:
+    def test_defaults_come_from_config(self):
+        cfg = _cfg()
+        cfg.max_tokens = 8192
+        cfg.temperature = 0.3
+        client = create_client(cfg)
+        assert client.max_tokens == 8192
+        assert client.temperature == 0.3
+
+    def test_overrides_win(self):
+        """Job properties, not connection properties: the reranker wants
+        1024 tokens and no thinking regardless of which profile it uses."""
+        cfg = _cfg()
+        cfg.max_tokens = 8192
+        cfg.thinking = "extended"
+        client = create_client(cfg, "rerank", max_tokens=1024,
+                               temperature=0.0, thinking="off")
+        assert client.max_tokens == 1024
+        assert client.temperature == 0.0
+        assert client.thinking == "off"
+
+
+class TestResolveProfile:
+    def test_returns_the_profile_object_itself(self):
+        cfg = _cfg()
+        assert resolve_profile(cfg) is cfg.profiles["cloud"]
+
+    def test_named_utility_resolves_to_its_profile(self):
+        cfg = _cfg()
+        cfg.utility_profiles["skill_eval"] = "local"
+        assert resolve_profile(cfg, "skill_eval") is cfg.profiles["local"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_create_client.py -q`
+Expected: FAIL — `ImportError: cannot import name 'create_client' from 'freecad_ai.llm.client'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `create_client_from_config` in `freecad_ai/llm/client.py`:
+
+```python
+def resolve_profile(cfg, utility: str | None = None):
+    """Return the ProviderConfig a call site should use.
+
+    ``utility`` is a call-site identifier ("compaction", "skill_eval",
+    "tool_optimize", "rerank"). None, unmapped, empty, or naming a profile
+    that no longer exists all mean "inherit the active profile" — a
+    deleted profile must never make the workbench unusable.
+    """
+    if utility:
+        label = cfg.utility_profiles.get(utility, "")
+        if label and label in cfg.profiles:
+            return cfg.profiles[label]
+    return cfg.provider
+
+
+def create_client(cfg=None, utility: str | None = None, *,
+                  max_tokens: int | None = None,
+                  temperature: float | None = None,
+                  thinking: str | None = None) -> LLMClient:
+    """Build an LLMClient for one call site.
+
+    Connection settings (vendor, url, key, model, params) come from the
+    resolved profile. Job settings (max_tokens, temperature, thinking)
+    come from the config unless the call site overrides them — the
+    reranker wants 1024 tokens and no thinking whichever profile it runs
+    on.
+
+    An empty ``api_key`` on the profile falls back to the vendor-wide
+    default in ``cfg.provider_keys``, so one Anthropic secret serves every
+    Anthropic profile while a gateway-authenticated Ollama profile can
+    still carry its own.
+    """
+    from ..config import get_config
+    if cfg is None:
+        cfg = get_config()
+    profile = resolve_profile(cfg, utility)
+
+    params = dict(cfg.model_params.get(profile.model, {}))
+    params.update(profile.params)
+
+    return LLMClient(
+        provider_name=profile.name,
+        base_url=profile.base_url,
+        api_key=profile.api_key or cfg.provider_keys.get(profile.name, ""),
+        model=profile.model,
+        max_tokens=cfg.max_tokens if max_tokens is None else max_tokens,
+        temperature=cfg.temperature if temperature is None else temperature,
+        thinking=cfg.thinking if thinking is None else thinking,
+        model_params=params,
+    )
+
+
+def create_client_from_config() -> LLMClient:
+    """Chat client from the active profile. Kept for third-party hooks."""
+    return create_client()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_create_client.py -q`
+Expected: PASS (21 tests)
+
+- [ ] **Step 5: Confirm nothing else regressed**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add freecad_ai/llm/client.py tests/unit/test_create_client.py
+git commit -m "feat(llm): add create_client(cfg, utility) resolver
+
+One resolver for every call site. Connection settings come from the
+resolved profile, job settings (max_tokens/temperature/thinking) from
+config unless the call site overrides them."
+```
+
+---
+
+### Task 5: Route compaction, skill evaluation and tool optimisation
+
+**Files:**
+- Modify: `freecad_ai/ui/chat_widget.py:528-529` (compaction worker)
+- Modify: `freecad_ai/extensions/skill_evaluator.py:218-226`
+- Modify: `freecad_ai/tools/optimize_tools.py:159-161`
+- Test: `tests/unit/test_utility_call_sites.py` (create)
+
+**Interfaces:**
+- Consumes: `create_client(cfg, utility, ...)` from Task 4.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_utility_call_sites.py`:
+
+```python
+"""Each utility call site asks for its own identifier.
+
+Testing intent rather than plumbing: patch create_client, run the call
+site, assert which utility name it requested. Without this, a call site
+silently keeps using the chat model and nobody notices.
+"""
+
+import pytest
+
+# settings_dialog/chat_widget import through ui/compat.py, which needs Qt.
+try:
+    import PySide6  # noqa: F401
+except ImportError:
+    try:
+        import PySide2  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+
+class TestCompaction:
+    def test_requests_the_compaction_utility(self):
+        from freecad_ai.ui.chat_widget import _CompactionWorker
+        worker = _CompactionWorker("some conversation text")
+        fake = MagicMock()
+        fake.send.return_value = "summary"
+        with patch("freecad_ai.llm.client.create_client",
+                   return_value=fake) as mk:
+            worker.run()
+        assert mk.call_args.args[1:] == ("compaction",) or \
+            mk.call_args.kwargs.get("utility") == "compaction"
+
+
+class TestToolOptimizer:
+    def test_requests_the_tool_optimize_utility(self):
+        from freecad_ai.tools.optimize_tools import _ask_llm_for_modification
+        fake = MagicMock()
+        fake.send.return_value = "```skill\ncontent\n```"
+        with patch("freecad_ai.llm.client.create_client",
+                   return_value=fake) as mk:
+            _ask_llm_for_modification("skill", 1, 0.5, "results", "strategy")
+        assert mk.call_args.args[1:] == ("tool_optimize",) or \
+            mk.call_args.kwargs.get("utility") == "tool_optimize"
+```
+
+Skill evaluation is covered by inspection rather than a unit test — `SkillEvaluator.run` needs a tool registry and a live document. Verify by reading the diff.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_utility_call_sites.py -q`
+Expected: FAIL — `AttributeError: <module 'freecad_ai.llm.client'> does not have the attribute 'create_client'` is already fixed by Task 4, so instead: the assertion fails because the call sites still call `create_client_from_config`, and the patch is never hit (`mk.call_args is None`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `freecad_ai/ui/chat_widget.py`, `_CompactionWorker.run`:
+
+```python
+            from ..llm.client import create_client
+            client = create_client(utility="compaction")
+```
+
+In `freecad_ai/tools/optimize_tools.py`, `_ask_llm_for_modification`:
+
+```python
+    from ..llm.client import create_client
+
+    client = create_client(utility="tool_optimize")
+```
+
+In `freecad_ai/extensions/skill_evaluator.py`, `SkillEvaluator.run`:
+
+```python
+        from ..llm.client import create_client
+```
+and
+```python
+        client = create_client(cfg, "skill_eval")
+```
+
+Leave `api_style = get_api_style(cfg.provider.name)` on line 224 as it is — the tool schema style follows the chat provider, which is what builds the conversation.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_utility_call_sites.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add freecad_ai/ui/chat_widget.py freecad_ai/extensions/skill_evaluator.py \
+        freecad_ai/tools/optimize_tools.py tests/unit/test_utility_call_sites.py
+git commit -m "feat: route compaction, skill eval and tool optimisation by utility
+
+Each now names its own profile slot instead of being locked to the
+chat model."
+```
+
+---
+
+### Task 6: Retire the bespoke reranker builder
+
+**Files:**
+- Modify: `freecad_ai/ui/chat_widget.py:95-135` (delete `_build_rerank_llm_client`), `:156`
+- Modify: `tests/unit/test_reranker_namespace.py`
+- Test: `tests/unit/test_create_client.py` (append)
+
+**Interfaces:**
+- Consumes: `create_client(cfg, "rerank", max_tokens=..., temperature=..., thinking=...)`.
+- Produces: `_build_rerank_llm_client` no longer exists.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_create_client.py`:
+
+```python
+class TestRerankerJobSettings:
+    def test_reranker_settings_survive_the_move(self):
+        """The old builder pinned max_tokens=1024, thinking off, and
+        temperature from params defaulting to 0.0. Reranking is a
+        classification job; those must not drift to the chat values."""
+        cfg = _cfg()
+        cfg.max_tokens = 8192
+        cfg.thinking = "extended"
+        cfg.utility_profiles["rerank"] = "local"
+        cfg.profiles["local"].params = {"temperature": 0.1, "top_k": 20}
+        params = dict(cfg.model_params.get("qwen3:8b", {}))
+        params.update(cfg.profiles["local"].params)
+        client = create_client(cfg, "rerank", max_tokens=1024,
+                               temperature=params.get("temperature", 0.0),
+                               thinking="off")
+        assert client.max_tokens == 1024
+        assert client.thinking == "off"
+        assert client.temperature == 0.1
+        assert client.model_params == {"temperature": 0.1, "top_k": 20}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_create_client.py -k Reranker -q`
+Expected: PASS already — this test exercises Task 4's resolver and is a characterisation test protecting the reranker's job settings through the refactor. That is intentional; the *failing* test for this task is the rewritten `test_reranker_namespace.py` in Step 3.
+
+- [ ] **Step 3: Rewrite the reranker namespace test against the new API**
+
+Replace the body of `tests/unit/test_reranker_namespace.py` below its imports. Update the module docstring's closing paragraph to:
+
+```python
+"""...
+Profiles retire this class of bug structurally: params are a field of a
+profile, so there is no shared namespace for the reranker to reach into.
+These tests now pin that the reranker reads its own profile's params and
+that an inheriting reranker gets the active profile's.
+"""
+```
+
+Replace the import and tests:
+
+```python
+from freecad_ai.config import AppConfig, ProviderConfig  # noqa: E402
+from freecad_ai.llm.client import create_client  # noqa: E402
+
+
+def _cfg_with_params():
+    cfg = AppConfig()
+    cfg.profiles = {
+        "main": ProviderConfig(name="ollama",
+                               base_url="http://localhost:11434/v1",
+                               model="main-model",
+                               params={"temperature": 0.8, "top_p": 0.9}),
+    }
+    cfg.active_profile = "main"
+    return cfg
+
+
+class TestRerankProfileParams:
+    def test_override_uses_its_own_profile_params(self):
+        cfg = _cfg_with_params()
+        cfg.profiles["rr"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1",
+            model="rr-model", params={"temperature": 0.1, "top_k": 20})
+        cfg.utility_profiles["rerank"] = "rr"
+        client = create_client(cfg, "rerank")
+        assert client.model == "rr-model"
+        assert client.model_params == {"temperature": 0.1, "top_k": 20}
+
+    def test_inherit_uses_the_active_profile(self):
+        cfg = _cfg_with_params()
+        client = create_client(cfg, "rerank")
+        assert client.model == "main-model"
+        assert client.model_params == {"temperature": 0.8, "top_p": 0.9}
+
+    def test_reranker_params_cannot_reach_the_main_profile(self):
+        """The #30 regression, now impossible by construction."""
+        cfg = _cfg_with_params()
+        cfg.profiles["rr"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1",
+            model="main-model", params={"temperature": 0.1})
+        cfg.utility_profiles["rerank"] = "rr"
+        create_client(cfg, "rerank")
+        assert cfg.profiles["main"].params == {"temperature": 0.8, "top_p": 0.9}
+```
+
+Delete the `TestBuildRerankClientReadPath` and `SettingsDialog._resolve_rerank_params` classes — both test code this task removes.
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_reranker_namespace.py -q`
+Expected: FAIL — `ImportError: cannot import name '_build_rerank_llm_client'` is gone, but `create_client(cfg, "rerank")` still returns the chat model because nothing routes it yet. Confirm the failure is the assertion, not the import.
+
+- [ ] **Step 5: Write minimal implementation**
+
+Delete `_build_rerank_llm_client` (`freecad_ai/ui/chat_widget.py:95-135`) entirely. At line 156, replace:
+
+```python
+            client = _build_rerank_llm_client(cfg)
+```
+
+with:
+
+```python
+            from ..llm.client import create_client, resolve_profile
+            # Reranking is a classification job: short output, no thinking,
+            # deterministic unless the profile itself sets a temperature.
+            # Those are call-site properties and stay fixed whichever
+            # profile the user points the reranker at.
+            profile = resolve_profile(cfg, "rerank")
+            params = dict(cfg.model_params.get(profile.model, {}))
+            params.update(profile.params)
+            client = create_client(
+                cfg, "rerank", max_tokens=1024, thinking="off",
+                temperature=params.get("temperature", 0.0))
+```
+
+
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_reranker_namespace.py tests/unit/test_create_client.py -q`
+Expected: PASS
+
+- [ ] **Step 7: Full suite**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add freecad_ai/ui/chat_widget.py tests/unit/test_reranker_namespace.py \
+        tests/unit/test_create_client.py
+git commit -m "refactor(rerank): use the profile resolver, drop the bespoke builder
+
+The reranker's four-field override becomes a profile like any other.
+Its job settings (1024 tokens, no thinking) stay at the call site."
+```
+
+---
+
+### Task 7: Profile selector in the Settings dialog
+
+**Files:**
+- Modify: `freecad_ai/ui/settings_dialog.py` — provider page layout, `_load_from_config` (:873-895), `_on_provider_changed` (:974)
+- Test: `tests/unit/test_profile_selector.py` (create)
+
+**Interfaces:**
+- Consumes: `AppConfig.profiles`, `.active_profile`, `.utility_profiles` (Task 1).
+- Produces: `SettingsDialog._rename_profile(old: str, new: str) -> None`, `SettingsDialog._delete_profile(label: str) -> None`, `SettingsDialog._commit_profile_fields() -> None`, `self.profile_combo`.
+
+Rename and delete carry the logic worth testing, so they go in plain methods that take arguments and touch `self._cfg` — not in signal handlers that read widgets. That is the same extraction pattern the input-history work used, and it is what makes these testable without a running dialog.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_profile_selector.py`:
+
+```python
+"""Profile management: rename cascades, delete never orphans.
+
+These call the dialog's methods with a fake self carrying only the
+attributes they touch, so no Qt dialog has to be constructed.
+"""
+
+import pytest
+
+# settings_dialog/chat_widget import through ui/compat.py, which needs Qt.
+try:
+    import PySide6  # noqa: F401
+except ImportError:
+    try:
+        import PySide2  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from freecad_ai.config import AppConfig, ProviderConfig  # noqa: E402
+from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
+
+
+class _FakeSelf:
+    def __init__(self, cfg):
+        self._cfg = cfg
+
+
+def _cfg():
+    cfg = AppConfig()
+    cfg.profiles = {
+        "cloud": ProviderConfig(name="anthropic", model="claude-sonnet-4-6"),
+        "local": ProviderConfig(name="ollama", model="qwen3:8b",
+                                base_url="http://localhost:11434/v1"),
+    }
+    cfg.active_profile = "cloud"
+    return cfg
+
+
+class TestRenameCascade:
+    def test_profile_is_renamed(self):
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "ollama-local")
+        assert set(cfg.profiles) == {"cloud", "ollama-local"}
+
+    def test_settings_travel_with_the_name(self):
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "ollama-local")
+        assert cfg.profiles["ollama-local"].model == "qwen3:8b"
+
+    def test_active_profile_follows(self):
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "cloud", "anthropic-main")
+        assert cfg.active_profile == "anthropic-main"
+
+    def test_utility_mappings_follow(self):
+        """A rename must never silently detach a utility from the profile
+        it was using."""
+        cfg = _cfg()
+        cfg.utility_profiles = {"compaction": "local", "rerank": "local"}
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "cheap")
+        assert cfg.utility_profiles == {"compaction": "cheap", "rerank": "cheap"}
+
+    def test_unrelated_mappings_are_untouched(self):
+        cfg = _cfg()
+        cfg.utility_profiles = {"compaction": "cloud", "rerank": "local"}
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "cheap")
+        assert cfg.utility_profiles["compaction"] == "cloud"
+
+    def test_ordering_is_preserved(self):
+        """Rebuilding the dict must not reshuffle the combo on the user."""
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "cloud", "zzz")
+        assert list(cfg.profiles) == ["zzz", "local"]
+
+    def test_collision_is_refused(self):
+        cfg = _cfg()
+        with pytest.raises(ValueError):
+            SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "cloud")
+
+    def test_empty_name_is_refused(self):
+        cfg = _cfg()
+        with pytest.raises(ValueError):
+            SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "  ")
+
+    def test_renaming_to_itself_is_a_no_op(self):
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "local")
+        assert set(cfg.profiles) == {"cloud", "local"}
+
+
+class TestDelete:
+    def test_profile_is_removed(self):
+        cfg = _cfg()
+        SettingsDialog._delete_profile(_FakeSelf(cfg), "local")
+        assert set(cfg.profiles) == {"cloud"}
+
+    def test_deleting_the_last_profile_is_refused(self):
+        cfg = _cfg()
+        del cfg.profiles["local"]
+        with pytest.raises(ValueError):
+            SettingsDialog._delete_profile(_FakeSelf(cfg), "cloud")
+
+    def test_deleting_the_active_profile_moves_the_pointer(self):
+        cfg = _cfg()
+        SettingsDialog._delete_profile(_FakeSelf(cfg), "cloud")
+        assert cfg.active_profile == "local"
+
+    def test_utilities_pointing_at_it_fall_back_to_inherit(self):
+        """Leaving a dangling name would work — the resolver tolerates it —
+        but clearing it keeps the dialog honest about what is configured."""
+        cfg = _cfg()
+        cfg.utility_profiles = {"compaction": "local"}
+        SettingsDialog._delete_profile(_FakeSelf(cfg), "local")
+        assert cfg.utility_profiles.get("compaction", "") == ""
+
+    def test_deleting_an_unknown_profile_is_refused(self):
+        cfg = _cfg()
+        with pytest.raises(ValueError):
+            SettingsDialog._delete_profile(_FakeSelf(cfg), "nope")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profile_selector.py -q`
+Expected: FAIL — `AttributeError: type object 'SettingsDialog' has no attribute '_rename_profile'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `SettingsDialog` in `freecad_ai/ui/settings_dialog.py`:
+
+```python
+    def _rename_profile(self, old: str, new: str) -> None:
+        """Rename a profile, carrying every reference to it along.
+
+        A profile's label is its identity — utility_profiles and
+        active_profile store the name, not a stable id — so a rename that
+        did not cascade would silently detach a utility from the
+        connection it was using.
+        """
+        new = (new or "").strip()
+        if not new:
+            raise ValueError("Profile name cannot be empty")
+        if old == new:
+            return
+        if new in self._cfg.profiles:
+            raise ValueError(f"A profile named {new!r} already exists")
+        if old not in self._cfg.profiles:
+            raise ValueError(f"No profile named {old!r}")
+        # Rebuild in place so the combo's order does not shuffle.
+        self._cfg.profiles = {
+            (new if label == old else label): prof
+            for label, prof in self._cfg.profiles.items()
+        }
+        if self._cfg.active_profile == old:
+            self._cfg.active_profile = new
+        for utility, label in list(self._cfg.utility_profiles.items()):
+            if label == old:
+                self._cfg.utility_profiles[utility] = new
+
+    def _delete_profile(self, label: str) -> None:
+        """Remove a profile, leaving nothing pointing at it."""
+        if label not in self._cfg.profiles:
+            raise ValueError(f"No profile named {label!r}")
+        if len(self._cfg.profiles) == 1:
+            raise ValueError("At least one profile is required")
+        del self._cfg.profiles[label]
+        if self._cfg.active_profile == label:
+            self._cfg.active_profile = next(iter(self._cfg.profiles))
+        for utility, mapped in list(self._cfg.utility_profiles.items()):
+            if mapped == label:
+                self._cfg.utility_profiles[utility] = ""
+```
+
+`self._cfg` must exist. In `__init__`, before `_load_from_config()`, add:
+
+```python
+        self._cfg = get_config()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_profile_selector.py -q`
+Expected: PASS (14 tests)
+
+- [ ] **Step 5: Add the selector widgets**
+
+On the provider page, above the existing provider combo, add:
+
+```python
+        # ── Profile selector ────────────────────────────────────────
+        profile_row = QHBoxLayout()
+        self.profile_combo = QComboBox()
+        self.profile_combo.setToolTip(translate(
+            "SettingsDialog",
+            "Named connection. Utilities below can each use a different one."))
+        profile_row.addWidget(self.profile_combo, 1)
+        self.profile_add_btn = QPushButton(translate("SettingsDialog", "New"))
+        self.profile_rename_btn = QPushButton(translate("SettingsDialog", "Rename"))
+        self.profile_delete_btn = QPushButton(translate("SettingsDialog", "Delete"))
+        for b in (self.profile_add_btn, self.profile_rename_btn,
+                  self.profile_delete_btn):
+            profile_row.addWidget(b)
+        form.addRow(translate("SettingsDialog", "Profile:"), profile_row)
+
+        self.profile_combo.currentIndexChanged.connect(self._on_profile_changed)
+        self.profile_add_btn.clicked.connect(self._on_profile_add)
+        self.profile_rename_btn.clicked.connect(self._on_profile_rename)
+        self.profile_delete_btn.clicked.connect(self._on_profile_delete)
+```
+
+And the handlers:
+
+```python
+    def _refresh_profile_combo(self) -> None:
+        """Repopulate the profile combo without firing its handler."""
+        self.profile_combo.blockSignals(True)
+        try:
+            self.profile_combo.clear()
+            for label in self._cfg.profiles:
+                self.profile_combo.addItem(label, label)
+            idx = self.profile_combo.findData(self._cfg.active_profile)
+            if idx >= 0:
+                self.profile_combo.setCurrentIndex(idx)
+        finally:
+            self.profile_combo.blockSignals(False)
+
+    def _commit_profile_fields(self) -> None:
+        """Write the visible connection widgets back into their profile.
+
+        Called before switching away from a profile so an in-progress edit
+        is not lost — the #75 complaint, from the other direction.
+        """
+        label = getattr(self, "_current_profile_label", None)
+        prof = self._cfg.profiles.get(label)
+        if prof is None:
+            return
+        names = get_provider_names()
+        idx = self.provider_combo.currentIndex()
+        if 0 <= idx < len(names):
+            prof.name = names[idx]
+        prof.base_url = self.base_url_edit.text()
+        prof.api_key = self.api_key_edit.text()
+        prof.model = self.model_edit.text()
+
+    def _show_profile(self, label: str) -> None:
+        """Populate the connection widgets from a profile."""
+        prof = self._cfg.profiles[label]
+        self._current_profile_label = label
+        names = get_provider_names()
+        try:
+            idx = names.index(prof.name)
+        except ValueError:
+            idx = 0
+        # Programmatic index moves must not run _on_provider_changed —
+        # that handler exists to apply a preset on a *user* switch, and
+        # firing it here would overwrite the profile's saved URL (#75).
+        self.provider_combo.blockSignals(True)
+        try:
+            self.provider_combo.setCurrentIndex(idx)
+        finally:
+            self.provider_combo.blockSignals(False)
+        self.api_key_edit.setText(prof.api_key)
+        self.base_url_edit.setText(prof.base_url)
+        self.model_edit.setText(prof.model)
+        self._load_model_params_table(prof.model, self._cfg)
+
+    def _on_profile_changed(self, index):
+        label = self.profile_combo.itemData(index)
+        if not label or label == getattr(self, "_current_profile_label", None):
+            return
+        self._commit_profile_fields()
+        self._cfg.active_profile = label
+        self._show_profile(label)
+
+    def _on_profile_add(self):
+        base = translate("SettingsDialog", "New profile")
+        label, n = base, 2
+        while label in self._cfg.profiles:
+            label, n = f"{base} {n}", n + 1
+        self._commit_profile_fields()
+        self._cfg.profiles[label] = ProviderConfig()
+        self._cfg.active_profile = label
+        self._refresh_profile_combo()
+        self._show_profile(label)
+
+    def _on_profile_rename(self):
+        old = self._current_profile_label
+        new, ok = QInputDialog.getText(
+            self, translate("SettingsDialog", "Rename profile"),
+            translate("SettingsDialog", "Name:"), QLineEdit.Normal, old)
+        if not ok:
+            return
+        try:
+            self._rename_profile(old, new)
+        except ValueError as e:
+            QMessageBox.warning(
+                self, translate("SettingsDialog", "Rename profile"), str(e))
+            return
+        self._current_profile_label = new.strip()
+        self._refresh_profile_combo()
+
+    def _on_profile_delete(self):
+        label = self._current_profile_label
+        if QMessageBox.question(
+                self, translate("SettingsDialog", "Delete profile"),
+                translate("SettingsDialog",
+                          "Delete profile '{}'?").format(label)) \
+                != QMessageBox.Yes:
+            return
+        try:
+            self._delete_profile(label)
+        except ValueError as e:
+            QMessageBox.warning(
+                self, translate("SettingsDialog", "Delete profile"), str(e))
+            return
+        self._refresh_profile_combo()
+        self._show_profile(self._cfg.active_profile)
+```
+
+Add `QInputDialog`, `QMessageBox`, `QPushButton`, `QHBoxLayout` to the imports from `.compat` if not already present, and `ProviderConfig` to the `..config` import.
+
+- [ ] **Step 6: Rework `_load_from_config` to go through the profile path**
+
+Replace lines 873-887 of `freecad_ai/ui/settings_dialog.py`:
+
+```python
+    def _load_from_config(self):
+        """Populate fields from the current config."""
+        cfg = self._cfg = get_config()
+
+        self._refresh_profile_combo()
+        self._show_profile(cfg.active_profile)
+
+        self.max_tokens_spin.setValue(cfg.max_tokens)
+```
+
+The provider/key/url/model/params lines are now `_show_profile`'s job. Everything from `max_tokens_spin` onward stays as it was.
+
+This removes the load-path fragility the spec called out: today the sequence is correct only because line 885 happens to re-set the base URL *after* line 882's `setCurrentIndex` clobbered it. `_show_profile` blocks the signal instead of racing it.
+
+- [ ] **Step 7: Make `_on_provider_changed` write to the profile**
+
+`_on_provider_changed` keeps its preset-applying behavior — a user picking a different vendor *should* get that vendor's URL — but must now also record it. At the end of the handler, after the params table reload, add:
+
+```python
+            # A vendor switch is an explicit "point this profile
+            # elsewhere", so record it. Only a user-driven change reaches
+            # here: programmatic index moves are wrapped in blockSignals.
+            self._commit_profile_fields()
+```
+
+- [ ] **Step 8: Verify the whole suite still passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add freecad_ai/ui/settings_dialog.py tests/unit/test_profile_selector.py
+git commit -m "feat(settings): profile selector with cascading rename
+
+Adds New/Rename/Delete for connection profiles. Renames carry
+active_profile and utility_profiles along; deletes never orphan a
+utility. Programmatic combo moves are blockSignals-guarded so the
+load path no longer depends on statement order (#75)."
+```
+
+---
+
+### Task 8: Per-utility profile dropdowns
+
+**Files:**
+- Modify: `freecad_ai/ui/settings_dialog.py` — provider page (bottom), `_load_from_config`, `_save_settings`; delete the `rerank_llm_*` widget group (:540-570 and its load/save lines)
+- Test: `tests/unit/test_utility_dropdowns.py` (create)
+
+**Interfaces:**
+- Consumes: `AppConfig.utility_profiles`, `SettingsDialog._cfg`.
+- Produces: `SettingsDialog.UTILITIES: list[tuple[str, str]]`, `SettingsDialog._collect_utility_profiles(selections: dict) -> dict` (classmethod).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_utility_dropdowns.py`:
+
+```python
+"""Utility → profile mapping, as the dialog collects it.
+
+_collect_utility_profiles takes what the dropdowns hold and produces the
+config dict, so the filtering rule (inherit is stored as absent, not as a
+dangling name) is testable without Qt.
+"""
+
+import pytest
+
+# settings_dialog/chat_widget import through ui/compat.py, which needs Qt.
+try:
+    import PySide6  # noqa: F401
+except ImportError:
+    try:
+        import PySide2  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
+
+
+class TestUtilityIdentifiers:
+    def test_all_four_are_offered(self):
+        assert {u for u, _ in SettingsDialog.UTILITIES} == {
+            "compaction", "skill_eval", "tool_optimize", "rerank"}
+
+    def test_each_has_a_label(self):
+        assert all(label for _, label in SettingsDialog.UTILITIES)
+
+
+class TestCollect:
+    def test_inherit_is_stored_as_absent(self):
+        """An empty selection means inherit; storing it as a key with an
+        empty value would work but leaves noise in config.json."""
+        assert SettingsDialog._collect_utility_profiles(
+            {"compaction": "", "rerank": ""}) == {}
+
+    def test_explicit_choices_are_kept(self):
+        assert SettingsDialog._collect_utility_profiles(
+            {"compaction": "cheap", "rerank": ""}) == {
+                "compaction": "cheap"}
+
+    def test_unknown_utilities_are_dropped(self):
+        """Defends the config against a stale key from a future version
+        being written back by an older one."""
+        assert SettingsDialog._collect_utility_profiles(
+            {"compaction": "cheap", "not_a_utility": "x"}) == {
+                "compaction": "cheap"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_utility_dropdowns.py -q`
+Expected: FAIL — `AttributeError: type object 'SettingsDialog' has no attribute 'UTILITIES'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `SettingsDialog`, as a class attribute near the top of the class body:
+
+```python
+    # Call sites that can run on their own profile. The identifier is the
+    # contract with create_client(cfg, utility); adding a new one here and
+    # at its call site is the whole opt-in.
+    UTILITIES = [
+        ("compaction", "Context compaction"),
+        ("skill_eval", "Skill evaluation"),
+        ("tool_optimize", "Tool optimisation"),
+        ("rerank", "Tool reranking"),
+    ]
+
+    @classmethod
+    def _collect_utility_profiles(cls, selections: dict) -> dict:
+        """Turn dropdown selections into the config mapping.
+
+        An empty selection means inherit the active profile and is stored
+        by omission, so config.json carries only real overrides.
+
+        A classmethod because it touches no widgets — that is what makes
+        it testable without constructing a dialog.
+        """
+        known = {u for u, _ in cls.UTILITIES}
+        return {
+            utility: label
+            for utility, label in selections.items()
+            if utility in known and label
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/test_utility_dropdowns.py -q`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Add the widgets at the bottom of the provider page**
+
+Per the spec: below the profile fields the dropdowns refer to, so the reading order is "define connections, then say which one each job uses."
+
+```python
+        # ── Utilities ───────────────────────────────────────────────
+        self.utility_group = QGroupBox(translate(
+            "SettingsDialog", "Utility models"))
+        util_form = QFormLayout()
+        self.utility_combos = {}
+        for utility, label in self.UTILITIES:
+            combo = QComboBox()
+            combo.setToolTip(translate(
+                "SettingsDialog",
+                "Which profile this job runs on. Leave inherited to use "
+                "the active profile."))
+            self.utility_combos[utility] = combo
+            util_form.addRow(
+                translate("SettingsDialog", label) + ":", combo)
+        self.utility_group.setLayout(util_form)
+        layout.addWidget(self.utility_group)
+```
+
+And the repopulate helper, called from `_refresh_profile_combo` so the lists track renames and deletes:
+
+```python
+    def _refresh_utility_combos(self) -> None:
+        """Repopulate every utility dropdown from the current profiles."""
+        for utility, combo in self.utility_combos.items():
+            current = self._cfg.utility_profiles.get(utility, "")
+            combo.blockSignals(True)
+            try:
+                combo.clear()
+                combo.addItem(translate(
+                    "SettingsDialog", "(same as active profile)"), "")
+                for label in self._cfg.profiles:
+                    combo.addItem(label, label)
+                idx = combo.findData(current)
+                combo.setCurrentIndex(idx if idx >= 0 else 0)
+            finally:
+                combo.blockSignals(False)
+```
+
+Call it at the end of `_refresh_profile_combo`.
+
+- [ ] **Step 6: Save the selections**
+
+In `_save_settings`, where the `rerank_llm_*` fields were being written, put:
+
+```python
+        self._commit_profile_fields()
+        cfg.profiles = self._cfg.profiles
+        cfg.active_profile = self._cfg.active_profile
+        cfg.utility_profiles = self._collect_utility_profiles({
+            utility: combo.currentData()
+            for utility, combo in self.utility_combos.items()
+        })
+```
+
+Delete the `rerank_llm_group` construction (`:540-570`), its `_load_from_config` population lines, its `_save_settings` writes, and `_resolve_rerank_params`. The reranker's connection is a profile now.
+
+- [ ] **Step 7: Verify**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q`
+Expected: PASS. Any test referencing `rerank_llm_provider_combo` or `_resolve_rerank_params` should have been removed in Task 6; if one survives, it is testing deleted code — delete it.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add freecad_ai/ui/settings_dialog.py tests/unit/test_utility_dropdowns.py
+git commit -m "feat(settings): per-utility profile dropdowns
+
+Compaction, skill evaluation, tool optimisation and reranking each pick
+a profile or inherit the active one. Replaces the reranker's bespoke
+four-field override group."
+```
+
+---
+
+### Task 9: Live verification, docs and changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md` (configuration section)
+- Test: manual, in a real FreeCAD session
+
+Unit tests cannot catch an invalid Qt layout or a handler wired to the wrong signal, and this task touches the dialog heavily. Verify in the GUI.
+
+- [ ] **Step 1: Back up the real config before touching it**
+
+```bash
+cp ~/.config/FreeCAD/FreeCADAI/config.json /tmp/config.json.pre-profiles
+```
+
+- [ ] **Step 2: Launch FreeCAD and exercise the dialog**
+
+```bash
+QT_QPA_PLATFORM=xcb ~/bin/freecad
+```
+
+Walk the migration and the new UI:
+
+1. Open AI Settings. The profile combo shows one profile named after your current provider, with your existing URL, key and model intact.
+2. Create a second profile, point it at Ollama, edit its Base URL to something non-default.
+3. Switch back to the first profile and return. **The edited URL is still there** — this is #75.
+4. Rename the second profile. It stays selected and keeps its settings.
+5. Set Context compaction to the second profile. Save, reopen: the choice persisted.
+6. Send a chat message long enough to trigger compaction; confirm in the Report View that the compaction call went to the second profile's model.
+7. Delete the second profile. Compaction falls back to inherited, and the dialog still opens.
+8. Open Edit → Preferences. The provider, model, URL and key shown are the active profile's — confirming the parameter-store bridge still tracks it.
+
+- [ ] **Step 3: Confirm the config round-tripped**
+
+```bash
+python3 -m json.tool ~/.config/FreeCAD/FreeCADAI/config.json | \
+  grep -A3 -E '"(profiles|active_profile|utility_profiles|provider)"' | head -40
+```
+
+Expected: `profiles` and `active_profile` present; a legacy `provider` mirror matching the active profile.
+
+- [ ] **Step 4: Update the changelog**
+
+Add under `## [Unreleased]` in `CHANGELOG.md`:
+
+```markdown
+### Added
+- **Connection profiles.** LLM connection settings are now named profiles.
+  Define as many as you like — `ollama-local` and `ollama-remote` can
+  coexist with different URLs and keys — and switch between them from the
+  Settings dialog without losing anything.
+- **Per-utility models.** Context compaction, skill evaluation, tool
+  optimisation and tool reranking each choose a profile, or inherit the
+  active one. Run chat on a large cloud model and the throwaway work on a
+  cheap or local one.
+
+### Changed
+- The reranker's four-field provider override is replaced by a profile.
+  Existing overrides migrate automatically into a profile named `rerank`.
+
+### Fixed
+- Switching provider in the Settings dialog no longer overwrites a
+  Base URL you had edited (#75). Connection settings live in the profile,
+  and programmatic dropdown moves no longer fire the preset handler.
+```
+
+- [ ] **Step 5: Update the README**
+
+In the configuration section, document the profile concept and the utility dropdowns. Keep it to a short subsection — what a profile is, that utilities can each pick one, and that existing configs migrate with no action needed.
+
+- [ ] **Step 6: Restore the pre-test config if you were experimenting**
+
+```bash
+# Only if the live session left the config in a state you do not want:
+cp /tmp/config.json.pre-profiles ~/.config/FreeCAD/FreeCADAI/config.json
+```
+
+- [ ] **Step 7: Final full-suite run**
+
+Run: `env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py -q`
+Expected: PASS, count at or above the 1196 baseline.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "docs: connection profiles and per-utility models"
+```
+
+- [ ] **Step 9: Close out**
+
+Close #75 referencing the profile work, and note on #30 that the shared-params hazard is now structurally impossible rather than comment-enforced.
+
+---
+
+## Notes for the executor
+
+**Do not start until PR #73 has merged and this branch is rebased onto it.** #73 edits `config.py` and `settings_dialog.py` — the two files this plan rewrites most. It has been waiting on its author for a week; restructuring underneath it would force a contributor to redo their work.
+
+**The riskiest task is 2, not 7.** A UI mistake is visible immediately; a migration mistake silently mangles a config file the user has been running for months. If a step in Task 2 feels ambiguous, stop and ask rather than guessing.
+
+**`cfg.provider` is load-bearing in 44 places.** If you find yourself editing one of them, ask whether the property is doing its job — the answer is usually that it is, and the edit is unnecessary.

--- a/docs/superpowers/specs/2026-09-06-connection-profiles-design.md
+++ b/docs/superpowers/specs/2026-09-06-connection-profiles-design.md
@@ -1,0 +1,227 @@
+# Connection Profiles — Design
+
+**Issues:** [#75 — Switching provider silently overwrites a user-edited Base URL](https://github.com/ghbalf/freecad-ai/issues/75) (resolved by this design)
+**Date:** 2026-09-06
+**Status:** Draft (awaiting review)
+
+## Goal
+
+Let each LLM call site — the chat itself and the utility calls it makes — use its
+own connection settings, so a cheap or local model can do the throwaway work
+while chat runs on an expensive one.
+
+Today exactly one utility can be redirected. The LLM reranker reads a bespoke
+four-field override (`chat_widget.py:116-119`); compaction, skill evaluation and
+tool optimisation all call bare `create_client_from_config()` and are locked to
+the chat model. Adding a second override group per utility would mean five
+config fields hand-wired in four places, so this replaces the pattern rather
+than repeating it.
+
+The same change resolves #75. That bug exists because one flat set of provider
+fields is overwritten from a preset whenever the provider dropdown moves; once
+connection settings are stored per named profile, browsing between them stops
+destroying anything.
+
+## Approved decisions
+
+| Decision | Choice |
+|----------|--------|
+| Unit of configuration | **Named profile** — an arbitrary label over `{provider, base_url, api_key, model, params}` |
+| Several profiles per vendor | **Supported.** `ollama-local` and `ollama-remote` may coexist |
+| API key location | **In the profile**, falling back to a per-provider default when the profile's own key is empty |
+| Main chat config | **Is a profile.** The flat `provider.*` fields migrate into one and are no longer read |
+| Utility selection | `utility_profiles: {utility_name: profile_name}`; absent or empty means *inherit the active profile* |
+| Extensibility | **By name, not by schema.** A new call site opts in by choosing an identifier; no new config fields |
+| Sampling params | **Inside the profile.** Two profiles cannot share a params namespace |
+| Legacy keys | **Left in the JSON, unread, for one release.** Dropped a version later |
+| Sequencing | **After PR #73 merges** — it edits the same two files |
+| Load-path guard | `blockSignals` around `setCurrentIndex` ships regardless |
+
+## Schema
+
+```python
+@dataclass
+class Profile:
+    provider: str = "anthropic"      # key into PROVIDER_PRESETS
+    base_url: str = ""               # empty -> preset default
+    api_key:  str = ""               # empty -> provider_keys[provider]
+    model:    str = ""               # empty -> preset default
+    params:   dict = field(default_factory=dict)
+
+
+@dataclass
+class AppConfig:
+    profiles:         dict = field(default_factory=dict)   # name -> Profile
+    active_profile:   str  = ""                            # what chat uses
+    provider_keys:    dict = field(default_factory=dict)   # vendor -> default key
+    utility_profiles: dict = field(default_factory=dict)   # utility -> profile name
+```
+
+Utility identifiers are fixed strings: `"compaction"`, `"skill_eval"`,
+`"tool_optimize"`, `"rerank"`.
+
+### Why the API key sits in the profile with a provider-level fallback
+
+Both pure positions lose something. A key held only per vendor cannot express
+`ollama-local` needing no credential while `ollama-remote` sits behind an
+authenticating gateway. A key held only per profile makes you re-enter the same
+Anthropic secret for every Anthropic profile.
+
+Resolution is therefore `profile.api_key or provider_keys[profile.provider]`.
+The common case costs one entry; the divergent case stays expressible. This is
+the `or`-fallback idiom the codebase already uses for the reranker override and
+for the MCP env-over-config resolvers, so it should read as familiar.
+
+## Resolution
+
+One function replaces every current client construction:
+
+```python
+def create_client(cfg, utility: str | None = None) -> LLMClient:
+    """Build a client for a call site.
+
+    ``utility`` names a call site (``"compaction"``, ``"rerank"``, ...).
+    None means the chat client. An unmapped or empty entry inherits the
+    active profile, which is the default for every utility.
+    """
+```
+
+Field resolution, in order:
+
+| Field | Source |
+|-------|--------|
+| `provider` | `profile.provider` |
+| `base_url` | `profile.base_url` or `PROVIDER_PRESETS[provider]["base_url"]` |
+| `api_key` | `profile.api_key` or `provider_keys[provider]` |
+| `model` | `profile.model` or `PROVIDER_PRESETS[provider]["default_model"]` |
+| `params` | `model_params.get(model, {})` overlaid with `profile.params` |
+
+`model_params` keeps its current meaning — global per-model defaults, keyed by
+model name — and `profile.params` layers on top. Existing per-model settings
+therefore continue to apply, and a profile only states what it changes.
+
+### Call sites
+
+| Site | Today | After |
+|------|-------|-------|
+| `chat_widget.py:251` | `create_client_from_config()` | `create_client(cfg)` |
+| `settings_dialog.py:60` | `create_client_from_config()` | `create_client(cfg)` |
+| `chat_widget.py:529` | `create_client_from_config()` | `create_client(cfg, "compaction")` |
+| `skill_evaluator.py:226` | `create_client_from_config()` | `create_client(cfg, "skill_eval")` |
+| `optimize_tools.py:161` | `create_client_from_config()` | `create_client(cfg, "tool_optimize")` |
+| `chat_widget.py:116-119` | bespoke 4-field override | `create_client(cfg, "rerank")` |
+
+The bespoke reranker block is deleted, not kept alongside.
+
+### This retires issue #30 structurally
+
+`rerank_params` exists as a separate dict because the reranker once overwrote
+the chat model's sampling parameters. Today a comment in `config.py` is what
+stops that recurring — the invariant lives in prose, and a future contributor
+reusing `model_params` would reintroduce it.
+
+Under profiles, params are a field *of* a profile. Two profiles cannot share a
+params namespace, because there is no shared namespace to reach. The rule moves
+out of a comment and into the shape of the data.
+
+## Migration
+
+Triggered on load when `profiles` is absent.
+
+1. Create a profile named after the current provider (e.g. `"anthropic"`) from
+   `provider.{name, base_url, api_key, model}` and `model_params[provider.model]`.
+   Set `active_profile` to that name.
+2. Copy `provider.api_key` into `provider_keys[provider.name]`.
+3. If `rerank_llm_model` is set, create a second profile named `"rerank"` from
+   the `rerank_llm_*` fields plus `rerank_params`, and set
+   `utility_profiles["rerank"] = "rerank"`. If it is unset, the reranker
+   inherits, matching today's behavior.
+
+   `rerank_llm_api_key` maps onto `Profile.api_key` and so keeps working. This
+   is the field that would have had no home had keys been stored per vendor
+   only, and it is the concrete case that settled that decision.
+4. Leave `provider.*`, `rerank_llm_*` and `rerank_params` in the JSON, unread.
+
+Step 4 is deliberate. A user who installs this version and then downgrades gets
+their previous configuration back rather than an empty dialog. The dead keys are
+removed one release later, once the new shape has shipped.
+
+An untouched `config.json` must produce a single profile equivalent to its
+previous flat configuration — no behavior change on upgrade, per the project
+rule that new `AppConfig` defaults preserve prior-version behavior.
+
+### Failure handling
+
+A profile name in `active_profile` or `utility_profiles` that does not exist in
+`profiles` resolves to the active profile, and to the first profile if the
+active one is also missing. A config with no profiles at all is migrated as
+above; if there is nothing to migrate from either, one profile is created from
+`ProviderConfig` defaults. Configuration must never leave the dialog unusable.
+
+## What this does and does not do for #75
+
+Switching between profiles never writes to a field, so the accidental data loss
+in #75 disappears: browsing to another connection and back leaves both intact.
+
+Changing a profile's **provider** dropdown still resets that profile's base URL
+and model to the new vendor's preset. That is intended — it is an explicit
+"point this profile at a different vendor" action, not a side effect of
+looking around — and it matches how the field behaves for the 21 presets whose
+URLs are complete.
+
+#75 is therefore closed as resolved by design rather than by a targeted patch.
+The `blockSignals` guard around `setCurrentIndex` in `_load_settings` ships
+anyway: today the load path is correct only because line 885 happens to run
+after line 882, and that fragility is worth removing independently.
+
+## UI
+
+The Provider page gains a profile selector — a combo plus `[+] [rename]
+[delete]` — and the existing provider, base URL, API key, model and parameter
+widgets become the fields of whichever profile is selected. Deleting the last
+profile is refused; deleting the active one moves `active_profile` to another.
+
+Renaming a profile rewrites every reference to it in the same operation:
+`active_profile` and any matching `utility_profiles` values follow the new name.
+A rename must never silently detach a utility from the profile it was using. A
+name that is already taken is refused rather than merged.
+
+A Utilities section adds one dropdown per identifier (compaction, skill
+evaluation, tool optimisation, reranking), each listing *inherit active* plus
+every profile name. The existing reranker override widgets are removed, since
+their configuration now lives in a profile.
+
+The Settings dialog is already large, and this adds a button row plus a section.
+The Utilities section goes at the bottom of the Provider page, below the profile
+fields it refers to, so the reading order is "define connections, then say which
+one each job uses."
+
+## Testing
+
+Migration carries the most risk and gets the most coverage.
+
+- Real old-shape `config.json` fixtures asserted against expected profile output:
+  no rerank override, a rerank override present, a `custom` provider with empty
+  preset fields, and a config already in the new shape (must be left alone).
+- Round trip proving legacy keys survive a load/save cycle unmodified.
+- Resolution per utility: inherit when unmapped, override when mapped, fallback
+  when a mapped profile name is missing.
+- API key fallback: profile key wins; empty profile key falls through to
+  `provider_keys`; both empty yields empty.
+- Params layering: `model_params` applies, `profile.params` overrides it, and
+  one profile's params never appear in another's client.
+- A #75-shaped regression: edit a profile's base URL, select another profile,
+  return, and assert the edit survives.
+- Renaming a profile that `active_profile` and a `utility_profiles` entry both
+  point at: both references follow the new name.
+- One test per converted call site asserting it requests the right identifier.
+
+## Sequencing
+
+PR #73 (`fix/59-mcp-bearer-token-auth`) edits `config.py` and
+`settings_dialog.py` and is one bug fix from mergeable. It lands first; this
+work rebases onto it. Restructuring config underneath a contributor who has
+already waited a week is not a trade worth making for ordering convenience.
+
+PR #74 (Cloudflare) is unaffected either way — it adds a preset entry, and
+presets are untouched by this design.

--- a/docs/superpowers/specs/2026-09-06-connection-profiles-design.md
+++ b/docs/superpowers/specs/2026-09-06-connection-profiles-design.md
@@ -2,7 +2,8 @@
 
 **Issues:** [#75 — Switching provider silently overwrites a user-edited Base URL](https://github.com/ghbalf/freecad-ai/issues/75) (resolved by this design)
 **Date:** 2026-09-06
-**Status:** Draft (awaiting review)
+**Status:** Draft (awaiting review) — **amended after final review**, see
+[Amended after final review](#amended-after-final-review)
 
 ## Goal
 
@@ -68,9 +69,14 @@ authenticating gateway. A key held only per profile makes you re-enter the same
 Anthropic secret for every Anthropic profile.
 
 Resolution is therefore `profile.api_key or provider_keys[profile.provider]`.
-The common case costs one entry; the divergent case stays expressible. This is
-the `or`-fallback idiom the codebase already uses for the reranker override and
-for the MCP env-over-config resolvers, so it should read as familiar.
+`provider_keys` is a hand-written per-vendor default — nothing populates it
+automatically, and no widget shows it — so the common case costs one entry *in
+the profile*, and the vendor-wide entry is there for the user who wants several
+profiles on one vendor to share a secret. The divergent case stays expressible.
+This is the `or`-fallback idiom the codebase already uses for the reranker
+override and for the MCP env-over-config resolvers, so it should read as
+familiar. (Amended: the original text had migration seed `provider_keys`, which
+made the fallback a place the dialog could not clear. See Ruling 2.)
 
 ## Resolution
 
@@ -94,11 +100,15 @@ Field resolution, in order:
 | `base_url` | `profile.base_url` or `PROVIDER_PRESETS[provider]["base_url"]` |
 | `api_key` | `profile.api_key` or `provider_keys[provider]` |
 | `model` | `profile.model` or `PROVIDER_PRESETS[provider]["default_model"]` |
-| `params` | `model_params.get(model, {})` overlaid with `profile.params` |
+| `params` | `profile.params` |
 
-`model_params` keeps its current meaning — global per-model defaults, keyed by
-model name — and `profile.params` layers on top. Existing per-model settings
-therefore continue to apply, and a profile only states what it changes.
+The profile is the whole answer: what the Model Parameters table shows for a
+profile is exactly what that profile sends. `model_params` — the old global
+per-model dict, keyed by model name — is no longer read at run time. Migration
+folds each profile's entry into `profile.params` once (Migration step 1), so
+existing settings still apply, and the dict then joins the other legacy keys as
+dead weight in the JSON. (Amended: the original design underlaid `model_params`
+here. See Ruling 1.)
 
 ### Call sites
 
@@ -131,7 +141,9 @@ Triggered on load when `profiles` is absent.
 1. Create a profile named after the current provider (e.g. `"anthropic"`) from
    `provider.{name, base_url, api_key, model}` and `model_params[provider.model]`.
    Set `active_profile` to that name.
-2. Copy `provider.api_key` into `provider_keys[provider.name]`.
+2. Leave `provider_keys` alone. The key migrates onto the profile in step 1
+   and nowhere else. (Amended: this step originally copied the key into
+   `provider_keys` as well. See Ruling 2.)
 3. If `rerank_llm_model` is set, create a second profile named `"rerank"` from
    the `rerank_llm_*` fields plus `rerank_params`, and set
    `utility_profiles["rerank"] = "rerank"`. If it is unset, the reranker
@@ -140,7 +152,8 @@ Triggered on load when `profiles` is absent.
    `rerank_llm_api_key` maps onto `Profile.api_key` and so keeps working. This
    is the field that would have had no home had keys been stored per vendor
    only, and it is the concrete case that settled that decision.
-4. Leave `provider.*`, `rerank_llm_*` and `rerank_params` in the JSON, unread.
+4. Leave `provider.*`, `rerank_llm_*`, `rerank_params` and `model_params` in
+   the JSON, unread.
 
 Step 4 is deliberate. A user who installs this version and then downgrades gets
 their previous configuration back rather than an empty dialog. The dead keys are
@@ -208,8 +221,9 @@ Migration carries the most risk and gets the most coverage.
   when a mapped profile name is missing.
 - API key fallback: profile key wins; empty profile key falls through to
   `provider_keys`; both empty yields empty.
-- Params layering: `model_params` applies, `profile.params` overrides it, and
-  one profile's params never appear in another's client.
+- Params: `profile.params` is what the client gets, a key removed from a
+  profile stays removed, two profiles on one model keep separate parameters,
+  and one profile's params never appear in another's client.
 - A #75-shaped regression: edit a profile's base URL, select another profile,
   return, and assert the edit survives.
 - Renaming a profile that `active_profile` and a `utility_profiles` entry both
@@ -225,3 +239,24 @@ already waited a week is not a trade worth making for ordering convenience.
 
 PR #74 (Cloudflare) is unaffected either way — it adds a preset entry, and
 presets are untouched by this design.
+
+## Amended after final review
+
+The final whole-branch review found two places where the design as written was
+unimplementable as intended, because both named a store that decides the
+outcome and that no widget can reach. Both are corrected above, in place, with
+a pointer back to the ruling.
+
+**Ruling 1 — `params` resolve from the profile alone.** Underlaying
+`model_params` meant Remove in the Model Parameters table could not remove
+anything: the row reappeared from the global dict on the next client build,
+and two profiles on the same model could never disagree about a parameter.
+Migration's one-time copy into `profile.params` (step 1) is what preserves
+existing settings; the run-time read is gone.
+
+**Ruling 2 — migration does not seed `provider_keys`.** Seeding put a second
+copy of the user's credential in a store the Settings dialog neither shows nor
+writes, so clearing the API Key field left the old key on disk and still being
+sent — the opposite of what someone rotating a leaked key intends. It also
+overwrote a hand-written vendor default on the first load after upgrade. The
+`or`-fallback survives; only its automatic population is gone.

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -402,8 +402,13 @@ class AppConfig:
     context_window: int = 20000  # tokens — compaction triggers above this
     temperature: float = 0.3
     model_params: dict = field(default_factory=dict)
-    # Per-model parameter overrides, keyed by model name:
-    # {"gemma4:27b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64}, ...}
+    # LEGACY, unread since connection profiles: per-model parameter
+    # overrides keyed by model name,
+    # {"gemma4:27b": {"temperature": 1.0, "top_p": 0.95, "top_k": 64}, ...}.
+    # Sampling parameters now live on the profile (ProviderConfig.params);
+    # migration copies this dict's entry for the migrated model into it
+    # once. Kept in the JSON so a downgrade still finds it, and removed one
+    # release on — like provider/rerank_llm_*/rerank_params.
     auto_execute: bool = False
     max_retries: int = 3
     # Max agentic tool-loop turns per user message. 0 = endless (the Stop

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -606,8 +606,16 @@ class AppConfig:
             # Malformed "profiles" (e.g. a list from a bad hand-edit):
             # treat as absent so the flat-provider migration path runs.
             raw_profiles = None
+        # A profile *value* that is not a mapping (a hand-edit like
+        # {"profiles": {"a": "x"}}) used to raise TypeError out of
+        # ProviderConfig(**p), which load_config caught by discarding the
+        # whole config and returning bare defaults — losing every other
+        # setting the user had. Normalise it to a default profile instead,
+        # so one bad entry degrades in place like the other malformed
+        # shapes on this path.
         profiles = {
-            label: ProviderConfig(**p)
+            label: ProviderConfig(**p) if isinstance(p, dict)
+            else ProviderConfig()
             for label, p in (raw_profiles or {}).items()
         }
 

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -582,6 +582,10 @@ class AppConfig:
             legacy_provider = None
 
         raw_profiles = data.pop("profiles", None)
+        if not isinstance(raw_profiles, dict):
+            # Malformed "profiles" (e.g. a list from a bad hand-edit):
+            # treat as absent so the flat-provider migration path runs.
+            raw_profiles = None
         profiles = {
             label: ProviderConfig(**p)
             for label, p in (raw_profiles or {}).items()
@@ -617,12 +621,16 @@ class AppConfig:
         # main provider (chat_widget._build_rerank_llm_client). Bake those
         # `or` fallbacks into a standalone profile.
         if data.get("rerank_llm_model"):
+            rerank_params = data.get("rerank_params")
+            if not isinstance(rerank_params, dict):
+                # Malformed "rerank_params" (e.g. a string): no override.
+                rerank_params = {}
             cfg.profiles["rerank"] = ProviderConfig(
                 name=data.get("rerank_llm_provider_name") or main.name,
                 base_url=data.get("rerank_llm_base_url") or main.base_url,
                 api_key=data.get("rerank_llm_api_key") or main.api_key,
                 model=data["rerank_llm_model"],
-                params=dict(data.get("rerank_params") or {}),
+                params=dict(rerank_params),
             )
             cfg.utility_profiles["rerank"] = "rerank"
 

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -26,6 +26,7 @@ where an aborted/buggy prior migration left duplicate data behind.
 
 import datetime
 import json
+import logging
 import os
 import shutil
 import sys
@@ -33,6 +34,8 @@ import time
 import time
 from dataclasses import dataclass, field, asdict, fields
 
+
+logger = logging.getLogger(__name__)
 
 # Marker filename inside the active config dir. Its presence signals that
 # this version of the workbench has already migrated into this target.
@@ -399,8 +402,18 @@ def _profile_from_dict(raw) -> "ProviderConfig":
     filters its own unknown keys in from_dict.
     """
     if not isinstance(raw, dict):
+        logger.warning(
+            "Profile entry is %s, not an object — using defaults for it. "
+            "Check the \"profiles\" section of config.json.",
+            type(raw).__name__)
         return ProviderConfig()
     known = {f.name for f in fields(ProviderConfig)}
+    unknown = set(raw) - known
+    if unknown:
+        logger.warning(
+            "Ignoring unrecognised profile field(s) %s — most likely written "
+            "by a newer version of the workbench.",
+            ", ".join(sorted(unknown)))
     return ProviderConfig(**{k: v for k, v in raw.items() if k in known})
 
 
@@ -672,6 +685,14 @@ class AppConfig:
             if not isinstance(rerank_params, dict):
                 # Malformed "rerank_params" (e.g. a string): no override.
                 rerank_params = {}
+            if not rerank_params:
+                # Configs written before rerank_params existed (<= v0.16.4)
+                # kept the override reranker's params in the shared
+                # model_params dict, keyed by its model. load_config used
+                # to seed them afterwards, which is too late for this
+                # migration and lands in a field nothing reads any more.
+                rerank_params = cfg.model_params.get(
+                    data["rerank_llm_model"], {})
             cfg.profiles["rerank"] = ProviderConfig(
                 name=data.get("rerank_llm_provider_name") or main.name,
                 base_url=data.get("rerank_llm_base_url") or main.base_url,
@@ -711,12 +732,9 @@ def load_config() -> AppConfig:
             cfg = AppConfig.from_dict(data)
         except (json.JSONDecodeError, TypeError, KeyError):
             pass
-    # Migrate pre-namespace configs: the reranker override model's params used
-    # to live in the shared model_params dict. Seed the new rerank_params slot
-    # from there so override users don't silently lose their params on upgrade.
-    # Idempotent — only fills an empty rerank_params (issue #30 follow-up).
-    if cfg.rerank_llm_model and not cfg.rerank_params:
-        cfg.rerank_params = dict(cfg.model_params.get(cfg.rerank_llm_model, {}))
+    # (The pre-namespace rerank_params seeding that used to live here now
+    # runs inside _migrate_flat_provider, where the profile that actually
+    # reads those params is built. rerank_params itself is legacy.)
     _apply_param_store_overrides(cfg)
     _write_to_param_store(cfg)
     return cfg

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -570,7 +570,22 @@ class AppConfig:
         return _provider_supports_tools(self.provider.name)
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        """Serialise, including a legacy ``provider`` mirror.
+
+        ``provider`` is a property now, so asdict() skips it. We write it
+        anyway for one release: a user who installs this version and then
+        downgrades gets their connection back instead of a blank dialog.
+        Drop this mirror — and the rerank_llm_*/rerank_params fields —
+        one release after profiles ship.
+        """
+        data = asdict(self)
+        data["provider"] = {
+            "name": self.provider.name,
+            "api_key": self.provider.api_key,
+            "base_url": self.provider.base_url,
+            "model": self.provider.model,
+        }
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> "AppConfig":

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -574,29 +574,57 @@ class AppConfig:
 
     @classmethod
     def from_dict(cls, data: dict) -> "AppConfig":
-        provider_data = data.pop("provider", {})
-        # Filter out unknown keys to avoid TypeError
-        known = {f.name for f in cls.__dataclass_fields__.values()}
+        data = dict(data)  # never mutate the caller's parsed JSON
+        legacy_provider = data.pop("provider", None)
+        if not isinstance(legacy_provider, dict):
+            # Malformed legacy "provider" (e.g. a bad config.json hand-edit):
+            # treat as absent rather than raising deep in the migration path.
+            legacy_provider = None
+
+        raw_profiles = data.pop("profiles", None)
+        profiles = {
+            label: ProviderConfig(**p)
+            for label, p in (raw_profiles or {}).items()
+        }
+
+        known = {f.name for f in cls.__dataclass_fields__.values()} - {"profiles"}
         filtered = {k: v for k, v in data.items() if k in known}
+        cfg = cls(profiles=profiles, **filtered)
 
-        # Convert profiles dict values to ProviderConfig if needed
-        if "profiles" in filtered and isinstance(filtered["profiles"], dict):
-            profiles_dict = filtered["profiles"]
-            converted = {}
-            for label, profile_data in profiles_dict.items():
-                if isinstance(profile_data, dict):
-                    converted[label] = ProviderConfig(**profile_data)
-                else:
-                    converted[label] = profile_data
-            filtered["profiles"] = converted
-
-        cfg = cls(**filtered)
-        # Minimal migration: if old JSON has "provider", restore it as the active profile
-        if provider_data:
-            provider = ProviderConfig(**provider_data)
-            cfg.profiles = {provider.name: provider}
-            cfg.active_profile = provider.name
+        if not raw_profiles:
+            cls._migrate_flat_provider(cfg, legacy_provider or {}, data)
         return cfg
+
+    @staticmethod
+    def _migrate_flat_provider(cfg: "AppConfig", legacy: dict, data: dict) -> None:
+        """Turn a pre-profiles config into one or two profiles.
+
+        Only runs when the JSON carries no ``profiles`` key, so it is a
+        one-time upgrade rather than something that fights an already
+        migrated file on every load.
+        """
+        main = ProviderConfig(**{
+            k: v for k, v in legacy.items()
+            if k in {"name", "api_key", "base_url", "model"}
+        })
+        main.params = dict(cfg.model_params.get(main.model, {}))
+        cfg.profiles = {main.name: main}
+        cfg.active_profile = main.name
+        if main.api_key:
+            cfg.provider_keys[main.name] = main.api_key
+
+        # The old reranker override inherited each empty field from the
+        # main provider (chat_widget._build_rerank_llm_client). Bake those
+        # `or` fallbacks into a standalone profile.
+        if data.get("rerank_llm_model"):
+            cfg.profiles["rerank"] = ProviderConfig(
+                name=data.get("rerank_llm_provider_name") or main.name,
+                base_url=data.get("rerank_llm_base_url") or main.base_url,
+                api_key=data.get("rerank_llm_api_key") or main.api_key,
+                model=data["rerank_llm_model"],
+                params=dict(data.get("rerank_params") or {}),
+            )
+            cfg.utility_profiles["rerank"] = "rerank"
 
 
 def _ensure_dirs():

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -633,8 +633,8 @@ class AppConfig:
             cfg.provider_keys[main.name] = main.api_key
 
         # The old reranker override inherited each empty field from the
-        # main provider (chat_widget._build_rerank_llm_client). Bake those
-        # `or` fallbacks into a standalone profile.
+        # main provider (the pre-profiles reranker builder in chat_widget).
+        # Bake those `or` fallbacks into a standalone profile.
         if data.get("rerank_llm_model"):
             rerank_params = data.get("rerank_params")
             if not isinstance(rerank_params, dict):

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -372,10 +372,16 @@ PROVIDER_PRESETS = {
 
 @dataclass
 class ProviderConfig:
+    """One named connection: vendor, endpoint, credential, model, params.
+
+    ``name`` is the *vendor* key into PROVIDER_PRESETS. A profile's own
+    label is its key in ``AppConfig.profiles``, not a field here.
+    """
     name: str = "anthropic"
     api_key: str = ""
     base_url: str = "https://api.anthropic.com"
     model: str = "claude-sonnet-4-6"
+    params: dict = field(default_factory=dict)
 
     def apply_preset(self, provider_name: str):
         """Apply a provider preset, updating base_url and model to defaults."""
@@ -387,7 +393,10 @@ class ProviderConfig:
 
 @dataclass
 class AppConfig:
-    provider: ProviderConfig = field(default_factory=ProviderConfig)
+    profiles: dict = field(default_factory=dict)      # label -> ProviderConfig
+    active_profile: str = ""                          # label chat uses
+    provider_keys: dict = field(default_factory=dict) # vendor -> default api key
+    utility_profiles: dict = field(default_factory=dict)  # utility -> label
     mode: str = "plan"  # "plan" or "act"
     max_tokens: int = 4096
     context_window: int = 20000  # tokens — compaction triggers above this
@@ -507,6 +516,36 @@ class AppConfig:
     # is naturally bounded by the number of distinct documents ever edited.
     max_backups: int = 0
 
+    def __post_init__(self):
+        self._ensure_profile()
+
+    def _ensure_profile(self) -> None:
+        """Guarantee at least one profile and a valid active label.
+
+        A config must never leave the dialog unusable, so an empty or
+        dangling ``active_profile`` resolves rather than raising. Cheap
+        and idempotent, so the ``provider`` property can call it on every
+        access and never hand back a KeyError.
+        """
+        if not self.profiles:
+            default = ProviderConfig()
+            self.profiles = {default.name: default}
+            self.active_profile = default.name
+        if self.active_profile not in self.profiles:
+            self.active_profile = next(iter(self.profiles))
+
+    @property
+    def provider(self) -> ProviderConfig:
+        """The active profile.
+
+        Every ``cfg.provider.*`` read and write in the codebase means "the
+        active chat connection", so they all keep working through here.
+        Reads AND writes: the FreeCAD parameter-store bridge assigns to
+        ``cfg.provider.model`` etc., and those land in the stored profile.
+        """
+        self._ensure_profile()
+        return self.profiles[self.active_profile]
+
     @property
     def supports_vision(self) -> bool:
         """Whether the current LLM supports vision (images in content blocks)."""
@@ -536,11 +575,28 @@ class AppConfig:
     @classmethod
     def from_dict(cls, data: dict) -> "AppConfig":
         provider_data = data.pop("provider", {})
-        provider = ProviderConfig(**provider_data)
         # Filter out unknown keys to avoid TypeError
-        known = {f.name for f in cls.__dataclass_fields__.values()} - {"provider"}
+        known = {f.name for f in cls.__dataclass_fields__.values()}
         filtered = {k: v for k, v in data.items() if k in known}
-        return cls(provider=provider, **filtered)
+
+        # Convert profiles dict values to ProviderConfig if needed
+        if "profiles" in filtered and isinstance(filtered["profiles"], dict):
+            profiles_dict = filtered["profiles"]
+            converted = {}
+            for label, profile_data in profiles_dict.items():
+                if isinstance(profile_data, dict):
+                    converted[label] = ProviderConfig(**profile_data)
+                else:
+                    converted[label] = profile_data
+            filtered["profiles"] = converted
+
+        cfg = cls(**filtered)
+        # Minimal migration: if old JSON has "provider", restore it as the active profile
+        if provider_data:
+            provider = ProviderConfig(**provider_data)
+            cfg.profiles = {provider.name: provider}
+            cfg.active_profile = provider.name
+        return cfg
 
 
 def _ensure_dirs():

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -31,7 +31,7 @@ import shutil
 import sys
 import time
 import time
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field, asdict, fields
 
 
 # Marker filename inside the active config dir. Its presence signals that
@@ -391,6 +391,19 @@ class ProviderConfig:
         self.model = preset.get("default_model", self.model)
 
 
+def _profile_from_dict(raw) -> "ProviderConfig":
+    """Build a ProviderConfig from JSON, ignoring anything it cannot take.
+
+    Unknown keys are dropped rather than raised on, so a config written by
+    a later version stays loadable by this one. Mirrors how AppConfig
+    filters its own unknown keys in from_dict.
+    """
+    if not isinstance(raw, dict):
+        return ProviderConfig()
+    known = {f.name for f in fields(ProviderConfig)}
+    return ProviderConfig(**{k: v for k, v in raw.items() if k in known})
+
+
 @dataclass
 class AppConfig:
     profiles: dict = field(default_factory=dict)      # label -> ProviderConfig
@@ -606,16 +619,17 @@ class AppConfig:
             # Malformed "profiles" (e.g. a list from a bad hand-edit):
             # treat as absent so the flat-provider migration path runs.
             raw_profiles = None
-        # A profile *value* that is not a mapping (a hand-edit like
-        # {"profiles": {"a": "x"}}) used to raise TypeError out of
-        # ProviderConfig(**p), which load_config caught by discarding the
-        # whole config and returning bare defaults — losing every other
-        # setting the user had. Normalise it to a default profile instead,
-        # so one bad entry degrades in place like the other malformed
-        # shapes on this path.
+        # A profile entry that ProviderConfig(**p) cannot take used to
+        # raise TypeError, which load_config caught by discarding the whole
+        # config and returning bare defaults — losing every other setting
+        # the user had, and letting the next save write the loss to disk.
+        # Two shapes do it: a value that is not a mapping at all (the
+        # hand-edit {"profiles": {"a": "x"}}), and a mapping carrying a
+        # field this version does not know, which is what a profile
+        # written by a *newer* version looks like. Both degrade in place
+        # now, like the other malformed shapes on this path.
         profiles = {
-            label: ProviderConfig(**p) if isinstance(p, dict)
-            else ProviderConfig()
+            label: _profile_from_dict(p)
             for label, p in (raw_profiles or {}).items()
         }
 

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -634,8 +634,13 @@ class AppConfig:
         main.params = dict(cfg.model_params.get(main.model, {}))
         cfg.profiles = {main.name: main}
         cfg.active_profile = main.name
-        if main.api_key:
-            cfg.provider_keys[main.name] = main.api_key
+        # Deliberately no provider_keys seeding here. The key is already on
+        # the profile above, where the dialog can show and clear it;
+        # copying it into provider_keys as well created a credential no
+        # widget could reach, so clearing the API Key field to rotate a
+        # leaked key left the old one on disk and still being sent.
+        # provider_keys stays a hand-written per-vendor default that
+        # create_client falls back to — never auto-populated.
 
         # The old reranker override inherited each empty field from the
         # main provider (the pre-profiles reranker builder in chat_widget).

--- a/freecad_ai/extensions/skill_evaluator.py
+++ b/freecad_ai/extensions/skill_evaluator.py
@@ -215,7 +215,7 @@ class SkillEvaluator:
                  test_cases: list[dict], runs_per_test: int = 2,
                  validation_content: str = "") -> list[EvalResult]:
         """Run skill against all test cases and return results."""
-        from ..llm.client import create_client_from_config
+        from ..llm.client import create_client
         from ..core.system_prompt import build_system_prompt
         from ..llm.providers import get_api_style
         from ..config import get_config
@@ -223,7 +223,7 @@ class SkillEvaluator:
         cfg = get_config()
         api_style = get_api_style(cfg.provider.name)
         system = build_system_prompt(mode="act", tools_enabled=True)
-        client = create_client_from_config()
+        client = create_client(cfg, "skill_eval")
 
         from ..tools.setup import create_default_registry
         from ..tools.optimize_tools import get_eval_tools

--- a/freecad_ai/extensions/skill_evaluator.py
+++ b/freecad_ai/extensions/skill_evaluator.py
@@ -217,13 +217,12 @@ class SkillEvaluator:
         """Run skill against all test cases and return results."""
         from ..llm.client import create_client
         from ..core.system_prompt import build_system_prompt
-        from ..llm.providers import get_api_style
         from ..config import get_config
 
         cfg = get_config()
-        api_style = get_api_style(cfg.provider.name)
         system = build_system_prompt(mode="act", tools_enabled=True)
         client = create_client(cfg, "skill_eval")
+        api_style = client.api_style
 
         from ..tools.setup import create_default_registry
         from ..tools.optimize_tools import get_eval_tools

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -910,6 +910,18 @@ def resolve_profile(cfg, utility: str | None = None):
     return cfg.provider
 
 
+def resolve_params(cfg, profile) -> dict:
+    """Merge global per-model defaults with a profile's own params.
+
+    ``cfg.model_params`` holds defaults keyed by model name; the profile
+    layers on top, so a profile states only what it changes. Returns a
+    fresh dict — callers and the shared config entry must never alias.
+    """
+    params = dict(cfg.model_params.get(profile.model, {}))
+    params.update(profile.params)
+    return params
+
+
 def create_client(cfg=None, utility: str | None = None, *,
                   max_tokens: int | None = None,
                   temperature: float | None = None,
@@ -932,8 +944,7 @@ def create_client(cfg=None, utility: str | None = None, *,
         cfg = get_config()
     profile = resolve_profile(cfg, utility)
 
-    params = dict(cfg.model_params.get(profile.model, {}))
-    params.update(profile.params)
+    params = resolve_params(cfg, profile)
 
     return LLMClient(
         provider_name=profile.name,

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -922,24 +922,30 @@ def create_client(cfg=None, utility: str | None = None, *,
     reranker wants 1024 tokens and no thinking whichever profile it runs
     on.
 
-    An empty ``api_key`` on the profile falls back to the vendor-wide
-    default in ``cfg.provider_keys``, so one Anthropic secret serves every
-    Anthropic profile while a gateway-authenticated Ollama profile can
-    still carry its own.
+    An empty ``api_key``, ``base_url``, or ``model`` on the profile falls
+    back to the vendor preset in ``PROVIDER_PRESETS`` (or, for the key, the
+    vendor-wide default in ``cfg.provider_keys``) — so one Anthropic secret
+    serves every Anthropic profile, a gateway-authenticated Ollama profile
+    can still carry its own, and a profile left with blank connection
+    fields still resolves to something that works rather than an empty
+    string. An unmapped vendor name (e.g. "custom") degrades gracefully:
+    the preset lookup is a plain ``.get(name, {})``, never a KeyError.
     """
-    from ..config import get_config
+    from ..config import PROVIDER_PRESETS, get_config
     if cfg is None:
         cfg = get_config()
     profile = resolve_profile(cfg, utility)
+    preset = PROVIDER_PRESETS.get(profile.name, {})
+    model = profile.model or preset.get("default_model", "")
 
-    params = dict(cfg.model_params.get(profile.model, {}))
+    params = dict(cfg.model_params.get(model, {}))
     params.update(profile.params)
 
     return LLMClient(
         provider_name=profile.name,
-        base_url=profile.base_url,
+        base_url=profile.base_url or preset.get("base_url", ""),
         api_key=profile.api_key or cfg.provider_keys.get(profile.name, ""),
-        model=profile.model,
+        model=model,
         max_tokens=cfg.max_tokens if max_tokens is None else max_tokens,
         temperature=cfg.temperature if temperature is None else temperature,
         thinking=cfg.thinking if thinking is None else thinking,

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -922,30 +922,24 @@ def create_client(cfg=None, utility: str | None = None, *,
     reranker wants 1024 tokens and no thinking whichever profile it runs
     on.
 
-    An empty ``api_key``, ``base_url``, or ``model`` on the profile falls
-    back to the vendor preset in ``PROVIDER_PRESETS`` (or, for the key, the
-    vendor-wide default in ``cfg.provider_keys``) — so one Anthropic secret
-    serves every Anthropic profile, a gateway-authenticated Ollama profile
-    can still carry its own, and a profile left with blank connection
-    fields still resolves to something that works rather than an empty
-    string. An unmapped vendor name (e.g. "custom") degrades gracefully:
-    the preset lookup is a plain ``.get(name, {})``, never a KeyError.
+    An empty ``api_key`` on the profile falls back to the vendor-wide
+    default in ``cfg.provider_keys``, so one Anthropic secret serves every
+    Anthropic profile while a gateway-authenticated Ollama profile can
+    still carry its own.
     """
-    from ..config import PROVIDER_PRESETS, get_config
+    from ..config import get_config
     if cfg is None:
         cfg = get_config()
     profile = resolve_profile(cfg, utility)
-    preset = PROVIDER_PRESETS.get(profile.name, {})
-    model = profile.model or preset.get("default_model", "")
 
-    params = dict(cfg.model_params.get(model, {}))
+    params = dict(cfg.model_params.get(profile.model, {}))
     params.update(profile.params)
 
     return LLMClient(
         provider_name=profile.name,
-        base_url=profile.base_url or preset.get("base_url", ""),
+        base_url=profile.base_url,
         api_key=profile.api_key or cfg.provider_keys.get(profile.name, ""),
-        model=model,
+        model=profile.model,
         max_tokens=cfg.max_tokens if max_tokens is None else max_tokens,
         temperature=cfg.temperature if temperature is None else temperature,
         thinking=cfg.thinking if thinking is None else thinking,

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -895,19 +895,58 @@ def should_strip_thinking(model: str, override: bool | None = None) -> bool:
     return any(model_lower.startswith(prefix) for prefix in _STRIP_THINKING_MODELS)
 
 
-def create_client_from_config() -> LLMClient:
-    """Create an LLMClient from the current application config."""
+def resolve_profile(cfg, utility: str | None = None):
+    """Return the ProviderConfig a call site should use.
+
+    ``utility`` is a call-site identifier ("compaction", "skill_eval",
+    "tool_optimize", "rerank"). None, unmapped, empty, or naming a profile
+    that no longer exists all mean "inherit the active profile" — a
+    deleted profile must never make the workbench unusable.
+    """
+    if utility:
+        label = cfg.utility_profiles.get(utility, "")
+        if label and label in cfg.profiles:
+            return cfg.profiles[label]
+    return cfg.provider
+
+
+def create_client(cfg=None, utility: str | None = None, *,
+                  max_tokens: int | None = None,
+                  temperature: float | None = None,
+                  thinking: str | None = None) -> LLMClient:
+    """Build an LLMClient for one call site.
+
+    Connection settings (vendor, url, key, model, params) come from the
+    resolved profile. Job settings (max_tokens, temperature, thinking)
+    come from the config unless the call site overrides them — the
+    reranker wants 1024 tokens and no thinking whichever profile it runs
+    on.
+
+    An empty ``api_key`` on the profile falls back to the vendor-wide
+    default in ``cfg.provider_keys``, so one Anthropic secret serves every
+    Anthropic profile while a gateway-authenticated Ollama profile can
+    still carry its own.
+    """
     from ..config import get_config
-    cfg = get_config()
-    # Resolve per-model params: saved params for this model, or empty dict.
-    model_params = cfg.model_params.get(cfg.provider.model, {})
+    if cfg is None:
+        cfg = get_config()
+    profile = resolve_profile(cfg, utility)
+
+    params = dict(cfg.model_params.get(profile.model, {}))
+    params.update(profile.params)
+
     return LLMClient(
-        provider_name=cfg.provider.name,
-        base_url=cfg.provider.base_url,
-        api_key=cfg.provider.api_key,
-        model=cfg.provider.model,
-        max_tokens=cfg.max_tokens,
-        temperature=cfg.temperature,
-        thinking=cfg.thinking,
-        model_params=model_params,
+        provider_name=profile.name,
+        base_url=profile.base_url,
+        api_key=profile.api_key or cfg.provider_keys.get(profile.name, ""),
+        model=profile.model,
+        max_tokens=cfg.max_tokens if max_tokens is None else max_tokens,
+        temperature=cfg.temperature if temperature is None else temperature,
+        thinking=cfg.thinking if thinking is None else thinking,
+        model_params=params,
     )
+
+
+def create_client_from_config() -> LLMClient:
+    """Chat client from the active profile. Kept for third-party hooks."""
+    return create_client()

--- a/freecad_ai/llm/client.py
+++ b/freecad_ai/llm/client.py
@@ -911,15 +911,21 @@ def resolve_profile(cfg, utility: str | None = None):
 
 
 def resolve_params(cfg, profile) -> dict:
-    """Merge global per-model defaults with a profile's own params.
+    """Return the sampling parameters a profile runs with.
 
-    ``cfg.model_params`` holds defaults keyed by model name; the profile
-    layers on top, so a profile states only what it changes. Returns a
-    fresh dict — callers and the shared config entry must never alias.
+    The profile is authoritative: what the Model Parameters table shows
+    for a profile is exactly what that profile sends, so removing a row
+    removes the parameter. ``cfg.model_params`` — the old per-model dict
+    keyed by model name — is legacy and no longer read; it used to be
+    underlaid here, which no widget could write and which therefore made
+    Remove a no-op and stopped two profiles on one model from disagreeing.
+    Migration folds it into ``profile.params`` once, on upgrade.
+
+    ``cfg`` stays in the signature: every call site has one, and the
+    resolution rule is the kind of thing that grows a config input again.
+    Returns a fresh dict — callers must never alias the profile's own.
     """
-    params = dict(cfg.model_params.get(profile.model, {}))
-    params.update(profile.params)
-    return params
+    return dict(profile.params)
 
 
 def create_client(cfg=None, utility: str | None = None, *,

--- a/freecad_ai/tools/optimize_tools.py
+++ b/freecad_ai/tools/optimize_tools.py
@@ -156,9 +156,9 @@ def _evaluate_once(skill_name, skill_content, parsed_cases, runs_per_test,
 def _ask_llm_for_modification(skill_content, iteration, score, results_text,
                                strategy_instruction):
     """Ask the LLM to suggest a modified SKILL.md based on results."""
-    from ..llm.client import create_client_from_config
+    from ..llm.client import create_client
 
-    client = create_client_from_config()
+    client = create_client(utility="tool_optimize")
     prompt = MODIFICATION_PROMPT.format(
         skill_content=skill_content,
         iteration=iteration,

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -94,47 +94,6 @@ def _is_binary_content(data: bytes) -> bool:
     return False
 
 
-def _build_rerank_llm_client(cfg):
-    """Construct the LLMClient used for LLM-based reranking.
-
-    Each override field is inherited from the main provider when empty,
-    so the common case (same provider, maybe a different model) is a
-    one-field change. Full override (different provider entirely) works
-    too, for e.g. running reranking on a local Ollama model while the
-    main chat uses a cloud provider.
-
-    Model params come from one of two disjoint namespaces, so the reranker
-    can never overwrite the main model's params (issue #30):
-      - Inherited model (no override) → the main model's params from
-        ``cfg.model_params`` (handles provider quirks like Moonshot's locked
-        ``temperature=1``)
-      - Override model → the reranker's own ``cfg.rerank_params`` (important
-        for small Ollama models that need ``num_predict`` / ``top_k`` /
-        ``repeat_penalty`` etc.)
-    """
-    from ..llm.client import LLMClient
-    provider_name = cfg.rerank_llm_provider_name or cfg.provider.name
-    base_url = cfg.rerank_llm_base_url or cfg.provider.base_url
-    api_key = cfg.rerank_llm_api_key or cfg.provider.api_key
-    model = cfg.rerank_llm_model or cfg.provider.model
-
-    if cfg.rerank_llm_model:  # override → reranker's own param namespace
-        model_params = dict(cfg.rerank_params)
-    else:  # inherit → use the main model's params
-        model_params = dict(cfg.model_params.get(model, {}))
-
-    return LLMClient(
-        provider_name=provider_name,
-        base_url=base_url,
-        api_key=api_key,
-        model=model,
-        max_tokens=1024,
-        temperature=model_params.get("temperature", 0.0),
-        thinking="off",
-        model_params=model_params,
-    )
-
-
 def _freecad_log(msg: str):
     """Print a line to FreeCAD's Report View, if FreeCAD is available."""
     try:
@@ -153,7 +112,16 @@ def _run_reranker(cfg, pairs, user_text):
     from ..tools.reranker import rerank_tools, rerank_tools_llm
     if cfg.rerank_method == "llm":
         try:
-            client = _build_rerank_llm_client(cfg)
+            from ..llm.client import create_client, resolve_profile, resolve_params
+            # Reranking is a classification job: short output, no thinking,
+            # deterministic unless the profile itself sets a temperature.
+            # Those are call-site properties and stay fixed whichever
+            # profile the user points the reranker at.
+            profile = resolve_profile(cfg, "rerank")
+            params = resolve_params(cfg, profile)
+            client = create_client(
+                cfg, "rerank", max_tokens=1024, thinking="off",
+                temperature=params.get("temperature", 0.0))
         except Exception as e:
             _freecad_log("LLM reranker: cannot build client ({}); using keyword".format(e))
             return rerank_tools(

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -525,8 +525,8 @@ class _CompactionWorker(QThread):
 
     def run(self):
         try:
-            from ..llm.client import create_client_from_config
-            client = create_client_from_config()
+            from ..llm.client import create_client
+            client = create_client(utility="compaction")
 
             messages = [
                 {

--- a/freecad_ai/ui/compat.py
+++ b/freecad_ai/ui/compat.py
@@ -11,4 +11,3 @@ try:
 except ImportError:
     from PySide2 import QtWidgets, QtCore, QtGui  # noqa: F401
     PYSIDE_VERSION = 2
-

--- a/freecad_ai/ui/compat.py
+++ b/freecad_ai/ui/compat.py
@@ -12,11 +12,3 @@ except ImportError:
     from PySide2 import QtWidgets, QtCore, QtGui  # noqa: F401
     PYSIDE_VERSION = 2
 
-# Marks a string literal for extraction by pylupdate without translating it
-# where it is written — for labels declared in a module-level table and
-# passed through translate() at the use site. pylupdate only ever sees
-# literals, so translate(some_variable) extracts nothing at all.
-# getattr, not an attribute access: both bindings return the text unchanged,
-# so the fallback is an identity function rather than a degraded path.
-QT_TRANSLATE_NOOP = getattr(
-    QtCore, "QT_TRANSLATE_NOOP", lambda context, text: text)

--- a/freecad_ai/ui/compat.py
+++ b/freecad_ai/ui/compat.py
@@ -11,3 +11,12 @@ try:
 except ImportError:
     from PySide2 import QtWidgets, QtCore, QtGui  # noqa: F401
     PYSIDE_VERSION = 2
+
+# Marks a string literal for extraction by pylupdate without translating it
+# where it is written — for labels declared in a module-level table and
+# passed through translate() at the use site. pylupdate only ever sees
+# literals, so translate(some_variable) extracts nothing at all.
+# getattr, not an attribute access: both bindings return the text unchanged,
+# so the fallback is an identity function rather than a degraded path.
+QT_TRANSLATE_NOOP = getattr(
+    QtCore, "QT_TRANSLATE_NOOP", lambda context, text: text)

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -1456,6 +1456,41 @@ class SettingsDialog(QDialog):
         self.system_prompt_edit.setPlainText(default)
         self._last_default_prompt = default
 
+    @staticmethod
+    def _profiles_missing_base_url(profiles) -> list:
+        """Sorted labels of profiles with no Base URL, which cannot work.
+
+        LLMClient builds every request URL as base_url + a path, so a blank
+        one yields a relative path and a network error nowhere near the
+        cause. Resolution deliberately does not substitute the provider
+        preset here — a silent substitution is issue #75's shape — so the
+        blank has to be surfaced instead.
+        """
+        return sorted(
+            label for label, prof in profiles.items()
+            if not (getattr(prof, "base_url", "") or "").strip())
+
+    def _confirm_incomplete_profiles(self) -> bool:
+        """Ask before saving a profile that has no Base URL. True to proceed.
+
+        A question rather than a refusal: a config may already carry a
+        half-filled profile the user never selects, and blocking OK on it
+        would strand every unrelated setting in this dialog.
+        """
+        incomplete = self._profiles_missing_base_url(self._profiles)
+        if not incomplete:
+            return True
+        return QMessageBox.question(
+            self,
+            translate("SettingsDialog", "Profile has no Base URL"),
+            translate(
+                "SettingsDialog",
+                "No Base URL is set for: %s.\n\nRequests made with such a "
+                "profile fail with a connection error rather than a clear "
+                "message. Save anyway?") % ", ".join(incomplete),
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No) == QMessageBox.Yes
+
     def _save(self):
         """Save settings to config and close."""
         cfg = get_config()
@@ -1468,6 +1503,8 @@ class SettingsDialog(QDialog):
         # profiles[active_profile]) then reads correctly for everything
         # below, with no separate provider.* writes needed.
         self._commit_profile_fields()
+        if not self._confirm_incomplete_profiles():
+            return
         cfg.profiles = copy.deepcopy(self._profiles)
         cfg.active_profile = self._active_profile
         cfg.utility_profiles = self._collect_utility_profiles({

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -1094,14 +1094,12 @@ class SettingsDialog(QDialog):
         prof.base_url = self.base_url_edit.text()
         prof.api_key = self.api_key_edit.text()
         prof.model = self.model_edit.text()
-        # Commit the table's effective merge (global cfg.model_params
-        # layered under the profile's own — see _load_model_params_table),
-        # not just whatever the profile already stated. A visited profile
-        # thereby absorbs the global defaults it was inheriting and states
-        # them itself from here on: that keeps "what you saw is what you
-        # saved" true and stops one profile's edit from moving another
-        # profile's values through the shared cfg.model_params layer. Do
-        # not "simplify" this back to a partial dict.
+        # The table is the profile's params in full (see
+        # _load_model_params_table), so this is a straight write-back and
+        # a removed row is a removed parameter. Do not reintroduce a
+        # merge with cfg.model_params here: that shared layer is legacy
+        # and unread, and layering it back in would make Remove a no-op
+        # again.
         prof.params = self._read_model_params_table()
 
     def _show_profile(self, label: str) -> None:
@@ -1196,9 +1194,15 @@ class SettingsDialog(QDialog):
             if new_model:
                 self.model_edit.setText(new_model)
 
-            # Load saved params for the (possibly preserved) model
-            cfg = get_config()
-            self._load_model_params_table(self.model_edit.text(), cfg)
+            # Load saved params for the (possibly preserved) model. The
+            # working-copy profile, not the singleton: a vendor switch
+            # keeps the parameters this profile already states, and falls
+            # back to the new preset's default_params only when it states
+            # none.
+            prof = self._profiles.get(
+                getattr(self, "_current_profile_label", None))
+            self._load_model_params_table(
+                self.model_edit.text(), self._cfg, prof)
 
             # Apply provider-recommended reranker settings only when the
             # reranker UI is still at its factory default (off + top_n 15).
@@ -1280,14 +1284,13 @@ class SettingsDialog(QDialog):
         self._load_model_params_table(new_model, self._cfg, prof)
 
     def _load_model_params_table(self, model_name: str, cfg=None, profile=None):
-        """Populate the params table with the effective resolve_params() merge.
+        """Populate the params table with what resolve_params() will send.
 
-        Priority: cfg.model_params[model] (the global per-model default
-        layer) with `profile`'s own params layered on top — exactly what
-        resolve_params() computes for create_client() — then provider
-        defaults, then global temperature if neither layer has anything.
-        Saving this table commits the merge into the profile (see
-        _commit_profile_fields), not the global layer.
+        That is the profile's own params and nothing else — the legacy
+        cfg.model_params dict is not read here or in create_client, so a
+        row removed from this table stays removed. When the profile states
+        nothing, seed the table from the provider preset's default_params,
+        and failing that from the global temperature.
         """
         if cfg is None:
             cfg = get_config()
@@ -1295,9 +1298,7 @@ class SettingsDialog(QDialog):
             profile = self._profiles.get(
                 getattr(self, "_current_profile_label", None))
 
-        params = dict(cfg.model_params.get(model_name, {}))
-        if profile is not None:
-            params.update(profile.params)
+        params = dict(profile.params) if profile is not None else {}
 
         if not params:
             # No saved params — try provider defaults
@@ -1410,8 +1411,8 @@ class SettingsDialog(QDialog):
         cfg.execution_timeout = self.execution_timeout_spin.value()
 
         # Model params reach the profile via _commit_profile_fields above
-        # (prof.params = the table's effective merge) — cfg.model_params
-        # stays the global layer and is no longer written from here.
+        # (prof.params = the table, in full) — cfg.model_params is legacy
+        # and is neither read nor written from here.
         model_name = self.model_edit.text().strip()
         if model_name:
             params = self._read_model_params_table()

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -11,6 +11,7 @@ Provides a GUI for configuring:
   - Test connection button
 """
 
+import copy
 import os
 import secrets
 
@@ -48,18 +49,41 @@ from ..llm.providers import get_provider_names
 
 
 class _TestConnectionThread(QThread):
-    """Background thread for testing LLM connection and detecting capabilities."""
+    """Background thread for testing LLM connection and detecting capabilities.
+
+    Takes provider/URL/key/model/model_params as arguments rather than
+    reading config — so the user can test before saving, and so a profile
+    that isn't cfg.active_profile can't have its values smuggled into the
+    active one through the singleton (see _TestRerankerThread).
+    """
     finished = Signal(bool, str)        # success, message
     vision_result = Signal(bool)        # vision probe result
     capabilities_result = Signal(dict)  # full caps dict (Ollama: vision/tools/thinking)
 
-    def __init__(self, parent=None):
+    def __init__(self, provider_name, base_url, api_key, model,
+                 model_params, parent=None):
         super().__init__(parent)
+        self._provider = provider_name
+        self._base_url = base_url
+        self._api_key = api_key
+        self._model = model
+        self._model_params = dict(model_params or {})
 
     def run(self):
         try:
-            from ..llm.client import create_client_from_config
-            client = create_client_from_config()
+            from ..config import get_config
+            from ..llm.client import LLMClient
+            cfg = get_config()
+            client = LLMClient(
+                provider_name=self._provider,
+                base_url=self._base_url,
+                api_key=self._api_key,
+                model=self._model,
+                max_tokens=cfg.max_tokens,
+                temperature=cfg.temperature,
+                thinking=cfg.thinking,
+                model_params=self._model_params,
+            )
             response = client.test_connection()
             self.finished.emit(True, translate("SettingsDialog", "Connected! Response: ") + response)
 
@@ -923,8 +947,16 @@ class SettingsDialog(QDialog):
         """Populate fields from the current config."""
         cfg = self._cfg = get_config()
 
+        # Profile edits stay dialog-local until OK. cfg is the live singleton,
+        # so mutating its profiles in place makes Cancel a no-op — and an
+        # unrelated save_current_config() (the vision probe calls one) would
+        # flush a discarded edit to disk.
+        self._profiles = copy.deepcopy(cfg.profiles)
+        self._active_profile = cfg.active_profile
+        self._utility_profiles = dict(cfg.utility_profiles)
+
         self._refresh_profile_combo()
-        self._show_profile(cfg.active_profile)
+        self._show_profile(self._active_profile)
 
         self.max_tokens_spin.setValue(cfg.max_tokens)
         self.context_window_spin.setValue(cfg.context_window)
@@ -1026,42 +1058,42 @@ class SettingsDialog(QDialog):
             raise ValueError("Profile name cannot be empty")
         if old == new:
             return
-        if new in self._cfg.profiles:
+        if new in self._profiles:
             raise ValueError(f"A profile named {new!r} already exists")
-        if old not in self._cfg.profiles:
+        if old not in self._profiles:
             raise ValueError(f"No profile named {old!r}")
         # Rebuild in place so the combo's order does not shuffle.
-        self._cfg.profiles = {
+        self._profiles = {
             (new if label == old else label): prof
-            for label, prof in self._cfg.profiles.items()
+            for label, prof in self._profiles.items()
         }
-        if self._cfg.active_profile == old:
-            self._cfg.active_profile = new
-        for utility, label in list(self._cfg.utility_profiles.items()):
+        if self._active_profile == old:
+            self._active_profile = new
+        for utility, label in list(self._utility_profiles.items()):
             if label == old:
-                self._cfg.utility_profiles[utility] = new
+                self._utility_profiles[utility] = new
 
     def _delete_profile(self, label: str) -> None:
         """Remove a profile, leaving nothing pointing at it."""
-        if label not in self._cfg.profiles:
+        if label not in self._profiles:
             raise ValueError(f"No profile named {label!r}")
-        if len(self._cfg.profiles) == 1:
+        if len(self._profiles) == 1:
             raise ValueError("At least one profile is required")
-        del self._cfg.profiles[label]
-        if self._cfg.active_profile == label:
-            self._cfg.active_profile = next(iter(self._cfg.profiles))
-        for utility, mapped in list(self._cfg.utility_profiles.items()):
+        del self._profiles[label]
+        if self._active_profile == label:
+            self._active_profile = next(iter(self._profiles))
+        for utility, mapped in list(self._utility_profiles.items()):
             if mapped == label:
-                self._cfg.utility_profiles[utility] = ""
+                self._utility_profiles[utility] = ""
 
     def _refresh_profile_combo(self) -> None:
         """Repopulate the profile combo without firing its handler."""
         self.profile_combo.blockSignals(True)
         try:
             self.profile_combo.clear()
-            for label in self._cfg.profiles:
+            for label in self._profiles:
                 self.profile_combo.addItem(label, label)
-            idx = self.profile_combo.findData(self._cfg.active_profile)
+            idx = self.profile_combo.findData(self._active_profile)
             if idx >= 0:
                 self.profile_combo.setCurrentIndex(idx)
         finally:
@@ -1074,7 +1106,7 @@ class SettingsDialog(QDialog):
         is not lost — the #75 complaint, from the other direction.
         """
         label = getattr(self, "_current_profile_label", None)
-        prof = self._cfg.profiles.get(label)
+        prof = self._profiles.get(label)
         if prof is None:
             return
         names = get_provider_names()
@@ -1087,7 +1119,7 @@ class SettingsDialog(QDialog):
 
     def _show_profile(self, label: str) -> None:
         """Populate the connection widgets from a profile."""
-        prof = self._cfg.profiles[label]
+        prof = self._profiles[label]
         self._current_profile_label = label
         names = get_provider_names()
         try:
@@ -1112,17 +1144,17 @@ class SettingsDialog(QDialog):
         if not label or label == getattr(self, "_current_profile_label", None):
             return
         self._commit_profile_fields()
-        self._cfg.active_profile = label
+        self._active_profile = label
         self._show_profile(label)
 
     def _on_profile_add(self):
         base = translate("SettingsDialog", "New profile")
         label, n = base, 2
-        while label in self._cfg.profiles:
+        while label in self._profiles:
             label, n = f"{base} {n}", n + 1
         self._commit_profile_fields()
-        self._cfg.profiles[label] = ProviderConfig()
-        self._cfg.active_profile = label
+        self._profiles[label] = ProviderConfig()
+        self._active_profile = label
         self._refresh_profile_combo()
         self._show_profile(label)
 
@@ -1157,7 +1189,7 @@ class SettingsDialog(QDialog):
                 self, translate("SettingsDialog", "Delete profile"), str(e))
             return
         self._refresh_profile_combo()
-        self._show_profile(self._cfg.active_profile)
+        self._show_profile(self._active_profile)
 
     def _on_provider_changed(self, index):
         """Update base URL, model, and default params when provider changes."""
@@ -1356,12 +1388,18 @@ class SettingsDialog(QDialog):
     def _save(self):
         """Save settings to config and close."""
         cfg = get_config()
-        names = get_provider_names()
-        idx = self.provider_combo.currentIndex()
-        cfg.provider.name = names[idx] if 0 <= idx < len(names) else "anthropic"
-        cfg.provider.api_key = self.api_key_edit.text()
-        cfg.provider.base_url = self.base_url_edit.text()
-        cfg.provider.model = self.model_edit.text()
+
+        # Profile edits (add/rename/delete/field changes) have lived in the
+        # dialog-local working copy since _load_from_config. OK is the only
+        # point where they land in the real config — commit the visible
+        # widgets into the currently-shown profile first, then write the
+        # whole working copy back. cfg.provider (a property resolving
+        # profiles[active_profile]) then reads correctly for everything
+        # below, with no separate provider.* writes needed.
+        self._commit_profile_fields()
+        cfg.profiles = copy.deepcopy(self._profiles)
+        cfg.active_profile = self._active_profile
+
         cfg.max_tokens = self.max_tokens_spin.value()
         cfg.context_window = self.context_window_spin.value()
         cfg.max_tool_turns = self.max_tool_turns_spin.value()
@@ -1633,13 +1671,28 @@ class SettingsDialog(QDialog):
         """Test the LLM connection in a background thread."""
         self._save_temp()
 
+        # Resolve provider/URL/key/model/params from the visible widgets
+        # directly, rather than through cfg — the visible profile may not be
+        # cfg.active_profile (e.g. a profile added but not yet saved), and
+        # writing it into the singleton would smuggle it into the wrong
+        # profile (see _save_temp).
+        names = get_provider_names()
+        idx = self.provider_combo.currentIndex()
+        provider_name = names[idx] if 0 <= idx < len(names) else "anthropic"
+        base_url = self.base_url_edit.text()
+        api_key = self.api_key_edit.text()
+        model = self.model_edit.text()
+        model_params = self._read_model_params_table()
+
         self.test_btn.setEnabled(False)
         self.save_btn.setEnabled(False)
         self.cancel_btn.setEnabled(False)
         self.test_status.setText(translate("SettingsDialog", "Testing..."))
         self.test_status.setStyleSheet("color: #666;")
 
-        self._test_thread = _TestConnectionThread(self)
+        self._test_thread = _TestConnectionThread(
+            provider_name, base_url, api_key, model, model_params, self,
+        )
         self._test_thread.finished.connect(self._on_test_finished)
         self._test_thread.vision_result.connect(self._on_vision_probed)
         self._test_thread.capabilities_result.connect(self._on_capabilities_detected)
@@ -1713,14 +1766,15 @@ class SettingsDialog(QDialog):
                 pass
 
     def _save_temp(self):
-        """Temporarily apply current UI values to config (for test connection)."""
+        """Temporarily apply current UI values to config (for test connection).
+
+        Connection fields (provider/base_url/api_key/model) are deliberately
+        NOT written here — _test_connection reads them straight from the
+        widgets and hands them to _TestConnectionThread, so testing a
+        profile that isn't cfg.active_profile can't leak its values into the
+        active one through this singleton write.
+        """
         cfg = get_config()
-        names = get_provider_names()
-        idx = self.provider_combo.currentIndex()
-        cfg.provider.name = names[idx] if 0 <= idx < len(names) else "anthropic"
-        cfg.provider.api_key = self.api_key_edit.text()
-        cfg.provider.base_url = self.base_url_edit.text()
-        cfg.provider.model = self.model_edit.text()
 
         try:
             cfg.max_tokens = self.max_tokens_spin.value()

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -15,7 +15,7 @@ import copy
 import os
 import secrets
 
-from .compat import QtWidgets, QtCore, QtGui
+from .compat import QtWidgets, QtCore, QtGui, QT_TRANSLATE_NOOP
 from ..i18n import translate
 
 QDialog = QtWidgets.QDialog
@@ -202,11 +202,18 @@ class SettingsDialog(QDialog):
     # Call sites that can run on their own profile. The identifier is the
     # contract with create_client(cfg, utility); adding a new one here and
     # at its call site is the whole opt-in.
+    # The labels are QT_TRANSLATE_NOOP-wrapped so pylupdate5 (which
+    # extracts string literals only) finds them here; the use site below
+    # runs them through translate() to resolve them at runtime.
     UTILITIES = [
-        ("compaction", "Context compaction"),
-        ("skill_eval", "Skill evaluation"),
-        ("tool_optimize", "Tool optimisation"),
-        ("rerank", "Tool reranking"),
+        ("compaction",
+         QT_TRANSLATE_NOOP("SettingsDialog", "Context compaction")),
+        ("skill_eval",
+         QT_TRANSLATE_NOOP("SettingsDialog", "Skill evaluation")),
+        ("tool_optimize",
+         QT_TRANSLATE_NOOP("SettingsDialog", "Tool optimisation")),
+        ("rerank",
+         QT_TRANSLATE_NOOP("SettingsDialog", "Tool reranking")),
     ]
 
     @classmethod
@@ -646,7 +653,7 @@ class SettingsDialog(QDialog):
         # utility dropdown's selection, or the active profile when it is
         # left on "inherit") without waiting for the user to send a real
         # message. The reranker's connection is a profile now, not a
-        # bespoke override group — see the Utility models group below.
+        # bespoke override group — see the Utility models group above.
         test_layout = QHBoxLayout()
         self._rerank_test_btn = QPushButton(
             translate("SettingsDialog", "Test Reranker"))

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -199,6 +199,33 @@ class _TestRerankerThread(QThread):
 class SettingsDialog(QDialog):
     """Configuration dialog for FreeCAD AI."""
 
+    # Call sites that can run on their own profile. The identifier is the
+    # contract with create_client(cfg, utility); adding a new one here and
+    # at its call site is the whole opt-in.
+    UTILITIES = [
+        ("compaction", "Context compaction"),
+        ("skill_eval", "Skill evaluation"),
+        ("tool_optimize", "Tool optimisation"),
+        ("rerank", "Tool reranking"),
+    ]
+
+    @classmethod
+    def _collect_utility_profiles(cls, selections: dict) -> dict:
+        """Turn dropdown selections into the config mapping.
+
+        An empty selection means inherit the active profile and is stored
+        by omission, so config.json carries only real overrides.
+
+        A classmethod because it touches no widgets — that is what makes
+        it testable without constructing a dialog.
+        """
+        known = {u for u, _ in cls.UTILITIES}
+        return {
+            utility: label
+            for utility, label in selections.items()
+            if utility in known and label
+        }
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle(translate("SettingsDialog", "FreeCAD AI Settings"))
@@ -207,7 +234,6 @@ class SettingsDialog(QDialog):
         self.resize(540, 700)
         self._test_thread = None
         self._last_default_prompt = ""
-        self._rerank_last_model = ""
         self._cfg = get_config()
         self._build_ui()
         self._load_from_config()
@@ -278,6 +304,27 @@ class SettingsDialog(QDialog):
 
         provider_group.setLayout(provider_layout)
         layout.addWidget(provider_group)
+
+        # ── Utilities ───────────────────────────────────────────────
+        # Below the profile fields they refer to, so the reading order is
+        # "define connections, then say which one each job uses."
+        self.utility_group = QGroupBox(translate(
+            "SettingsDialog", "Utility models"))
+        util_form = QFormLayout()
+        self.utility_combos = {}
+        for utility, ulabel in self.UTILITIES:
+            combo = QComboBox()
+            combo.setToolTip(translate(
+                "SettingsDialog",
+                "Which profile this job runs on. Leave inherited to use "
+                "the active profile."))
+            combo.currentIndexChanged.connect(
+                lambda index, u=utility: self._on_utility_combo_changed(u, index))
+            self.utility_combos[utility] = combo
+            util_form.addRow(
+                translate("SettingsDialog", ulabel) + ":", combo)
+        self.utility_group.setLayout(util_form)
+        layout.addWidget(self.utility_group)
 
         # Model Parameters group — fixed fields + freeform key-value table
         model_params_group = QGroupBox(translate("SettingsDialog", "Model Parameters"))
@@ -558,8 +605,6 @@ class SettingsDialog(QDialog):
                       "LLM: semantic ranking via a small/fast LLM\n"
                       "Both keyword and LLM include pinned tools unconditionally.")
         )
-        self.rerank_method_combo.currentIndexChanged.connect(
-            self._on_rerank_method_changed)
         method_layout.addWidget(self.rerank_method_combo)
         method_layout.addStretch()
         rerank_layout.addLayout(method_layout)
@@ -583,100 +628,18 @@ class SettingsDialog(QDialog):
         pinned_layout.addWidget(self.rerank_pinned_edit)
         rerank_layout.addLayout(pinned_layout)
 
-        # LLM reranker provider override — only relevant when method == "llm".
-        # Fields left empty inherit the main provider's settings.
-        self.rerank_llm_group = QGroupBox(
-            translate("SettingsDialog", "LLM reranker provider (empty = same as main)"))
-        llm_form = QFormLayout()
-
-        self.rerank_llm_provider_combo = QComboBox()
-        self.rerank_llm_provider_combo.addItem(
-            translate("SettingsDialog", "(same as main)"), "")
-        for name in get_provider_names():
-            self.rerank_llm_provider_combo.addItem(name.capitalize(), name)
-        llm_form.addRow(translate("SettingsDialog", "Provider:"),
-                        self.rerank_llm_provider_combo)
-
-        self.rerank_llm_base_url_edit = QLineEdit()
-        self.rerank_llm_base_url_edit.setPlaceholderText(
-            translate("SettingsDialog", "inherit from main"))
-        llm_form.addRow(translate("SettingsDialog", "Base URL:"),
-                        self.rerank_llm_base_url_edit)
-
-        self.rerank_llm_api_key_edit = QLineEdit()
-        self.rerank_llm_api_key_edit.setEchoMode(QLineEdit.Password)
-        self.rerank_llm_api_key_edit.setPlaceholderText(
-            translate("SettingsDialog", "inherit from main"))
-        llm_form.addRow(translate("SettingsDialog", "API key:"),
-                        self.rerank_llm_api_key_edit)
-
-        self.rerank_llm_model_edit = QLineEdit()
-        self.rerank_llm_model_edit.setPlaceholderText(
-            translate("SettingsDialog", "inherit from main"))
-        # textChanged fires on every keystroke, so toggling between
-        # inherit/override updates the params table live — users who type
-        # a model and click Save immediately still see the right table.
-        self.rerank_llm_model_edit.textChanged.connect(
-            self._on_rerank_model_changed)
-        llm_form.addRow(translate("SettingsDialog", "Model:"),
-                        self.rerank_llm_model_edit)
-
-        # Per-model parameters for the reranker's effective model. Written
-        # back into the shared cfg.model_params dict so a given model's
-        # params are consistent whether the model is used as main, reranker,
-        # or both. When the reranker inherits the main model (override
-        # field empty), the table is prefilled with the main model's
-        # current params and locked read-only — edits belong on the main
-        # Model Parameters table. When an override model is set, the table
-        # is editable and writes to that model's slot in model_params.
-        self._rerank_params_label = QLabel()
-        llm_form.addRow(self._rerank_params_label)
-
-        self.rerank_params_table = QTableWidget(0, 2)
-        self.rerank_params_table.setHorizontalHeaderLabels([
-            translate("SettingsDialog", "Parameter"),
-            translate("SettingsDialog", "Value"),
-        ])
-        self.rerank_params_table.horizontalHeader().setStretchLastSection(True)
-        self.rerank_params_table.horizontalHeader().setSectionResizeMode(
-            0, QHeaderView.Interactive)
-        self.rerank_params_table.setColumnWidth(0, 160)
-        self.rerank_params_table.setMaximumHeight(120)
-        self.rerank_params_table.setToolTip(
-            translate("SettingsDialog",
-                      "Parameters for the reranker's model. Merged into the\n"
-                      "API request body just like main model parameters.\n"
-                      "Common: temperature, top_p, top_k, num_predict."))
-        llm_form.addRow(self.rerank_params_table)
-
-        rp_btn_layout = QHBoxLayout()
-        self._rerank_add_btn = QPushButton(translate("SettingsDialog", "Add"))
-        self._rerank_add_btn.clicked.connect(self._add_rerank_param)
-        rp_btn_layout.addWidget(self._rerank_add_btn)
-
-        self._rerank_remove_btn = QPushButton(translate("SettingsDialog", "Remove"))
-        self._rerank_remove_btn.clicked.connect(self._remove_rerank_param)
-        rp_btn_layout.addWidget(self._rerank_remove_btn)
-
-        self._rerank_defaults_btn = QPushButton(translate("SettingsDialog", "Load Defaults"))
-        self._rerank_defaults_btn.setToolTip(
-            translate("SettingsDialog",
-                      "Load recommended parameters for the reranker's provider"))
-        self._rerank_defaults_btn.clicked.connect(self._load_rerank_default_params)
-        rp_btn_layout.addWidget(self._rerank_defaults_btn)
-        rp_btn_layout.addStretch()
-        llm_form.addRow(rp_btn_layout)
-
-        # Test button — validates the reranker call without waiting for the
-        # user to send a message. Uses current dialog values, not disk, so
-        # the user can iterate on params before saving.
+        # Test button — probes the reranker's resolved profile (the rerank
+        # utility dropdown's selection, or the active profile when it is
+        # left on "inherit") without waiting for the user to send a real
+        # message. The reranker's connection is a profile now, not a
+        # bespoke override group — see the Utility models group below.
         test_layout = QHBoxLayout()
         self._rerank_test_btn = QPushButton(
             translate("SettingsDialog", "Test Reranker"))
         self._rerank_test_btn.setToolTip(
             translate("SettingsDialog",
-                      "Send a small test prompt to the reranker LLM using the\n"
-                      "current dialog settings. Reports success or the exact\n"
+                      "Send a small test prompt to the reranker LLM using\n"
+                      "its resolved profile. Reports success or the exact\n"
                       "error from the provider — useful for diagnosing 4xx\n"
                       "errors, timeouts, or unparseable responses."))
         self._rerank_test_btn.clicked.connect(self._test_reranker)
@@ -685,10 +648,7 @@ class SettingsDialog(QDialog):
         self._rerank_test_status.setWordWrap(True)
         self._rerank_test_status.setStyleSheet("color: #666;")
         test_layout.addWidget(self._rerank_test_status, 1)
-        llm_form.addRow(test_layout)
-
-        self.rerank_llm_group.setLayout(llm_form)
-        rerank_layout.addWidget(self.rerank_llm_group)
+        rerank_layout.addLayout(test_layout)
 
         rerank_group.setLayout(rerank_layout)
         layout.addWidget(rerank_group)
@@ -974,21 +934,6 @@ class SettingsDialog(QDialog):
         self.rerank_top_n_spin.setValue(cfg.rerank_top_n)
         self.rerank_pinned_edit.setText(", ".join(cfg.rerank_pinned_tools))
 
-        # LLM reranker provider override
-        provider_idx = self.rerank_llm_provider_combo.findData(
-            cfg.rerank_llm_provider_name)
-        if provider_idx >= 0:
-            self.rerank_llm_provider_combo.setCurrentIndex(provider_idx)
-        else:
-            self.rerank_llm_provider_combo.setCurrentIndex(0)
-        self.rerank_llm_base_url_edit.setText(cfg.rerank_llm_base_url)
-        self.rerank_llm_api_key_edit.setText(cfg.rerank_llm_api_key)
-        self.rerank_llm_model_edit.setText(cfg.rerank_llm_model)
-        # Force a fresh resolve (setText above may have fired the signal mid-load)
-        self._rerank_last_model = ""
-        self._on_rerank_model_changed()
-        self._on_rerank_method_changed(self.rerank_method_combo.currentIndex())
-
         thinking_map = {"off": 0, "on": 1, "extended": 2}
         self.thinking_combo.setCurrentIndex(thinking_map.get(cfg.thinking, 0))
 
@@ -1098,6 +1043,39 @@ class SettingsDialog(QDialog):
                 self.profile_combo.setCurrentIndex(idx)
         finally:
             self.profile_combo.blockSignals(False)
+        self._refresh_utility_combos()
+
+    def _refresh_utility_combos(self) -> None:
+        """Repopulate every utility dropdown from the working copy.
+
+        Reads self._profiles, not self._cfg.profiles: a profile added or
+        renamed in this dialog session must appear in these lists before
+        the user presses OK.
+        """
+        for utility, combo in self.utility_combos.items():
+            current = self._utility_profiles.get(utility, "")
+            combo.blockSignals(True)
+            try:
+                combo.clear()
+                combo.addItem(translate(
+                    "SettingsDialog", "(same as active profile)"), "")
+                for label in self._profiles:
+                    combo.addItem(label, label)
+                idx = combo.findData(current)
+                combo.setCurrentIndex(idx if idx >= 0 else 0)
+            finally:
+                combo.blockSignals(False)
+
+    def _on_utility_combo_changed(self, utility: str, index: int) -> None:
+        """Track a utility dropdown's live selection in the working copy.
+
+        Without this, _utility_profiles only reflects what was loaded when
+        the dialog opened, and both _refresh_utility_combos (on a rename or
+        delete elsewhere in the dialog) and the rerank probe would read
+        stale state instead of the user's in-progress choice.
+        """
+        combo = self.utility_combos[utility]
+        self._utility_profiles[utility] = combo.itemData(index) or ""
 
     def _commit_profile_fields(self) -> None:
         """Write the visible connection widgets back into their profile.
@@ -1421,6 +1399,10 @@ class SettingsDialog(QDialog):
         self._commit_profile_fields()
         cfg.profiles = copy.deepcopy(self._profiles)
         cfg.active_profile = self._active_profile
+        cfg.utility_profiles = self._collect_utility_profiles({
+            utility: combo.currentData()
+            for utility, combo in self.utility_combos.items()
+        })
 
         cfg.max_tokens = self.max_tokens_spin.value()
         cfg.context_window = self.context_window_spin.value()
@@ -1492,21 +1474,6 @@ class SettingsDialog(QDialog):
             s.strip() for s in pinned_text.split(",") if s.strip()
         ] if pinned_text else []
 
-        # LLM reranker provider override
-        cfg.rerank_llm_provider_name = (
-            self.rerank_llm_provider_combo.currentData() or "")
-        cfg.rerank_llm_base_url = self.rerank_llm_base_url_edit.text().strip()
-        cfg.rerank_llm_api_key = self.rerank_llm_api_key_edit.text().strip()
-        rerank_model = self.rerank_llm_model_edit.text().strip()
-        cfg.rerank_llm_model = rerank_model
-
-        # Save the reranker params into their own namespace (cfg.rerank_params),
-        # never the shared model_params dict. In inherit mode the reranker has
-        # no params of its own — the main Model Parameters table owns the main
-        # model's slot, so the reranker can't clobber it (issue #30).
-        cfg.rerank_params = self._resolve_rerank_params(
-            rerank_model, self._read_rerank_params_table())
-
         save_current_config()
 
         # The menu's "Keep Chat Panel Open" tick mirrors this flag, and
@@ -1518,140 +1485,41 @@ class SettingsDialog(QDialog):
 
         self.accept()
 
-    def _on_rerank_method_changed(self, index: int):
-        """Show the LLM provider subgroup only when 'LLM' is selected."""
-        self.rerank_llm_group.setVisible(index == 2)
-
-    @staticmethod
-    def _resolve_rerank_params(rerank_model: str, table_params: dict) -> dict:
-        """Reranker params to persist into cfg.rerank_params.
-
-        Override mode (a distinct model is set) → persist the table. Inherit
-        mode (empty override) → persist nothing; the reranker reads the main
-        model's params at runtime and the main Model Parameters table owns
-        that slot, so the reranker can never overwrite it (issue #30).
-        """
-        return dict(table_params) if rerank_model.strip() else {}
-
-    def _on_rerank_model_changed(self, *_args):
-        """Refresh the reranker params table for the current model state.
-
-        - Empty override → mirror the main Model Parameters table's live
-          values (edits belong on the main table; the reranker inherits them).
-        - Non-empty override → show the reranker's own params. Renaming the
-          override model keeps the current edits (params are a single set, not
-          keyed per model); entering override from inherit loads the saved
-          cfg.rerank_params, falling back to provider defaults.
-        """
-        cfg = get_config()
-        prev_model = getattr(self, "_rerank_last_model", "") or ""
-        model = self.rerank_llm_model_edit.text().strip()
-        self._rerank_last_model = model
-
-        if not model:
-            # Inherit: show the main model's live params (reflects in-dialog
-            # edits there). These are not persisted under the reranker — the
-            # main table is authoritative.
-            self._populate_rerank_params_table(self._read_model_params_table())
-            self._rerank_params_label.setText(translate(
-                "SettingsDialog",
-                "Model parameters (inheriting main model — edit on the main table):"))
-            return
-
-        if prev_model:
-            # Was already overriding — the user just renamed the model.
-            # Keep the current edits (single param set, not per-model).
-            self._rerank_params_label.setText(translate(
-                "SettingsDialog", "Model parameters (reranker override):"))
-            return
-
-        # Entering override from inherit: load saved reranker params, else
-        # provider defaults.
-        params = dict(cfg.rerank_params)
-        if not params:
-            provider_name = (
-                self.rerank_llm_provider_combo.currentData()
-                or cfg.provider.name
-            )
-            preset = PROVIDER_PRESETS.get(provider_name, {})
-            params = dict(preset.get("default_params", {}))
-        self._populate_rerank_params_table(params)
-        self._rerank_params_label.setText(translate(
-            "SettingsDialog", "Model parameters (reranker override):"))
-
-    def _populate_rerank_params_table(self, params: dict):
-        self.rerank_params_table.setRowCount(0)
-        for key, value in params.items():
-            row = self.rerank_params_table.rowCount()
-            self.rerank_params_table.insertRow(row)
-            self.rerank_params_table.setItem(row, 0, QTableWidgetItem(str(key)))
-            self.rerank_params_table.setItem(row, 1, QTableWidgetItem(str(value)))
-
-    def _read_rerank_params_table(self) -> dict:
-        params = {}
-        for row in range(self.rerank_params_table.rowCount()):
-            key_item = self.rerank_params_table.item(row, 0)
-            val_item = self.rerank_params_table.item(row, 1)
-            if not key_item or not val_item:
-                continue
-            key = key_item.text().strip()
-            val_str = val_item.text().strip()
-            if not key:
-                continue
-            try:
-                if "." in val_str or "e" in val_str.lower():
-                    params[key] = float(val_str)
-                else:
-                    params[key] = int(val_str)
-            except ValueError:
-                if val_str.lower() in ("true", "false"):
-                    params[key] = val_str.lower() == "true"
-                else:
-                    params[key] = val_str
-        return params
-
-    def _add_rerank_param(self):
-        row = self.rerank_params_table.rowCount()
-        self.rerank_params_table.insertRow(row)
-        self.rerank_params_table.setItem(row, 0, QTableWidgetItem(""))
-        self.rerank_params_table.setItem(row, 1, QTableWidgetItem(""))
-        self.rerank_params_table.editItem(self.rerank_params_table.item(row, 0))
-
-    def _remove_rerank_param(self):
-        row = self.rerank_params_table.currentRow()
-        if row >= 0:
-            self.rerank_params_table.removeRow(row)
-
     def _test_reranker(self):
-        """Send a small probe prompt to the reranker LLM using dialog values.
+        """Send a small probe prompt to the reranker LLM using its resolved
+        profile — the rerank utility dropdown's selection, falling back to
+        the active profile when it is left on "inherit".
 
         Surfaces success or the exact error so the user can debug a broken
         reranker config (HTTP 4xx, auth failure, timeouts, hallucinations)
         without sending a real chat message and parsing the Report View.
+
+        Mirrors _test_connection: resolve through the same helpers runtime
+        uses (create_client's own resolve_profile/resolve_params), so this
+        probe cannot drift from what Act mode will actually build.
         """
-        # Resolve effective provider/URL/key/model from dialog state.
-        # Empty fields inherit from the main fields (same as runtime behavior).
-        provider = (self.rerank_llm_provider_combo.currentData() or "").strip()
-        if not provider:
-            names = get_provider_names()
-            idx = self.provider_combo.currentIndex()
-            provider = names[idx] if 0 <= idx < len(names) else ""
+        # An in-progress edit on the visible profile should be what gets
+        # probed, not whatever was last committed.
+        self._commit_profile_fields()
 
-        base_url = self.rerank_llm_base_url_edit.text().strip() \
-            or self.base_url_edit.text().strip()
-        api_key = self.rerank_llm_api_key_edit.text().strip() \
-            or self.api_key_edit.text().strip()
-        model = self.rerank_llm_model_edit.text().strip() \
-            or self.model_edit.text().strip()
-        # Effective params: use the reranker table (reflects current state
-        # for both inherit and override modes).
-        model_params = self._read_rerank_params_table()
-
-        if not model:
+        # Read the dropdown's live selection, not self._utility_profiles —
+        # that mapping is only written back into it on Save.
+        label = self.utility_combos["rerank"].currentData() or ""
+        profile = self._profiles.get(label) or self._profiles.get(
+            self._active_profile)
+        if profile is None:
             self._rerank_test_status.setText(translate(
-                "SettingsDialog", "No model configured"))
+                "SettingsDialog", "No profile configured"))
             self._rerank_test_status.setStyleSheet("color: #c62828;")
             return
+
+        from ..llm.client import resolve_params
+        base_url = profile.base_url
+        # Matches create_client()'s fallback exactly (see _test_connection).
+        api_key = profile.api_key or self._cfg.provider_keys.get(
+            profile.name, "")
+        model = profile.model
+        model_params = resolve_params(self._cfg, profile)
 
         self._rerank_test_btn.setEnabled(False)
         self._rerank_test_status.setText(translate(
@@ -1659,7 +1527,7 @@ class SettingsDialog(QDialog):
         self._rerank_test_status.setStyleSheet("color: #666;")
 
         self._rerank_test_thread = _TestRerankerThread(
-            provider, base_url, api_key, model, model_params, self,
+            profile.name, base_url, api_key, model, model_params, self,
         )
         self._rerank_test_thread.finished.connect(
             self._on_rerank_test_finished)
@@ -1676,18 +1544,6 @@ class SettingsDialog(QDialog):
             self._rerank_test_status.setText(
                 translate("SettingsDialog", "Error") + ": " + message)
             self._rerank_test_status.setStyleSheet("color: #c62828;")
-
-    def _load_rerank_default_params(self):
-        """Reset the reranker params table to the reranker provider's defaults."""
-        provider_name = (
-            self.rerank_llm_provider_combo.currentData()
-            or get_config().provider.name
-        )
-        preset = PROVIDER_PRESETS.get(provider_name, {})
-        params = dict(preset.get("default_params", {}))
-        if not params:
-            params = {"temperature": 0.3}
-        self._populate_rerank_params_table(params)
 
     def _test_connection(self):
         """Test the LLM connection in a background thread."""

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -270,6 +270,20 @@ class SettingsDialog(QDialog):
             profile_row.addWidget(b)
         provider_layout.addRow(translate("SettingsDialog", "Profile:"), profile_row)
 
+        # Selecting a profile in the combo means "edit this one". Chat runs
+        # on the profile this box is ticked for, and nothing else moves it.
+        self.profile_active_check = QCheckBox(translate(
+            "SettingsDialog", "Use this profile for chat"))
+        self.profile_active_check.setToolTip(translate(
+            "SettingsDialog",
+            "The ticked profile is the one the main chat runs on.\n"
+            "Utilities below inherit it unless they name their own.\n"
+            "To move it, tick a different profile — there is always\n"
+            "exactly one."))
+        self.profile_active_check.toggled.connect(
+            self._on_profile_active_toggled)
+        provider_layout.addRow("", self.profile_active_check)
+
         self.profile_combo.currentIndexChanged.connect(self._on_profile_changed)
         self.profile_add_btn.clicked.connect(self._on_profile_add)
         self.profile_rename_btn.clicked.connect(self._on_profile_rename)
@@ -1032,15 +1046,34 @@ class SettingsDialog(QDialog):
                 self._utility_profiles[utility] = ""
 
     def _refresh_profile_combo(self) -> None:
-        """Repopulate the profile combo without firing its handler."""
+        """Repopulate the profile combo without firing its handler.
+
+        The active profile is marked in the item *text* only; the item
+        data stays the bare label, because _on_profile_changed and
+        findData both key off it.
+
+        The selection follows the profile being edited, not the active
+        one. Browsing no longer moves active, so re-selecting by
+        _active_profile here would yank the combo back to it after every
+        add, rename and delete. Falls back to the active profile, and
+        then to the first entry, for the delete path — where the label
+        being edited is the one that just went away.
+        """
         self.profile_combo.blockSignals(True)
         try:
             self.profile_combo.clear()
             for label in self._profiles:
-                self.profile_combo.addItem(label, label)
-            idx = self.profile_combo.findData(self._active_profile)
-            if idx >= 0:
-                self.profile_combo.setCurrentIndex(idx)
+                text = (f"{label} (active)" if label == self._active_profile
+                        else label)
+                self.profile_combo.addItem(text, label)
+            for candidate in (getattr(self, "_current_profile_label", None),
+                              self._active_profile):
+                idx = self.profile_combo.findData(candidate) if candidate else -1
+                if idx >= 0:
+                    self.profile_combo.setCurrentIndex(idx)
+                    break
+            else:
+                self.profile_combo.setCurrentIndex(0)
         finally:
             self.profile_combo.blockSignals(False)
         self._refresh_utility_combos()
@@ -1124,12 +1157,40 @@ class SettingsDialog(QDialog):
         self.model_edit.setText(prof.model)
         self._load_model_params_table(prof.model, self._cfg, prof)
 
+        is_active = label == self._active_profile
+        # blockSignals, or populating the widgets would itself re-point
+        # chat through _on_profile_active_toggled.
+        self.profile_active_check.blockSignals(True)
+        try:
+            self.profile_active_check.setChecked(is_active)
+        finally:
+            self.profile_active_check.blockSignals(False)
+        # Disabled while ticked: there is always exactly one active
+        # profile, so the way to move it is to tick a different one, not
+        # to untick this one.
+        self.profile_active_check.setEnabled(not is_active)
+
+    def _on_profile_active_toggled(self, checked: bool) -> None:
+        """Point chat at the profile currently being edited.
+
+        Only the off->on transition is reachable — _show_profile disables
+        the box while it is ticked — so an untick is a no-op rather than
+        a way to end up with no active profile.
+        """
+        if not checked:
+            return
+        self._active_profile = self._current_profile_label
+        self.profile_active_check.setEnabled(False)
+        self._refresh_profile_combo()
+
     def _on_profile_changed(self, index):
+        # Selects a profile for editing. It deliberately does NOT make it
+        # active: browsing the profiles to see what they hold must not
+        # silently re-point chat on OK.
         label = self.profile_combo.itemData(index)
         if not label or label == getattr(self, "_current_profile_label", None):
             return
         self._commit_profile_fields()
-        self._active_profile = label
         self._show_profile(label)
 
     def _on_profile_add(self):
@@ -1139,9 +1200,11 @@ class SettingsDialog(QDialog):
             label, n = f"{base} {n}", n + 1
         self._commit_profile_fields()
         self._profiles[label] = ProviderConfig()
-        self._active_profile = label
-        self._refresh_profile_combo()
+        # Selected for editing, not made active. _show_profile first, so
+        # the refresh below finds _current_profile_label already pointing
+        # at the new profile and selects it.
         self._show_profile(label)
+        self._refresh_profile_combo()
 
     def _on_profile_rename(self):
         old = self._current_profile_label

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -1116,6 +1116,15 @@ class SettingsDialog(QDialog):
         prof.base_url = self.base_url_edit.text()
         prof.api_key = self.api_key_edit.text()
         prof.model = self.model_edit.text()
+        # Commit the table's effective merge (global cfg.model_params
+        # layered under the profile's own — see _load_model_params_table),
+        # not just whatever the profile already stated. A visited profile
+        # thereby absorbs the global defaults it was inheriting and states
+        # them itself from here on: that keeps "what you saw is what you
+        # saved" true and stops one profile's edit from moving another
+        # profile's values through the shared cfg.model_params layer. Do
+        # not "simplify" this back to a partial dict.
+        prof.params = self._read_model_params_table()
 
     def _show_profile(self, label: str) -> None:
         """Populate the connection widgets from a profile."""
@@ -1137,7 +1146,7 @@ class SettingsDialog(QDialog):
         self.api_key_edit.setText(prof.api_key)
         self.base_url_edit.setText(prof.base_url)
         self.model_edit.setText(prof.model)
-        self._load_model_params_table(prof.model, self._cfg)
+        self._load_model_params_table(prof.model, self._cfg, prof)
 
     def _on_profile_changed(self, index):
         label = self.profile_combo.itemData(index)
@@ -1277,28 +1286,41 @@ class SettingsDialog(QDialog):
         return state == QtCore.Qt.Checked
 
     def _on_model_changed(self):
-        """Save current params under the old model, load params for the new one."""
+        """Stash the edited table on the working-copy profile, load the new model's."""
         new_model = self.model_edit.text().strip()
         if new_model == self._last_model_name or not new_model:
             return
-        # Save current table under old model name (in-memory only)
-        cfg = get_config()
-        if self._last_model_name:
+        # Stash current table on the working-copy profile (never the live
+        # singleton — see _commit_profile_fields for why cfg.model_params
+        # is read-only from this dialog).
+        prof = self._profiles.get(getattr(self, "_current_profile_label", None))
+        if self._last_model_name and prof is not None:
             params = self._read_model_params_table()
             if params:
-                cfg.model_params[self._last_model_name] = params
+                prof.params = params
         # Load params for new model
-        self._load_model_params_table(new_model, cfg)
+        self._load_model_params_table(new_model, self._cfg, prof)
 
-    def _load_model_params_table(self, model_name: str, cfg=None):
-        """Populate the params table for the given model.
+    def _load_model_params_table(self, model_name: str, cfg=None, profile=None):
+        """Populate the params table with the effective resolve_params() merge.
 
-        Priority: saved params for this model > provider defaults > global temperature.
+        Priority: cfg.model_params[model] (the global per-model default
+        layer) with `profile`'s own params layered on top — exactly what
+        resolve_params() computes for create_client() — then provider
+        defaults, then global temperature if neither layer has anything.
+        Saving this table commits the merge into the profile (see
+        _commit_profile_fields), not the global layer.
         """
         if cfg is None:
             cfg = get_config()
+        if profile is None:
+            profile = self._profiles.get(
+                getattr(self, "_current_profile_label", None))
 
-        params = cfg.model_params.get(model_name, {})
+        params = dict(cfg.model_params.get(model_name, {}))
+        if profile is not None:
+            params.update(profile.params)
+
         if not params:
             # No saved params — try provider defaults
             names = get_provider_names()
@@ -1405,15 +1427,15 @@ class SettingsDialog(QDialog):
         cfg.max_tool_turns = self.max_tool_turns_spin.value()
         cfg.execution_timeout = self.execution_timeout_spin.value()
 
-        # Save model parameters for the current model
+        # Model params reach the profile via _commit_profile_fields above
+        # (prof.params = the table's effective merge) — cfg.model_params
+        # stays the global layer and is no longer written from here.
         model_name = self.model_edit.text().strip()
         if model_name:
             params = self._read_model_params_table()
-            if params:
-                cfg.model_params[model_name] = params
-            elif model_name in cfg.model_params:
-                del cfg.model_params[model_name]
-            # Keep global temperature in sync for backward compat
+            # Keep global temperature in sync for backward compat —
+            # cfg.temperature is still the job-level fallback create_client
+            # passes when a profile states no temperature.
             cfg.temperature = params.get("temperature", cfg.temperature)
 
         cfg.enable_tools = self.enable_tools_check.isChecked()
@@ -1680,7 +1702,13 @@ class SettingsDialog(QDialog):
         idx = self.provider_combo.currentIndex()
         provider_name = names[idx] if 0 <= idx < len(names) else "anthropic"
         base_url = self.base_url_edit.text()
-        api_key = self.api_key_edit.text()
+        # Match create_client()'s fallback: an explicit key on the widget
+        # wins, else the vendor-wide default in provider_keys. Without this
+        # a profile that deliberately leaves its own key blank to inherit
+        # the vendor default fails Test Connection even though real chat
+        # works fine.
+        api_key = self.api_key_edit.text() or \
+            self._cfg.provider_keys.get(provider_name, "")
         model = self.model_edit.text()
         model_params = self._read_model_params_table()
 
@@ -1773,6 +1801,12 @@ class SettingsDialog(QDialog):
         widgets and hands them to _TestConnectionThread, so testing a
         profile that isn't cfg.active_profile can't leak its values into the
         active one through this singleton write.
+
+        Model params are the same story: _test_connection reads the table
+        itself and passes it straight to _TestConnectionThread (the vision
+        probe builds its client from that same thread), so writing them
+        into cfg.model_params/cfg.temperature here would feed nothing —
+        it would only leak to disk via the vision-probe's save.
         """
         cfg = get_config()
 
@@ -1788,14 +1822,6 @@ class SettingsDialog(QDialog):
             cfg.max_tool_turns = self.max_tool_turns_spin.value()
         except Exception:
             pass
-
-        # Apply model params temporarily for test connection
-        model_name = self.model_edit.text().strip()
-        if model_name:
-            params = self._read_model_params_table()
-            if params:
-                cfg.model_params[model_name] = params
-                cfg.temperature = params.get("temperature", cfg.temperature)
 
         thinking_values = ["off", "on", "extended"]
         cfg.thinking = thinking_values[self.thinking_combo.currentIndex()]

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -41,8 +41,9 @@ QListWidget = QtWidgets.QListWidget
 QListWidgetItem = QtWidgets.QListWidgetItem
 QFileDialog = QtWidgets.QFileDialog
 QMessageBox = QtWidgets.QMessageBox
+QInputDialog = QtWidgets.QInputDialog
 
-from ..config import get_config, save_current_config, PROVIDER_PRESETS
+from ..config import get_config, save_current_config, PROVIDER_PRESETS, ProviderConfig
 from ..llm.providers import get_provider_names
 
 
@@ -183,6 +184,7 @@ class SettingsDialog(QDialog):
         self._test_thread = None
         self._last_default_prompt = ""
         self._rerank_last_model = ""
+        self._cfg = get_config()
         self._build_ui()
         self._load_from_config()
 
@@ -202,6 +204,26 @@ class SettingsDialog(QDialog):
         # Provider group
         provider_group = QGroupBox(translate("SettingsDialog", "LLM Provider"))
         provider_layout = QFormLayout()
+
+        # ── Profile selector ────────────────────────────────────────
+        profile_row = QHBoxLayout()
+        self.profile_combo = QComboBox()
+        self.profile_combo.setToolTip(translate(
+            "SettingsDialog",
+            "Named connection. Utilities below can each use a different one."))
+        profile_row.addWidget(self.profile_combo, 1)
+        self.profile_add_btn = QPushButton(translate("SettingsDialog", "New"))
+        self.profile_rename_btn = QPushButton(translate("SettingsDialog", "Rename"))
+        self.profile_delete_btn = QPushButton(translate("SettingsDialog", "Delete"))
+        for b in (self.profile_add_btn, self.profile_rename_btn,
+                  self.profile_delete_btn):
+            profile_row.addWidget(b)
+        provider_layout.addRow(translate("SettingsDialog", "Profile:"), profile_row)
+
+        self.profile_combo.currentIndexChanged.connect(self._on_profile_changed)
+        self.profile_add_btn.clicked.connect(self._on_profile_add)
+        self.profile_rename_btn.clicked.connect(self._on_profile_rename)
+        self.profile_delete_btn.clicked.connect(self._on_profile_delete)
 
         self.provider_combo = QComboBox()
         self.provider_combo.addItems([n.capitalize() for n in get_provider_names()])
@@ -899,25 +921,15 @@ class SettingsDialog(QDialog):
 
     def _load_from_config(self):
         """Populate fields from the current config."""
-        cfg = get_config()
+        cfg = self._cfg = get_config()
 
-        names = get_provider_names()
-        try:
-            idx = names.index(cfg.provider.name)
-        except ValueError:
-            idx = 0
-        self.provider_combo.setCurrentIndex(idx)
+        self._refresh_profile_combo()
+        self._show_profile(cfg.active_profile)
 
-        self.api_key_edit.setText(cfg.provider.api_key)
-        self.base_url_edit.setText(cfg.provider.base_url)
-        self.model_edit.setText(cfg.provider.model)
         self.max_tokens_spin.setValue(cfg.max_tokens)
         self.context_window_spin.setValue(cfg.context_window)
         self.max_tool_turns_spin.setValue(cfg.max_tool_turns)
         self.execution_timeout_spin.setValue(cfg.execution_timeout)
-
-        # Model parameters table
-        self._load_model_params_table(cfg.provider.model, cfg)
 
         self.enable_tools_check.setChecked(cfg.enable_tools)
         self.auto_execute_check.setChecked(cfg.auto_execute)
@@ -999,6 +1011,154 @@ class SettingsDialog(QDialog):
         # Hooks
         self._refresh_hooks_list()
 
+    # ── Connection profiles ─────────────────────────────────────
+
+    def _rename_profile(self, old: str, new: str) -> None:
+        """Rename a profile, carrying every reference to it along.
+
+        A profile's label is its identity — utility_profiles and
+        active_profile store the name, not a stable id — so a rename that
+        did not cascade would silently detach a utility from the
+        connection it was using.
+        """
+        new = (new or "").strip()
+        if not new:
+            raise ValueError("Profile name cannot be empty")
+        if old == new:
+            return
+        if new in self._cfg.profiles:
+            raise ValueError(f"A profile named {new!r} already exists")
+        if old not in self._cfg.profiles:
+            raise ValueError(f"No profile named {old!r}")
+        # Rebuild in place so the combo's order does not shuffle.
+        self._cfg.profiles = {
+            (new if label == old else label): prof
+            for label, prof in self._cfg.profiles.items()
+        }
+        if self._cfg.active_profile == old:
+            self._cfg.active_profile = new
+        for utility, label in list(self._cfg.utility_profiles.items()):
+            if label == old:
+                self._cfg.utility_profiles[utility] = new
+
+    def _delete_profile(self, label: str) -> None:
+        """Remove a profile, leaving nothing pointing at it."""
+        if label not in self._cfg.profiles:
+            raise ValueError(f"No profile named {label!r}")
+        if len(self._cfg.profiles) == 1:
+            raise ValueError("At least one profile is required")
+        del self._cfg.profiles[label]
+        if self._cfg.active_profile == label:
+            self._cfg.active_profile = next(iter(self._cfg.profiles))
+        for utility, mapped in list(self._cfg.utility_profiles.items()):
+            if mapped == label:
+                self._cfg.utility_profiles[utility] = ""
+
+    def _refresh_profile_combo(self) -> None:
+        """Repopulate the profile combo without firing its handler."""
+        self.profile_combo.blockSignals(True)
+        try:
+            self.profile_combo.clear()
+            for label in self._cfg.profiles:
+                self.profile_combo.addItem(label, label)
+            idx = self.profile_combo.findData(self._cfg.active_profile)
+            if idx >= 0:
+                self.profile_combo.setCurrentIndex(idx)
+        finally:
+            self.profile_combo.blockSignals(False)
+
+    def _commit_profile_fields(self) -> None:
+        """Write the visible connection widgets back into their profile.
+
+        Called before switching away from a profile so an in-progress edit
+        is not lost — the #75 complaint, from the other direction.
+        """
+        label = getattr(self, "_current_profile_label", None)
+        prof = self._cfg.profiles.get(label)
+        if prof is None:
+            return
+        names = get_provider_names()
+        idx = self.provider_combo.currentIndex()
+        if 0 <= idx < len(names):
+            prof.name = names[idx]
+        prof.base_url = self.base_url_edit.text()
+        prof.api_key = self.api_key_edit.text()
+        prof.model = self.model_edit.text()
+
+    def _show_profile(self, label: str) -> None:
+        """Populate the connection widgets from a profile."""
+        prof = self._cfg.profiles[label]
+        self._current_profile_label = label
+        names = get_provider_names()
+        try:
+            idx = names.index(prof.name)
+        except ValueError:
+            idx = 0
+        # Programmatic index moves must not run _on_provider_changed —
+        # that handler exists to apply a preset on a *user* switch, and
+        # firing it here would overwrite the profile's saved URL (#75).
+        self.provider_combo.blockSignals(True)
+        try:
+            self.provider_combo.setCurrentIndex(idx)
+        finally:
+            self.provider_combo.blockSignals(False)
+        self.api_key_edit.setText(prof.api_key)
+        self.base_url_edit.setText(prof.base_url)
+        self.model_edit.setText(prof.model)
+        self._load_model_params_table(prof.model, self._cfg)
+
+    def _on_profile_changed(self, index):
+        label = self.profile_combo.itemData(index)
+        if not label or label == getattr(self, "_current_profile_label", None):
+            return
+        self._commit_profile_fields()
+        self._cfg.active_profile = label
+        self._show_profile(label)
+
+    def _on_profile_add(self):
+        base = translate("SettingsDialog", "New profile")
+        label, n = base, 2
+        while label in self._cfg.profiles:
+            label, n = f"{base} {n}", n + 1
+        self._commit_profile_fields()
+        self._cfg.profiles[label] = ProviderConfig()
+        self._cfg.active_profile = label
+        self._refresh_profile_combo()
+        self._show_profile(label)
+
+    def _on_profile_rename(self):
+        old = self._current_profile_label
+        new, ok = QInputDialog.getText(
+            self, translate("SettingsDialog", "Rename profile"),
+            translate("SettingsDialog", "Name:"), QLineEdit.Normal, old)
+        if not ok:
+            return
+        try:
+            self._rename_profile(old, new)
+        except ValueError as e:
+            QMessageBox.warning(
+                self, translate("SettingsDialog", "Rename profile"), str(e))
+            return
+        self._current_profile_label = new.strip()
+        self._refresh_profile_combo()
+
+    def _on_profile_delete(self):
+        label = self._current_profile_label
+        if QMessageBox.question(
+                self, translate("SettingsDialog", "Delete profile"),
+                translate("SettingsDialog",
+                          "Delete profile '{}'?").format(label)) \
+                != QMessageBox.Yes:
+            return
+        try:
+            self._delete_profile(label)
+        except ValueError as e:
+            QMessageBox.warning(
+                self, translate("SettingsDialog", "Delete profile"), str(e))
+            return
+        self._refresh_profile_combo()
+        self._show_profile(self._cfg.active_profile)
+
     def _on_provider_changed(self, index):
         """Update base URL, model, and default params when provider changes."""
         names = get_provider_names()
@@ -1030,6 +1190,11 @@ class SettingsDialog(QDialog):
             rerank_defaults = preset.get("default_rerank", {})
             if rerank_defaults and self._rerank_at_factory_defaults():
                 self._apply_rerank_defaults(rerank_defaults)
+
+            # A vendor switch is an explicit "point this profile
+            # elsewhere", so record it. Only a user-driven change reaches
+            # here: programmatic index moves are wrapped in blockSignals.
+            self._commit_profile_fields()
 
     def _rerank_at_factory_defaults(self) -> bool:
         """True if the rerank UI matches AppConfig's factory defaults."""

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -15,8 +15,8 @@ import copy
 import os
 import secrets
 
-from .compat import QtWidgets, QtCore, QtGui, QT_TRANSLATE_NOOP
-from ..i18n import translate
+from .compat import QtWidgets, QtCore, QtGui
+from ..i18n import translate, QT_TRANSLATE_NOOP
 
 QDialog = QtWidgets.QDialog
 QWidget = QtWidgets.QWidget

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -229,9 +229,10 @@ class TestSaveLoad:
 
     def test_load_seeds_rerank_params_from_legacy_override_slot(self, tmp_config_dir):
         """Migration: pre-namespace configs stored the reranker override
-        model's params inside the shared model_params dict. On load, seed the
-        new rerank_params namespace from that slot so override users don't
-        silently lose their reranker params (issue #30 follow-up)."""
+        model's params inside the shared model_params dict. Those params must
+        still reach the reranker so override users don't silently lose them
+        (issue #30 follow-up). They now land on the "rerank" profile, which is
+        what create_client reads; the rerank_params field itself is legacy."""
         import freecad_ai.config as config_mod
         os.makedirs(os.path.dirname(config_mod.CONFIG_FILE), exist_ok=True)
         with open(config_mod.CONFIG_FILE, "w") as f:
@@ -241,7 +242,8 @@ class TestSaveLoad:
                 "model_params": {"rr-model": {"temperature": 0.0, "top_k": 20}},
             }, f)
         c = load_config()
-        assert c.rerank_params == {"temperature": 0.0, "top_k": 20}
+        assert c.profiles["rerank"].params == {"temperature": 0.0, "top_k": 20}
+        assert c.utility_profiles["rerank"] == "rerank"
 
     def test_load_does_not_seed_rerank_params_in_inherit_mode(self, tmp_config_dir):
         """No reranker override model → nothing to migrate; rerank_params

--- a/tests/unit/test_create_client.py
+++ b/tests/unit/test_create_client.py
@@ -101,34 +101,6 @@ class TestApiKeyFallback:
         assert create_client(cfg).api_key == "sk-remote"
 
 
-class TestBaseUrlAndModelFallback:
-    """Mirrors TestApiKeyFallback: an empty profile field falls back to the
-    vendor preset, never to an unusable empty string."""
-
-    def test_empty_base_url_falls_back_to_the_preset(self):
-        cfg = _cfg()
-        cfg.profiles["p"] = ProviderConfig(name="anthropic", base_url="", model="claude-sonnet-4-6")
-        cfg.active_profile = "p"
-        assert create_client(cfg).base_url == "https://api.anthropic.com"
-
-    def test_empty_model_falls_back_to_the_preset_default(self):
-        cfg = _cfg()
-        cfg.profiles["p"] = ProviderConfig(name="anthropic", base_url="https://api.anthropic.com", model="")
-        cfg.active_profile = "p"
-        assert create_client(cfg).model == "claude-sonnet-4-6"
-
-    def test_unknown_provider_with_empty_fields_degrades_gracefully(self):
-        """apply_preset already tolerates an unmapped vendor via .get(name,
-        {}); resolution must too — never raise KeyError for 'custom' or a
-        typo'd provider name."""
-        cfg = _cfg()
-        cfg.profiles["p"] = ProviderConfig(name="not-a-real-vendor", base_url="", model="")
-        cfg.active_profile = "p"
-        client = create_client(cfg)
-        assert client.base_url == ""
-        assert client.model == ""
-
-
 class TestParamLayering:
     def test_model_params_apply(self):
         cfg = _cfg()

--- a/tests/unit/test_create_client.py
+++ b/tests/unit/test_create_client.py
@@ -102,18 +102,53 @@ class TestApiKeyFallback:
 
 
 class TestParamLayering:
-    def test_model_params_apply(self):
+    """``profile.params`` is the only source of sampling parameters.
+
+    ``cfg.model_params`` used to be underlaid beneath it. Nothing in the
+    dialog could write that dict (it was read-only from there), so a
+    parameter deleted in the Model Parameters table came straight back
+    from the underlay on the next resolve, and two profiles naming the
+    same model could not disagree about it. It is legacy now: still
+    written to config.json, never read.
+    """
+
+    def test_profile_params_apply(self):
         cfg = _cfg()
-        cfg.model_params = {"claude-sonnet-4-6": {"temperature": 0.7}}
+        cfg.profiles["cloud"].params = {"temperature": 0.7}
         assert create_client(cfg).model_params["temperature"] == 0.7
 
-    def test_profile_params_override_model_params(self):
+    def test_legacy_model_params_are_not_read(self):
         cfg = _cfg()
-        cfg.model_params = {"qwen3:8b": {"top_k": 10, "top_p": 0.9}}
+        cfg.model_params = {"claude-sonnet-4-6": {"temperature": 0.7}}
+        assert create_client(cfg).model_params == {}
+
+    def test_a_key_removed_from_the_profile_stays_removed(self):
+        """The reported defect. Migration copies model_params[model] into
+        the profile, so for every upgraded user the same key sat in both
+        stores; Remove deleted it from the profile only."""
+        cfg = _cfg()
         cfg.active_profile = "local"
+        cfg.model_params = {"qwen3:8b": {"top_k": 40, "top_p": 0.9}}
+        cfg.profiles["local"].params = {"top_k": 40}  # top_p removed
         params = create_client(cfg).model_params
-        assert params["top_k"] == 40      # profile wins
-        assert params["top_p"] == 0.9     # model_params still contributes
+        assert "top_p" not in params
+        assert params == {"top_k": 40}
+
+    def test_two_profiles_on_one_model_keep_separate_params(self):
+        """No shared namespace to reach — the structural claim profiles
+        are for, which the underlay quietly falsified."""
+        cfg = _cfg()
+        cfg.profiles["a"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1",
+            model="qwen3:8b", params={"temperature": 0.1})
+        cfg.profiles["b"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1",
+            model="qwen3:8b", params={"top_k": 5})
+        cfg.utility_profiles["compaction"] = "a"
+        cfg.utility_profiles["rerank"] = "b"
+        assert create_client(cfg, "compaction").model_params == {
+            "temperature": 0.1}
+        assert create_client(cfg, "rerank").model_params == {"top_k": 5}
 
     def test_one_profile_params_never_leak_into_another(self):
         """Issue #30, now structural."""
@@ -151,14 +186,14 @@ class TestCreateClientFromConfigIsUnchanged:
     its observable output must match what the old hand-rolled version
     produced: provider/base_url/api_key/model straight from cfg.provider,
     max_tokens/temperature/thinking straight from cfg, and model_params
-    keyed only by cfg.model_params[cfg.provider.model]."""
+    from the active profile's own params."""
 
     def test_matches_the_pre_refactor_construction(self, monkeypatch):
         cfg = _cfg()
         cfg.max_tokens = 4096
         cfg.temperature = 0.5
         cfg.thinking = "on"
-        cfg.model_params = {"claude-sonnet-4-6": {"top_p": 0.8}}
+        cfg.provider.params = {"top_p": 0.8}
         monkeypatch.setattr("freecad_ai.config.get_config", lambda: cfg)
 
         client = create_client_from_config()
@@ -170,7 +205,7 @@ class TestCreateClientFromConfigIsUnchanged:
         assert client.max_tokens == cfg.max_tokens
         assert client.temperature == cfg.temperature
         assert client.thinking == cfg.thinking
-        assert client.model_params == cfg.model_params[cfg.provider.model]
+        assert client.model_params == cfg.provider.params
 
 
 class TestResolveProfile:
@@ -194,8 +229,7 @@ class TestRerankerJobSettings:
         cfg.thinking = "extended"
         cfg.utility_profiles["rerank"] = "local"
         cfg.profiles["local"].params = {"temperature": 0.1, "top_k": 20}
-        params = dict(cfg.model_params.get("qwen3:8b", {}))
-        params.update(cfg.profiles["local"].params)
+        params = dict(cfg.profiles["local"].params)
         client = create_client(cfg, "rerank", max_tokens=1024,
                                temperature=params.get("temperature", 0.0),
                                thinking="off")
@@ -209,10 +243,14 @@ class TestResolveParams:
     def test_returns_a_fresh_dict_not_an_alias(self):
         from freecad_ai.llm.client import resolve_params
         cfg = _cfg()
-        cfg.model_params = {"qwen3:8b": {"temperature": 0.5}}
         profile = cfg.profiles["local"]
         result = resolve_params(cfg, profile)
-        result["temperature"] = 999
+        result["top_k"] = 999
         result["new_key"] = "poison"
-        assert cfg.model_params["qwen3:8b"] == {"temperature": 0.5}
         assert profile.params == {"top_k": 40}
+
+    def test_ignores_the_legacy_model_params_dict(self):
+        from freecad_ai.llm.client import resolve_params
+        cfg = _cfg()
+        cfg.model_params = {"qwen3:8b": {"temperature": 0.5}}
+        assert resolve_params(cfg, cfg.profiles["local"]) == {"top_k": 40}

--- a/tests/unit/test_create_client.py
+++ b/tests/unit/test_create_client.py
@@ -182,3 +182,37 @@ class TestResolveProfile:
         cfg = _cfg()
         cfg.utility_profiles["skill_eval"] = "local"
         assert resolve_profile(cfg, "skill_eval") is cfg.profiles["local"]
+
+
+class TestRerankerJobSettings:
+    def test_reranker_settings_survive_the_move(self):
+        """The old builder pinned max_tokens=1024, thinking off, and
+        temperature from params defaulting to 0.0. Reranking is a
+        classification job; those must not drift to the chat values."""
+        cfg = _cfg()
+        cfg.max_tokens = 8192
+        cfg.thinking = "extended"
+        cfg.utility_profiles["rerank"] = "local"
+        cfg.profiles["local"].params = {"temperature": 0.1, "top_k": 20}
+        params = dict(cfg.model_params.get("qwen3:8b", {}))
+        params.update(cfg.profiles["local"].params)
+        client = create_client(cfg, "rerank", max_tokens=1024,
+                               temperature=params.get("temperature", 0.0),
+                               thinking="off")
+        assert client.max_tokens == 1024
+        assert client.thinking == "off"
+        assert client.temperature == 0.1
+        assert client.model_params == {"temperature": 0.1, "top_k": 20}
+
+
+class TestResolveParams:
+    def test_returns_a_fresh_dict_not_an_alias(self):
+        from freecad_ai.llm.client import resolve_params
+        cfg = _cfg()
+        cfg.model_params = {"qwen3:8b": {"temperature": 0.5}}
+        profile = cfg.profiles["local"]
+        result = resolve_params(cfg, profile)
+        result["temperature"] = 999
+        result["new_key"] = "poison"
+        assert cfg.model_params["qwen3:8b"] == {"temperature": 0.5}
+        assert profile.params == {"top_k": 40}

--- a/tests/unit/test_create_client.py
+++ b/tests/unit/test_create_client.py
@@ -1,0 +1,186 @@
+"""One resolver builds every LLM client.
+
+Each call site names a utility; an unmapped utility inherits the active
+profile, which is what every call site did before profiles existed.
+"""
+
+import pytest
+
+from freecad_ai.config import AppConfig, ProviderConfig
+from freecad_ai.llm.client import (
+    create_client,
+    create_client_from_config,
+    resolve_profile,
+)
+
+
+def _cfg():
+    cfg = AppConfig()
+    cfg.profiles = {
+        "cloud": ProviderConfig(name="anthropic", api_key="sk-cloud",
+                                base_url="https://api.anthropic.com",
+                                model="claude-sonnet-4-6"),
+        "local": ProviderConfig(name="ollama", api_key="",
+                                base_url="http://localhost:11434/v1",
+                                model="qwen3:8b", params={"top_k": 40}),
+    }
+    cfg.active_profile = "cloud"
+    return cfg
+
+
+class TestUtilityRouting:
+    def test_no_utility_uses_the_active_profile(self):
+        assert create_client(_cfg()).model == "claude-sonnet-4-6"
+
+    def test_unmapped_utility_inherits_the_active_profile(self):
+        assert create_client(_cfg(), "compaction").model == "claude-sonnet-4-6"
+
+    def test_mapped_utility_uses_its_own_profile(self):
+        cfg = _cfg()
+        cfg.utility_profiles["compaction"] = "local"
+        client = create_client(cfg, "compaction")
+        assert client.model == "qwen3:8b"
+        assert client.base_url == "http://localhost:11434/v1"
+
+    def test_one_utility_override_does_not_move_the_others(self):
+        cfg = _cfg()
+        cfg.utility_profiles["compaction"] = "local"
+        assert create_client(cfg, "rerank").model == "claude-sonnet-4-6"
+
+    def test_empty_mapping_means_inherit(self):
+        cfg = _cfg()
+        cfg.utility_profiles["rerank"] = ""
+        assert create_client(cfg, "rerank").model == "claude-sonnet-4-6"
+
+    def test_dangling_profile_name_falls_back_to_active(self):
+        """Never leave the user unable to chat because a profile was
+        deleted while a utility still pointed at it."""
+        cfg = _cfg()
+        cfg.utility_profiles["rerank"] = "deleted-profile"
+        assert create_client(cfg, "rerank").model == "claude-sonnet-4-6"
+
+    def test_same_provider_different_model_is_expressible(self):
+        """The original request: cheap model for compaction, same vendor."""
+        cfg = _cfg()
+        cfg.profiles["cheap"] = ProviderConfig(
+            name="anthropic", api_key="sk-cloud",
+            base_url="https://api.anthropic.com", model="claude-haiku-4-5")
+        cfg.utility_profiles["compaction"] = "cheap"
+        chat = create_client(cfg)
+        compact = create_client(cfg, "compaction")
+        assert chat.provider_name == compact.provider_name == "anthropic"
+        assert chat.model == "claude-sonnet-4-6"
+        assert compact.model == "claude-haiku-4-5"
+
+
+class TestApiKeyFallback:
+    def test_profile_key_wins(self):
+        cfg = _cfg()
+        cfg.provider_keys["anthropic"] = "sk-vendor"
+        assert create_client(cfg).api_key == "sk-cloud"
+
+    def test_empty_profile_key_falls_through_to_the_vendor_default(self):
+        cfg = _cfg()
+        cfg.active_profile = "local"
+        cfg.provider_keys["ollama"] = "sk-gateway"
+        assert create_client(cfg).api_key == "sk-gateway"
+
+    def test_both_empty_yields_empty(self):
+        cfg = _cfg()
+        cfg.active_profile = "local"
+        assert create_client(cfg).api_key == ""
+
+    def test_two_profiles_on_one_vendor_can_hold_different_keys(self):
+        """Why keys live in the profile: ollama-local needs none while
+        ollama-remote sits behind an authenticating gateway."""
+        cfg = _cfg()
+        cfg.profiles["remote"] = ProviderConfig(
+            name="ollama", api_key="sk-remote",
+            base_url="https://gpu.example.net/v1", model="qwen3:32b")
+        cfg.active_profile = "local"
+        assert create_client(cfg).api_key == ""
+        cfg.active_profile = "remote"
+        assert create_client(cfg).api_key == "sk-remote"
+
+
+class TestParamLayering:
+    def test_model_params_apply(self):
+        cfg = _cfg()
+        cfg.model_params = {"claude-sonnet-4-6": {"temperature": 0.7}}
+        assert create_client(cfg).model_params["temperature"] == 0.7
+
+    def test_profile_params_override_model_params(self):
+        cfg = _cfg()
+        cfg.model_params = {"qwen3:8b": {"top_k": 10, "top_p": 0.9}}
+        cfg.active_profile = "local"
+        params = create_client(cfg).model_params
+        assert params["top_k"] == 40      # profile wins
+        assert params["top_p"] == 0.9     # model_params still contributes
+
+    def test_one_profile_params_never_leak_into_another(self):
+        """Issue #30, now structural."""
+        cfg = _cfg()
+        cfg.utility_profiles["rerank"] = "local"
+        assert create_client(cfg, "rerank").model_params["top_k"] == 40
+        assert "top_k" not in create_client(cfg).model_params
+
+
+class TestCallSiteOverrides:
+    def test_defaults_come_from_config(self):
+        cfg = _cfg()
+        cfg.max_tokens = 8192
+        cfg.temperature = 0.3
+        client = create_client(cfg)
+        assert client.max_tokens == 8192
+        assert client.temperature == 0.3
+
+    def test_overrides_win(self):
+        """Job properties, not connection properties: the reranker wants
+        1024 tokens and no thinking regardless of which profile it uses."""
+        cfg = _cfg()
+        cfg.max_tokens = 8192
+        cfg.thinking = "extended"
+        client = create_client(cfg, "rerank", max_tokens=1024,
+                               temperature=0.0, thinking="off")
+        assert client.max_tokens == 1024
+        assert client.temperature == 0.0
+        assert client.thinking == "off"
+
+
+class TestCreateClientFromConfigIsUnchanged:
+    """create_client_from_config() is now create_client() under the hood.
+    Every existing call site still uses it until Tasks 5-6 convert them, so
+    its observable output must match what the old hand-rolled version
+    produced: provider/base_url/api_key/model straight from cfg.provider,
+    max_tokens/temperature/thinking straight from cfg, and model_params
+    keyed only by cfg.model_params[cfg.provider.model]."""
+
+    def test_matches_the_pre_refactor_construction(self, monkeypatch):
+        cfg = _cfg()
+        cfg.max_tokens = 4096
+        cfg.temperature = 0.5
+        cfg.thinking = "on"
+        cfg.model_params = {"claude-sonnet-4-6": {"top_p": 0.8}}
+        monkeypatch.setattr("freecad_ai.config.get_config", lambda: cfg)
+
+        client = create_client_from_config()
+
+        assert client.provider_name == cfg.provider.name
+        assert client.base_url == cfg.provider.base_url.rstrip("/")
+        assert client.api_key == cfg.provider.api_key
+        assert client.model == cfg.provider.model
+        assert client.max_tokens == cfg.max_tokens
+        assert client.temperature == cfg.temperature
+        assert client.thinking == cfg.thinking
+        assert client.model_params == cfg.model_params[cfg.provider.model]
+
+
+class TestResolveProfile:
+    def test_returns_the_profile_object_itself(self):
+        cfg = _cfg()
+        assert resolve_profile(cfg) is cfg.profiles["cloud"]
+
+    def test_named_utility_resolves_to_its_profile(self):
+        cfg = _cfg()
+        cfg.utility_profiles["skill_eval"] = "local"
+        assert resolve_profile(cfg, "skill_eval") is cfg.profiles["local"]

--- a/tests/unit/test_create_client.py
+++ b/tests/unit/test_create_client.py
@@ -4,8 +4,6 @@ Each call site names a utility; an unmapped utility inherits the active
 profile, which is what every call site did before profiles existed.
 """
 
-import pytest
-
 from freecad_ai.config import AppConfig, ProviderConfig
 from freecad_ai.llm.client import (
     create_client,
@@ -101,6 +99,34 @@ class TestApiKeyFallback:
         assert create_client(cfg).api_key == ""
         cfg.active_profile = "remote"
         assert create_client(cfg).api_key == "sk-remote"
+
+
+class TestBaseUrlAndModelFallback:
+    """Mirrors TestApiKeyFallback: an empty profile field falls back to the
+    vendor preset, never to an unusable empty string."""
+
+    def test_empty_base_url_falls_back_to_the_preset(self):
+        cfg = _cfg()
+        cfg.profiles["p"] = ProviderConfig(name="anthropic", base_url="", model="claude-sonnet-4-6")
+        cfg.active_profile = "p"
+        assert create_client(cfg).base_url == "https://api.anthropic.com"
+
+    def test_empty_model_falls_back_to_the_preset_default(self):
+        cfg = _cfg()
+        cfg.profiles["p"] = ProviderConfig(name="anthropic", base_url="https://api.anthropic.com", model="")
+        cfg.active_profile = "p"
+        assert create_client(cfg).model == "claude-sonnet-4-6"
+
+    def test_unknown_provider_with_empty_fields_degrades_gracefully(self):
+        """apply_preset already tolerates an unmapped vendor via .get(name,
+        {}); resolution must too — never raise KeyError for 'custom' or a
+        typo'd provider name."""
+        cfg = _cfg()
+        cfg.profiles["p"] = ProviderConfig(name="not-a-real-vendor", base_url="", model="")
+        cfg.active_profile = "p"
+        client = create_client(cfg)
+        assert client.base_url == ""
+        assert client.model == ""
 
 
 class TestParamLayering:

--- a/tests/unit/test_profile_selector.py
+++ b/tests/unit/test_profile_selector.py
@@ -188,6 +188,80 @@ class _Combo:
         self.calls.append(("block", b))
 
 
+class _Check:
+    """QCheckBox stand-in that records blockSignals order."""
+
+    def __init__(self, checked=False, enabled=True):
+        self._checked = checked
+        self._enabled = enabled
+        self.blocked = []
+
+    def setChecked(self, v):
+        self._checked = v
+
+    def isChecked(self):
+        return self._checked
+
+    def setEnabled(self, v):
+        self._enabled = v
+
+    def isEnabled(self):
+        return self._enabled
+
+    def blockSignals(self, b):
+        self.blocked.append(b)
+
+
+class _ProfileCombo:
+    """QComboBox stand-in carrying a real item model.
+
+    _refresh_profile_combo now renders a label per item and keys the
+    selection off itemData, so a stand-in that only records calls can no
+    longer tell the two apart.
+    """
+
+    def __init__(self):
+        self.items = []          # [(text, data)]
+        self._i = -1
+        self.blocked = []
+
+    def blockSignals(self, b):
+        self.blocked.append(b)
+
+    def clear(self):
+        self.items = []
+        self._i = -1
+
+    def addItem(self, text, data=None):
+        self.items.append((text, data))
+
+    def findData(self, data):
+        for i, (_text, d) in enumerate(self.items):
+            if d == data:
+                return i
+        return -1
+
+    def setCurrentIndex(self, i):
+        self._i = i
+
+    def currentIndex(self):
+        return self._i
+
+    def itemData(self, i):
+        return self.items[i][1]
+
+    def currentData(self):
+        if 0 <= self._i < len(self.items):
+            return self.items[self._i][1]
+        return None
+
+    def texts(self):
+        return [t for t, _d in self.items]
+
+    def data(self):
+        return [d for _t, d in self.items]
+
+
 class TestProfileFieldRoundTrip:
     """Editing a profile, browsing away and back preserves the edit (#75)."""
 
@@ -198,11 +272,13 @@ class TestProfileFieldRoundTrip:
         fake = types.SimpleNamespace(
             _cfg=cfg,
             _profiles=cfg.profiles,
+            _active_profile=cfg.active_profile,
             _current_profile_label=label,
             base_url_edit=_Edit(prof.base_url),
             api_key_edit=_Edit(prof.api_key),
             model_edit=_Edit(prof.model),
             provider_combo=_Combo(get_provider_names().index(prof.name)),
+            profile_active_check=_Check(),
         )
         fake._load_model_params_table = lambda model, cfg=None, profile=None: None
         fake._read_model_params_table = (
@@ -589,11 +665,13 @@ class TestParamsDoNotLeakBetweenProfiles:
         fake = types.SimpleNamespace(
             _cfg=cfg,
             _profiles=cfg.profiles,
+            _active_profile=cfg.active_profile,
             _current_profile_label="a",
             base_url_edit=_Edit(cfg.profiles["a"].base_url),
             api_key_edit=_Edit(cfg.profiles["a"].api_key),
             model_edit=_Edit(cfg.profiles["a"].model),
             provider_combo=_Combo(get_provider_names().index("anthropic")),
+            profile_active_check=_Check(),
         )
         fake._populate_model_params_table = (
             lambda params: (table.clear(), table.update(params)))
@@ -733,3 +811,192 @@ class TestTestConnectionKeyResolution:
         SettingsDialog._test_connection(fake)
 
         assert captured["api_key"] == ""
+
+
+# ── Selected profile vs active profile (final review, finding 3) ───────
+#
+# The combo meant both "edit this one" and "chat runs on this one":
+# _on_profile_changed and _on_profile_add each assigned _active_profile,
+# and _save committed it. So opening Settings to raise Max Tokens,
+# clicking another profile to see which model it used, setting Max Tokens
+# and pressing OK moved chat onto that other profile with nothing having
+# said so. An explicit "Use this profile for chat" checkbox separates the
+# two; the combo shows which profile is active by labelling it.
+
+def _selector_fake(cfg, label="cloud"):
+    """Fake self carrying the widgets the profile-selector methods touch."""
+    fake = types.SimpleNamespace(
+        _cfg=cfg,
+        _profiles=cfg.profiles,
+        _active_profile=cfg.active_profile,
+        _utility_profiles=cfg.utility_profiles,
+        _current_profile_label=label,
+        profile_combo=_ProfileCombo(),
+        profile_active_check=_Check(),
+        api_key_edit=_Edit(),
+        base_url_edit=_Edit(),
+        model_edit=_Edit(),
+        provider_combo=_Combo(get_provider_names().index("anthropic")),
+        utility_combos={},
+    )
+    fake._load_model_params_table = lambda model, cfg=None, profile=None: None
+    fake._read_model_params_table = lambda: {}
+    fake._commit_profile_fields = (
+        lambda: SettingsDialog._commit_profile_fields(fake))
+    fake._show_profile = lambda lbl: SettingsDialog._show_profile(fake, lbl)
+    fake._refresh_profile_combo = (
+        lambda: SettingsDialog._refresh_profile_combo(fake))
+    fake._refresh_utility_combos = lambda: None
+    fake._rename_profile = (
+        lambda old, new: SettingsDialog._rename_profile(fake, old, new))
+    return fake
+
+
+class TestBrowsingDoesNotMoveActive:
+    def test_selecting_another_profile_leaves_active_alone(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg)
+        fake.profile_combo.addItem("local", "local")
+
+        SettingsDialog._on_profile_changed(fake, 0)
+
+        assert fake._current_profile_label == "local"
+        assert fake._active_profile == "cloud"
+
+    def test_adding_a_profile_leaves_active_alone(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg)
+
+        SettingsDialog._on_profile_add(fake)
+
+        assert fake._active_profile == "cloud"
+        assert fake._current_profile_label not in ("cloud", "local")
+        assert fake._current_profile_label in fake._profiles
+
+    def test_the_new_profile_is_the_one_selected_for_editing(self):
+        """The combo must land on the profile just added, not snap back to
+        the active one — the trap in re-selecting by _active_profile."""
+        cfg = _cfg()
+        fake = _selector_fake(cfg)
+
+        SettingsDialog._on_profile_add(fake)
+
+        assert fake.profile_combo.currentData() == fake._current_profile_label
+
+    def test_rename_leaves_the_combo_on_the_renamed_profile(self, monkeypatch):
+        cfg = _cfg()
+        fake = _selector_fake(cfg, label="local")
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog.QInputDialog",
+            types.SimpleNamespace(getText=lambda *a, **k: ("cheap", True)))
+
+        SettingsDialog._on_profile_rename(fake)
+
+        assert fake._active_profile == "cloud"
+        assert fake.profile_combo.currentData() == "cheap"
+
+
+class TestActiveProfileCheckbox:
+    def test_showing_the_active_profile_checks_and_locks_the_box(self):
+        """Exactly one profile is always active, so the box is disabled
+        while checked: the way to move it is to check a different one."""
+        cfg = _cfg()
+        fake = _selector_fake(cfg)
+
+        SettingsDialog._show_profile(fake, "cloud")
+
+        assert fake.profile_active_check.isChecked() is True
+        assert fake.profile_active_check.isEnabled() is False
+        assert fake.profile_active_check.blocked == [True, False]
+
+    def test_showing_another_profile_unchecks_and_unlocks_the_box(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg)
+
+        SettingsDialog._show_profile(fake, "local")
+
+        assert fake.profile_active_check.isChecked() is False
+        assert fake.profile_active_check.isEnabled() is True
+
+    def test_ticking_the_box_moves_active(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg, label="local")
+
+        SettingsDialog._on_profile_active_toggled(fake, True)
+
+        assert fake._active_profile == "local"
+        assert fake.profile_active_check.isEnabled() is False
+
+    def test_ticking_the_box_relabels_the_combo(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg, label="local")
+
+        SettingsDialog._on_profile_active_toggled(fake, True)
+
+        assert fake.profile_combo.texts() == ["cloud", "local (active)"]
+
+    def test_an_untick_is_a_no_op(self):
+        """Unreachable through the UI (the widget is disabled while
+        checked), and must stay a no-op if it ever arrives anyway —
+        there is no such thing as no active profile."""
+        cfg = _cfg()
+        fake = _selector_fake(cfg, label="local")
+
+        SettingsDialog._on_profile_active_toggled(fake, False)
+
+        assert fake._active_profile == "cloud"
+
+
+class TestProfileComboRendering:
+    def test_exactly_one_entry_is_marked_active(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg)
+
+        SettingsDialog._refresh_profile_combo(fake)
+
+        assert fake.profile_combo.texts() == ["cloud (active)", "local"]
+
+    def test_item_data_stays_the_bare_label(self):
+        """_on_profile_changed and findData both key off it."""
+        cfg = _cfg()
+        fake = _selector_fake(cfg)
+
+        SettingsDialog._refresh_profile_combo(fake)
+
+        assert fake.profile_combo.data() == ["cloud", "local"]
+        assert fake.profile_combo.findData("cloud") == 0
+
+    def test_selection_follows_the_profile_being_edited(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg, label="local")
+
+        SettingsDialog._refresh_profile_combo(fake)
+
+        assert fake.profile_combo.currentData() == "local"
+
+    def test_selection_falls_back_to_active_when_the_edited_label_is_gone(self):
+        """The delete path: _current_profile_label names the profile that
+        was just removed."""
+        cfg = _cfg()
+        fake = _selector_fake(cfg, label="deleted")
+
+        SettingsDialog._refresh_profile_combo(fake)
+
+        assert fake.profile_combo.currentData() == "cloud"
+
+    def test_selection_falls_back_to_the_first_entry(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg, label="deleted")
+        fake._active_profile = "also-gone"
+
+        SettingsDialog._refresh_profile_combo(fake)
+
+        assert fake.profile_combo.currentIndex() == 0
+
+    def test_the_handler_is_blocked_while_repopulating(self):
+        cfg = _cfg()
+        fake = _selector_fake(cfg)
+
+        SettingsDialog._refresh_profile_combo(fake)
+
+        assert fake.profile_combo.blocked == [True, False]

--- a/tests/unit/test_profile_selector.py
+++ b/tests/unit/test_profile_selector.py
@@ -199,7 +199,9 @@ class TestProfileFieldRoundTrip:
             model_edit=_Edit(prof.model),
             provider_combo=_Combo(get_provider_names().index(prof.name)),
         )
-        fake._load_model_params_table = lambda model, cfg=None: None
+        fake._load_model_params_table = lambda model, cfg=None, profile=None: None
+        fake._read_model_params_table = (
+            lambda: dict(fake._profiles[fake._current_profile_label].params))
         return fake
 
     def test_edited_base_url_survives_switching_away_and_back(self):
@@ -410,3 +412,273 @@ class TestSaveTempDoesNotMutateStoredProfile:
 
         assert cfg.provider.base_url == original_base_url
         assert cfg.provider.name == original_name
+
+
+# ── Params table targets the working-copy profile (fix round 2) ────────
+#
+# resolve_params() layers profile.params on top of cfg.model_params, and
+# migration copied a profile's starting params into both places. The
+# dialog's Model Parameters table read/wrote cfg.model_params only, so for
+# any migrated profile the profile layer always won and every edit made
+# through the dialog was silently discarded — demonstrated against a real
+# config: temperature 1 -> 0.2 in the dialog, saved, runtime still resolved
+# 1. These tests pin the fix: the table must read the effective merge and
+# write into the working-copy profile's own params.
+
+class TestParamsTableEditSurvivesSaveAndResolve:
+    """The regression, end to end — this is the test that would have
+    caught the bug."""
+
+    def _migrated_cfg(self):
+        """A profile whose params were also copied into cfg.model_params
+        by migration — the exact shape that hid the bug."""
+        cfg = AppConfig()
+        cfg.profiles = {
+            "cloud": ProviderConfig(
+                name="anthropic", model="claude-sonnet-4-6",
+                params={"temperature": 1}),
+        }
+        cfg.active_profile = "cloud"
+        cfg.model_params = {"claude-sonnet-4-6": {"temperature": 1}}
+        return cfg
+
+    def _fake_for_save(self, cfg, table_params):
+        """Mirrors TestSaveWritesBackProfileState's fake — _save touches a
+        lot of unrelated widgets that only need to not raise."""
+        prof = cfg.profiles[cfg.active_profile]
+        working = copy.deepcopy(cfg.profiles)
+
+        fake = MagicMock()
+        fake._profiles = working
+        fake._active_profile = cfg.active_profile
+        fake._current_profile_label = cfg.active_profile
+        fake._commit_profile_fields = (
+            lambda: SettingsDialog._commit_profile_fields(fake))
+        fake._read_model_params_table = lambda: dict(table_params)
+        fake._read_rerank_params_table = lambda: {}
+        fake._read_strip_thinking_state = lambda: None
+        fake._get_default_prompt_text = lambda: ""
+        fake._parse_server_address = lambda host, port: ("127.0.0.1", 8765)
+        fake._parse_allowed_hosts = lambda text: []
+        fake._resolve_rerank_params = lambda model, params: {}
+        fake.accept = lambda: None
+
+        names = get_provider_names()
+        fake.provider_combo.currentIndex.return_value = names.index(prof.name)
+        fake.api_key_edit.text.return_value = prof.api_key
+        fake.base_url_edit.text.return_value = prof.base_url
+        fake.model_edit.text.return_value = prof.model
+        fake.thinking_combo.currentIndex.return_value = 0
+        fake.viewport_capture_combo.currentIndex.return_value = 0
+        fake.viewport_resolution_combo.currentIndex.return_value = 0
+        fake.rerank_method_combo.currentIndex.return_value = 0
+        fake.system_prompt_edit.toPlainText.return_value = ""
+        fake.rerank_pinned_edit.text.return_value = ""
+        fake.rerank_llm_provider_combo.currentData.return_value = ""
+        fake.rerank_llm_base_url_edit.text.return_value = ""
+        fake.rerank_llm_api_key_edit.text.return_value = ""
+        fake.rerank_llm_model_edit.text.return_value = ""
+        return fake
+
+    def test_edit_survives_save_and_resolve_params(self, monkeypatch):
+        from freecad_ai.llm.client import resolve_params
+
+        cfg = self._migrated_cfg()
+        fake = self._fake_for_save(cfg, {"temperature": 0.2})
+
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog.get_config", lambda: cfg)
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog.save_current_config", lambda: None)
+
+        SettingsDialog._save(fake)
+
+        assert resolve_params(cfg, cfg.provider)["temperature"] == 0.2
+
+
+class TestParamsTableDisplaysEffectiveMerge:
+    """The table shows exactly what resolve_params() will compute."""
+
+    def test_both_layers_appear_profile_wins_on_conflict(self):
+        cfg = _cfg()
+        prof = cfg.profiles["cloud"]
+        prof.params = {"temperature": 0.9, "top_p": 0.5}
+        cfg.model_params = {prof.model: {"temperature": 0.1, "max_tokens": 999}}
+
+        fake = types.SimpleNamespace(
+            _profiles=cfg.profiles,
+            _current_profile_label="cloud",
+            provider_combo=_Combo(get_provider_names().index(prof.name)),
+        )
+        captured = {}
+        fake._populate_model_params_table = captured.update
+
+        SettingsDialog._load_model_params_table(fake, prof.model, cfg, prof)
+
+        assert captured["temperature"] == 0.9  # profile wins the conflict
+        assert captured["top_p"] == 0.5         # profile-only key
+        assert captured["max_tokens"] == 999    # global-only key
+
+
+class TestParamsDoNotLeakBetweenProfiles:
+    """Switching profiles must not let one profile's params bleed into,
+    or overwrite, another's."""
+
+    def test_switching_a_b_a_keeps_each_profiles_own_params(self):
+        cfg = AppConfig()
+        cfg.profiles = {
+            "a": ProviderConfig(name="anthropic", model="model-a",
+                                params={"temperature": 0.1}),
+            "b": ProviderConfig(name="anthropic", model="model-b",
+                                params={"temperature": 0.9}),
+        }
+        cfg.active_profile = "a"
+        table = {}
+
+        fake = types.SimpleNamespace(
+            _cfg=cfg,
+            _profiles=cfg.profiles,
+            _current_profile_label="a",
+            base_url_edit=_Edit(cfg.profiles["a"].base_url),
+            api_key_edit=_Edit(cfg.profiles["a"].api_key),
+            model_edit=_Edit(cfg.profiles["a"].model),
+            provider_combo=_Combo(get_provider_names().index("anthropic")),
+        )
+        fake._populate_model_params_table = (
+            lambda params: (table.clear(), table.update(params)))
+        fake._read_model_params_table = lambda: dict(table)
+        fake._load_model_params_table = (
+            lambda model, cfg=None, profile=None:
+                SettingsDialog._load_model_params_table(
+                    fake, model, cfg, profile))
+
+        SettingsDialog._show_profile(fake, "a")
+        assert table["temperature"] == 0.1
+
+        SettingsDialog._commit_profile_fields(fake)
+        SettingsDialog._show_profile(fake, "b")
+        assert table["temperature"] == 0.9
+
+        SettingsDialog._commit_profile_fields(fake)
+        SettingsDialog._show_profile(fake, "a")
+        assert table["temperature"] == 0.1
+
+        assert cfg.profiles["a"].params["temperature"] == 0.1
+        assert cfg.profiles["b"].params["temperature"] == 0.9
+
+
+class TestOnModelChangedDoesNotMutateLiveConfig:
+    """Same class of defect round 1 removed elsewhere: this must write to
+    the working-copy profile, never cfg.model_params on the singleton."""
+
+    def test_stashes_into_profile_not_live_config(self):
+        cfg = _cfg()
+        prof = cfg.profiles["cloud"]
+        original_model_params = copy.deepcopy(cfg.model_params)
+
+        fake = types.SimpleNamespace(
+            _cfg=cfg,
+            _profiles=cfg.profiles,
+            _current_profile_label="cloud",
+            _last_model_name=prof.model,
+            model_edit=_Edit("new-model-name"),
+            provider_combo=_Combo(get_provider_names().index(prof.name)),
+        )
+        fake._read_model_params_table = lambda: {"temperature": 0.42}
+        fake._populate_model_params_table = lambda params: None
+
+        def _stub_load(model, cfg=None, profile=None):
+            fake._last_model_name = model
+        fake._load_model_params_table = _stub_load
+
+        SettingsDialog._on_model_changed(fake)
+
+        assert cfg.model_params == original_model_params
+        assert prof.params == {"temperature": 0.42}
+        assert fake._last_model_name == "new-model-name"
+
+
+class TestSaveTempLeavesParamsAlone:
+    """_save_temp's model-params write fed nothing (_test_connection reads
+    the table directly) and only leaked edits to disk via the vision
+    probe's save. It must leave cfg.model_params/cfg.temperature alone."""
+
+    def test_save_temp_does_not_touch_model_params_or_temperature(
+            self, monkeypatch):
+        cfg = _cfg()
+        cfg.model_params = {"claude-sonnet-4-6": {"temperature": 0.1}}
+        cfg.temperature = 0.1
+        original_model_params = copy.deepcopy(cfg.model_params)
+
+        fake = MagicMock()
+        fake.model_edit.text.return_value = "claude-sonnet-4-6"
+        fake._read_model_params_table.return_value = {"temperature": 0.9}
+        fake.thinking_combo.currentIndex.return_value = 0
+        fake.system_prompt_edit.toPlainText.return_value = ""
+        fake._get_default_prompt_text = lambda: ""
+
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog.get_config", lambda: cfg)
+
+        SettingsDialog._save_temp(fake)
+
+        assert cfg.model_params == original_model_params
+        assert cfg.temperature == 0.1
+
+
+class TestTestConnectionKeyResolution:
+    """Defect A: the probe must resolve the key exactly as create_client()
+    does, or a profile that inherits the vendor-wide key fails Test
+    Connection even though real chat works."""
+
+    def _fake(self, cfg, api_key_text, provider_name="anthropic"):
+        idx = get_provider_names().index(provider_name)
+        fake = MagicMock()
+        fake._cfg = cfg
+        fake.provider_combo.currentIndex.return_value = idx
+        fake.base_url_edit.text.return_value = "http://example/v1"
+        fake.api_key_edit.text.return_value = api_key_text
+        fake.model_edit.text.return_value = "some-model"
+        fake._read_model_params_table.return_value = {}
+        return fake
+
+    def _capture_thread_api_key(self, monkeypatch, captured):
+        def fake_thread(provider_name, base_url, api_key, model,
+                        model_params, parent):
+            captured["api_key"] = api_key
+            return MagicMock()
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog._TestConnectionThread", fake_thread)
+
+    def test_profile_key_wins_over_provider_keys(self, monkeypatch):
+        cfg = _cfg()
+        cfg.provider_keys = {"anthropic": "vendor-default"}
+        fake = self._fake(cfg, "profile-key")
+        captured = {}
+        self._capture_thread_api_key(monkeypatch, captured)
+
+        SettingsDialog._test_connection(fake)
+
+        assert captured["api_key"] == "profile-key"
+
+    def test_blank_profile_key_falls_back_to_provider_keys(self, monkeypatch):
+        cfg = _cfg()
+        cfg.provider_keys = {"anthropic": "vendor-default"}
+        fake = self._fake(cfg, "")
+        captured = {}
+        self._capture_thread_api_key(monkeypatch, captured)
+
+        SettingsDialog._test_connection(fake)
+
+        assert captured["api_key"] == "vendor-default"
+
+    def test_both_blank_yields_empty_string(self, monkeypatch):
+        cfg = _cfg()
+        cfg.provider_keys = {}
+        fake = self._fake(cfg, "")
+        captured = {}
+        self._capture_thread_api_key(monkeypatch, captured)
+
+        SettingsDialog._test_connection(fake)
+
+        assert captured["api_key"] == ""

--- a/tests/unit/test_profile_selector.py
+++ b/tests/unit/test_profile_selector.py
@@ -4,6 +4,10 @@ These call the dialog's methods with a fake self carrying only the
 attributes they touch, so no Qt dialog has to be constructed.
 """
 
+import copy
+import types
+from unittest.mock import MagicMock
+
 import pytest
 
 # settings_dialog/chat_widget import through ui/compat.py, which needs Qt.
@@ -16,12 +20,31 @@ except ImportError:
         pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
 
 from freecad_ai.config import AppConfig, ProviderConfig  # noqa: E402
+from freecad_ai.llm.providers import get_provider_names  # noqa: E402
 from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
 
 
 class _FakeSelf:
+    """Stand-in for the dialog as it looks post-fix: profile edits land in
+    a dialog-local working copy, not in ``cfg`` directly.
+
+    ``_profiles``/``_utility_profiles`` alias ``cfg``'s own dicts rather than
+    copying them — the rename/delete methods under test here only ever
+    mutate a *profile's* contents in place or the containing dict's items in
+    place, never reassign the whole dict, so aliasing keeps the pre-existing
+    assertions on ``cfg.profiles``/``cfg.utility_profiles`` valid. The one
+    exception is ``_active_profile`` (a plain string): a method that
+    reassigns it rebinds the fake's own attribute, not anything on ``cfg``,
+    so callers that care about the new active profile must read
+    ``fake._active_profile`` — see TestRenameCascade.test_active_profile_follows
+    and TestDelete.test_deleting_the_active_profile_moves_the_pointer.
+    """
+
     def __init__(self, cfg):
         self._cfg = cfg
+        self._profiles = cfg.profiles
+        self._active_profile = cfg.active_profile
+        self._utility_profiles = cfg.utility_profiles
 
 
 def _cfg():
@@ -38,18 +61,21 @@ def _cfg():
 class TestRenameCascade:
     def test_profile_is_renamed(self):
         cfg = _cfg()
-        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "ollama-local")
-        assert set(cfg.profiles) == {"cloud", "ollama-local"}
+        fake = _FakeSelf(cfg)
+        SettingsDialog._rename_profile(fake, "local", "ollama-local")
+        assert set(fake._profiles) == {"cloud", "ollama-local"}
 
     def test_settings_travel_with_the_name(self):
         cfg = _cfg()
-        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "ollama-local")
-        assert cfg.profiles["ollama-local"].model == "qwen3:8b"
+        fake = _FakeSelf(cfg)
+        SettingsDialog._rename_profile(fake, "local", "ollama-local")
+        assert fake._profiles["ollama-local"].model == "qwen3:8b"
 
     def test_active_profile_follows(self):
         cfg = _cfg()
-        SettingsDialog._rename_profile(_FakeSelf(cfg), "cloud", "anthropic-main")
-        assert cfg.active_profile == "anthropic-main"
+        fake = _FakeSelf(cfg)
+        SettingsDialog._rename_profile(fake, "cloud", "anthropic-main")
+        assert fake._active_profile == "anthropic-main"
 
     def test_utility_mappings_follow(self):
         """A rename must never silently detach a utility from the profile
@@ -68,8 +94,9 @@ class TestRenameCascade:
     def test_ordering_is_preserved(self):
         """Rebuilding the dict must not reshuffle the combo on the user."""
         cfg = _cfg()
-        SettingsDialog._rename_profile(_FakeSelf(cfg), "cloud", "zzz")
-        assert list(cfg.profiles) == ["zzz", "local"]
+        fake = _FakeSelf(cfg)
+        SettingsDialog._rename_profile(fake, "cloud", "zzz")
+        assert list(fake._profiles) == ["zzz", "local"]
 
     def test_collision_is_refused(self):
         cfg = _cfg()
@@ -83,8 +110,9 @@ class TestRenameCascade:
 
     def test_renaming_to_itself_is_a_no_op(self):
         cfg = _cfg()
-        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "local")
-        assert set(cfg.profiles) == {"cloud", "local"}
+        fake = _FakeSelf(cfg)
+        SettingsDialog._rename_profile(fake, "local", "local")
+        assert set(fake._profiles) == {"cloud", "local"}
 
 
 class TestDelete:
@@ -101,8 +129,9 @@ class TestDelete:
 
     def test_deleting_the_active_profile_moves_the_pointer(self):
         cfg = _cfg()
-        SettingsDialog._delete_profile(_FakeSelf(cfg), "cloud")
-        assert cfg.active_profile == "local"
+        fake = _FakeSelf(cfg)
+        SettingsDialog._delete_profile(fake, "cloud")
+        assert fake._active_profile == "local"
 
     def test_utilities_pointing_at_it_fall_back_to_inherit(self):
         """Leaving a dangling name would work — the resolver tolerates it —
@@ -163,6 +192,7 @@ class TestProfileFieldRoundTrip:
         prof = cfg.profiles[label]
         fake = types.SimpleNamespace(
             _cfg=cfg,
+            _profiles=cfg.profiles,
             _current_profile_label=label,
             base_url_edit=_Edit(prof.base_url),
             api_key_edit=_Edit(prof.api_key),
@@ -224,3 +254,159 @@ class TestProfileFieldRoundTrip:
         assert kinds == ["block", "index", "block"]
         assert fake.provider_combo.calls[0][1] is True
         assert fake.provider_combo.calls[2][1] is False
+
+
+# ── Dialog-local working state (fix round) ─────────────────────────
+#
+# Task 7 wired profile add/rename/delete/edit straight into the live
+# `get_config()` singleton. Cancel is a bare `self.reject()` with no
+# rollback, so OK and Cancel did the same thing to profiles, and an
+# unrelated `save_current_config()` (the vision probe after Test
+# Connection) could flush a discarded edit to disk. The fix gives the
+# dialog its own `_profiles`/`_active_profile`/`_utility_profiles`
+# working copy, populated by `copy.deepcopy` in `_load_from_config`,
+# and only `_save` writes it back into the real config.
+#
+# These fakes deliberately do NOT alias `cfg` the way `_FakeSelf` above
+# does — that aliasing is exactly what let the Task 7 bug hide from the
+# rename/delete unit tests (singleton identity never entered an
+# assertion). Here the config object and the working copy must be able
+# to diverge, so each fake carries its own independent `_profiles`.
+
+class TestCancelDiscardsProfileEdits:
+    """Reviewer finding 1 / the fix's core defect: a delete during the
+    dialog session must not reach `cfg` until `_save` runs."""
+
+    def test_delete_leaves_the_config_object_untouched(self):
+        cfg = _cfg()
+        fake = types.SimpleNamespace(
+            _profiles=copy.deepcopy(cfg.profiles),
+            _active_profile=cfg.active_profile,
+            _utility_profiles=dict(cfg.utility_profiles),
+        )
+
+        SettingsDialog._delete_profile(fake, "local")
+
+        # The assertion that matters is on cfg, not the working copy —
+        # Cancel (a bare reject(), no rollback) relies on cfg never having
+        # been touched in the first place.
+        assert "local" in cfg.profiles
+        # And the working copy did register the delete, so _save (below)
+        # has something real to write back on OK.
+        assert "local" not in fake._profiles
+
+
+class TestSaveWritesBackProfileState:
+    """OK persists: `_save` must copy the dialog's working profile state
+    into the real config, including a profile added during the session."""
+
+    def test_save_writes_profiles_and_active_profile_back(self, monkeypatch):
+        cfg = _cfg()
+        working = copy.deepcopy(cfg.profiles)
+        working["added"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1",
+            model="added-model")
+        names = get_provider_names()
+        idx = names.index("ollama")
+
+        fake = MagicMock()
+        fake._profiles = working
+        fake._active_profile = "added"
+        fake._current_profile_label = "added"
+        # _commit_profile_fields is the real method — it is what reads the
+        # (fake) widgets below into the working profile before the write-back.
+        fake._commit_profile_fields = (
+            lambda: SettingsDialog._commit_profile_fields(fake))
+        fake._read_model_params_table = lambda: {}
+        fake._read_rerank_params_table = lambda: {}
+        fake._read_strip_thinking_state = lambda: None
+        fake._get_default_prompt_text = lambda: ""
+        fake._parse_server_address = lambda host, port: ("127.0.0.1", 8765)
+        fake._parse_allowed_hosts = lambda text: []
+        fake._resolve_rerank_params = lambda model, params: {}
+        fake.accept = lambda: None
+
+        fake.provider_combo.currentIndex.return_value = idx
+        fake.api_key_edit.text.return_value = "k-added"
+        fake.base_url_edit.text.return_value = "http://localhost:11434/v1"
+        fake.model_edit.text.return_value = "added-model"
+        fake.thinking_combo.currentIndex.return_value = 0
+        fake.viewport_capture_combo.currentIndex.return_value = 0
+        fake.viewport_resolution_combo.currentIndex.return_value = 0
+        fake.rerank_method_combo.currentIndex.return_value = 0
+        fake.system_prompt_edit.toPlainText.return_value = ""
+        fake.rerank_pinned_edit.text.return_value = ""
+        fake.rerank_llm_provider_combo.currentData.return_value = ""
+        fake.rerank_llm_base_url_edit.text.return_value = ""
+        fake.rerank_llm_api_key_edit.text.return_value = ""
+        fake.rerank_llm_model_edit.text.return_value = ""
+
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog.get_config", lambda: cfg)
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog.save_current_config", lambda: None)
+
+        SettingsDialog._save(fake)
+
+        assert set(cfg.profiles) == {"cloud", "local", "added"}
+        assert cfg.active_profile == "added"
+        assert cfg.profiles["added"].model == "added-model"
+
+
+class TestWorkingCopyIsIndependent:
+    """A shallow `dict(cfg.profiles)` would pass both tests above and still
+    fail this one — the ProviderConfig objects would be shared, so editing
+    the working copy would edit cfg through the back door. Pins `deepcopy`
+    specifically."""
+
+    def test_mutating_the_working_copy_leaves_cfg_alone(self, monkeypatch):
+        cfg = _cfg()
+        fake = MagicMock()
+        # The one read-back _load_from_config makes: MagicMock's default
+        # return value doesn't compare to an int, so the widget needs a
+        # real one here or `if provider_idx >= 0` raises.
+        fake.rerank_llm_provider_combo.findData.return_value = -1
+
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog.get_config", lambda: cfg)
+
+        SettingsDialog._load_from_config(fake)
+
+        # First pin that a working copy was actually populated (fails loudly,
+        # rather than vacuously passing below, if _load_from_config never
+        # sets self._profiles at all).
+        assert fake._profiles["local"].model == cfg.profiles["local"].model
+
+        fake._profiles["local"].base_url = "http://mutated:9999/v1"
+
+        assert cfg.profiles["local"].base_url != "http://mutated:9999/v1"
+
+
+class TestSaveTempDoesNotMutateStoredProfile:
+    """Change 3: Test Connection must stop smuggling the visible widget
+    values into the active profile through `_save_temp`. Once the working
+    state can diverge from cfg, the visible profile may not even be
+    cfg.active_profile — see the fix brief for the concrete hazard."""
+
+    def test_save_temp_leaves_provider_untouched(self, monkeypatch):
+        cfg = _cfg()
+        original_base_url = cfg.provider.base_url
+        original_name = cfg.provider.name
+
+        fake = MagicMock()
+        fake.provider_combo.currentIndex.return_value = 0
+        fake.model_edit.text.return_value = "typed-model"
+        fake.base_url_edit.text.return_value = "http://typed:1234/v1"
+        fake.api_key_edit.text.return_value = "typed-key"
+        fake.thinking_combo.currentIndex.return_value = 0
+        fake.system_prompt_edit.toPlainText.return_value = ""
+        fake._read_model_params_table = lambda: {}
+        fake._get_default_prompt_text = lambda: ""
+
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog.get_config", lambda: cfg)
+
+        SettingsDialog._save_temp(fake)
+
+        assert cfg.provider.base_url == original_base_url
+        assert cfg.provider.name == original_name

--- a/tests/unit/test_profile_selector.py
+++ b/tests/unit/test_profile_selector.py
@@ -320,12 +320,10 @@ class TestSaveWritesBackProfileState:
         fake._commit_profile_fields = (
             lambda: SettingsDialog._commit_profile_fields(fake))
         fake._read_model_params_table = lambda: {}
-        fake._read_rerank_params_table = lambda: {}
         fake._read_strip_thinking_state = lambda: None
         fake._get_default_prompt_text = lambda: ""
         fake._parse_server_address = lambda host, port: ("127.0.0.1", 8765)
         fake._parse_allowed_hosts = lambda text: []
-        fake._resolve_rerank_params = lambda model, params: {}
         fake.accept = lambda: None
 
         fake.provider_combo.currentIndex.return_value = idx
@@ -338,10 +336,9 @@ class TestSaveWritesBackProfileState:
         fake.rerank_method_combo.currentIndex.return_value = 0
         fake.system_prompt_edit.toPlainText.return_value = ""
         fake.rerank_pinned_edit.text.return_value = ""
-        fake.rerank_llm_provider_combo.currentData.return_value = ""
-        fake.rerank_llm_base_url_edit.text.return_value = ""
-        fake.rerank_llm_api_key_edit.text.return_value = ""
-        fake.rerank_llm_model_edit.text.return_value = ""
+        # utility_combos is a plain dict on the real dialog; an unconfigured
+        # MagicMock's .items() default-iterates empty, so _collect_utility_
+        # profiles({}) == {} — nothing to stub for the utility dropdowns here.
 
         monkeypatch.setattr(
             "freecad_ai.ui.settings_dialog.get_config", lambda: cfg)
@@ -364,10 +361,10 @@ class TestWorkingCopyIsIndependent:
     def test_mutating_the_working_copy_leaves_cfg_alone(self, monkeypatch):
         cfg = _cfg()
         fake = MagicMock()
-        # The one read-back _load_from_config makes: MagicMock's default
-        # return value doesn't compare to an int, so the widget needs a
-        # real one here or `if provider_idx >= 0` raises.
-        fake.rerank_llm_provider_combo.findData.return_value = -1
+        # self._refresh_profile_combo() and self._show_profile(...) below
+        # resolve to fake's own auto-stubbed attributes (fake is a bare
+        # MagicMock, not a SettingsDialog instance), so their real bodies —
+        # and the widgets those bodies touch — never run here.
 
         monkeypatch.setattr(
             "freecad_ai.ui.settings_dialog.get_config", lambda: cfg)
@@ -455,12 +452,10 @@ class TestParamsTableEditSurvivesSaveAndResolve:
         fake._commit_profile_fields = (
             lambda: SettingsDialog._commit_profile_fields(fake))
         fake._read_model_params_table = lambda: dict(table_params)
-        fake._read_rerank_params_table = lambda: {}
         fake._read_strip_thinking_state = lambda: None
         fake._get_default_prompt_text = lambda: ""
         fake._parse_server_address = lambda host, port: ("127.0.0.1", 8765)
         fake._parse_allowed_hosts = lambda text: []
-        fake._resolve_rerank_params = lambda model, params: {}
         fake.accept = lambda: None
 
         names = get_provider_names()
@@ -474,10 +469,6 @@ class TestParamsTableEditSurvivesSaveAndResolve:
         fake.rerank_method_combo.currentIndex.return_value = 0
         fake.system_prompt_edit.toPlainText.return_value = ""
         fake.rerank_pinned_edit.text.return_value = ""
-        fake.rerank_llm_provider_combo.currentData.return_value = ""
-        fake.rerank_llm_base_url_edit.text.return_value = ""
-        fake.rerank_llm_api_key_edit.text.return_value = ""
-        fake.rerank_llm_model_edit.text.return_value = ""
         return fake
 
     def test_edit_survives_save_and_resolve_params(self, monkeypatch):

--- a/tests/unit/test_profile_selector.py
+++ b/tests/unit/test_profile_selector.py
@@ -6,6 +6,7 @@ attributes they touch, so no Qt dialog has to be constructed.
 
 import copy
 import types
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,7 +20,11 @@ except ImportError:
     except ImportError:
         pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
 
-from freecad_ai.config import AppConfig, ProviderConfig  # noqa: E402
+from freecad_ai.config import (  # noqa: E402
+    AppConfig,
+    PROVIDER_PRESETS,
+    ProviderConfig,
+)
 from freecad_ai.llm.providers import get_provider_names  # noqa: E402
 from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
 
@@ -413,14 +418,19 @@ class TestSaveTempDoesNotMutateStoredProfile:
 
 # ── Params table targets the working-copy profile (fix round 2) ────────
 #
-# resolve_params() layers profile.params on top of cfg.model_params, and
-# migration copied a profile's starting params into both places. The
-# dialog's Model Parameters table read/wrote cfg.model_params only, so for
-# any migrated profile the profile layer always won and every edit made
-# through the dialog was silently discarded — demonstrated against a real
-# config: temperature 1 -> 0.2 in the dialog, saved, runtime still resolved
-# 1. These tests pin the fix: the table must read the effective merge and
-# write into the working-copy profile's own params.
+# The dialog's Model Parameters table used to read and write
+# cfg.model_params only, while resolve_params() layered profile.params on
+# top of it — and migration copied a profile's starting params into both
+# places. So for any migrated profile the profile layer always won and
+# every edit made through the dialog was silently discarded: demonstrated
+# against a real config, temperature 1 -> 0.2 in the dialog, saved, runtime
+# still resolved 1.
+#
+# The final review found the other half of the same root cause: the
+# underlay itself. Nothing could write cfg.model_params, so removing a row
+# deleted the key from the profile and the underlay restored it. The
+# profile is now the sole source (see TestParamsTableShowsOnlyTheProfile
+# and tests/unit/test_create_client.py::TestParamLayering).
 
 class TestParamsTableEditSurvivesSaveAndResolve:
     """The regression, end to end — this is the test that would have
@@ -487,28 +497,78 @@ class TestParamsTableEditSurvivesSaveAndResolve:
         assert resolve_params(cfg, cfg.provider)["temperature"] == 0.2
 
 
-class TestParamsTableDisplaysEffectiveMerge:
-    """The table shows exactly what resolve_params() will compute."""
+class TestParamsTableShowsOnlyTheProfile:
+    """The table shows exactly what resolve_params() will compute — which
+    is the profile's own params, and nothing from the legacy
+    cfg.model_params dict."""
 
-    def test_both_layers_appear_profile_wins_on_conflict(self):
+    def _fake(self, cfg, label):
+        prof = cfg.profiles[label]
+        fake = types.SimpleNamespace(
+            _cfg=cfg,
+            _profiles=cfg.profiles,
+            _current_profile_label=label,
+            provider_combo=_Combo(get_provider_names().index(prof.name)),
+        )
+        fake._captured = {}
+        fake._populate_model_params_table = fake._captured.update
+        return fake
+
+    def test_profile_params_are_shown(self):
         cfg = _cfg()
         prof = cfg.profiles["cloud"]
         prof.params = {"temperature": 0.9, "top_p": 0.5}
-        cfg.model_params = {prof.model: {"temperature": 0.1, "max_tokens": 999}}
 
-        fake = types.SimpleNamespace(
-            _profiles=cfg.profiles,
-            _current_profile_label="cloud",
-            provider_combo=_Combo(get_provider_names().index(prof.name)),
-        )
-        captured = {}
-        fake._populate_model_params_table = captured.update
-
+        fake = self._fake(cfg, "cloud")
         SettingsDialog._load_model_params_table(fake, prof.model, cfg, prof)
 
-        assert captured["temperature"] == 0.9  # profile wins the conflict
-        assert captured["top_p"] == 0.5         # profile-only key
-        assert captured["max_tokens"] == 999    # global-only key
+        assert fake._captured == {"temperature": 0.9, "top_p": 0.5}
+
+    def test_legacy_model_params_never_reach_the_table(self):
+        """Re-opening the dialog re-rendered a removed row because the
+        table drew the merge. It must draw the profile."""
+        cfg = _cfg()
+        prof = cfg.profiles["cloud"]
+        prof.params = {"temperature": 0.9}
+        cfg.model_params = {prof.model: {"temperature": 0.1, "max_tokens": 999}}
+
+        fake = self._fake(cfg, "cloud")
+        SettingsDialog._load_model_params_table(fake, prof.model, cfg, prof)
+
+        assert fake._captured == {"temperature": 0.9}
+
+    def test_empty_profile_falls_back_to_the_provider_preset(self):
+        """Both empty-case fallbacks are unchanged by the fix."""
+        cfg = _cfg()
+        prof = cfg.profiles["cloud"]
+        prof.params = {}
+        cfg.model_params = {prof.model: {"temperature": 0.1}}
+
+        fake = self._fake(cfg, "cloud")
+        SettingsDialog._load_model_params_table(fake, prof.model, cfg, prof)
+
+        expected = dict(PROVIDER_PRESETS["anthropic"].get("default_params", {}))
+        if expected:
+            assert fake._captured == expected
+        else:
+            assert fake._captured == {"temperature": cfg.temperature}
+
+    def test_empty_profile_and_empty_preset_falls_back_to_temperature(self):
+        cfg = _cfg()
+        cfg.temperature = 0.42
+        prof = cfg.profiles["cloud"]
+        prof.params = {}
+
+        fake = self._fake(cfg, "cloud")
+        # An index with no default_params of its own, so only the last
+        # fallback can fire.
+        with mock.patch.dict(
+                "freecad_ai.ui.settings_dialog.PROVIDER_PRESETS",
+                {"anthropic": {"base_url": "", "default_model": "",
+                               "default_params": {}}}):
+            SettingsDialog._load_model_params_table(fake, prof.model, cfg, prof)
+
+        assert fake._captured == {"temperature": 0.42}
 
 
 class TestParamsDoNotLeakBetweenProfiles:

--- a/tests/unit/test_profile_selector.py
+++ b/tests/unit/test_profile_selector.py
@@ -1,0 +1,226 @@
+"""Profile management: rename cascades, delete never orphans.
+
+These call the dialog's methods with a fake self carrying only the
+attributes they touch, so no Qt dialog has to be constructed.
+"""
+
+import pytest
+
+# settings_dialog/chat_widget import through ui/compat.py, which needs Qt.
+try:
+    import PySide6  # noqa: F401
+except ImportError:
+    try:
+        import PySide2  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from freecad_ai.config import AppConfig, ProviderConfig  # noqa: E402
+from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
+
+
+class _FakeSelf:
+    def __init__(self, cfg):
+        self._cfg = cfg
+
+
+def _cfg():
+    cfg = AppConfig()
+    cfg.profiles = {
+        "cloud": ProviderConfig(name="anthropic", model="claude-sonnet-4-6"),
+        "local": ProviderConfig(name="ollama", model="qwen3:8b",
+                                base_url="http://localhost:11434/v1"),
+    }
+    cfg.active_profile = "cloud"
+    return cfg
+
+
+class TestRenameCascade:
+    def test_profile_is_renamed(self):
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "ollama-local")
+        assert set(cfg.profiles) == {"cloud", "ollama-local"}
+
+    def test_settings_travel_with_the_name(self):
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "ollama-local")
+        assert cfg.profiles["ollama-local"].model == "qwen3:8b"
+
+    def test_active_profile_follows(self):
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "cloud", "anthropic-main")
+        assert cfg.active_profile == "anthropic-main"
+
+    def test_utility_mappings_follow(self):
+        """A rename must never silently detach a utility from the profile
+        it was using."""
+        cfg = _cfg()
+        cfg.utility_profiles = {"compaction": "local", "rerank": "local"}
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "cheap")
+        assert cfg.utility_profiles == {"compaction": "cheap", "rerank": "cheap"}
+
+    def test_unrelated_mappings_are_untouched(self):
+        cfg = _cfg()
+        cfg.utility_profiles = {"compaction": "cloud", "rerank": "local"}
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "cheap")
+        assert cfg.utility_profiles["compaction"] == "cloud"
+
+    def test_ordering_is_preserved(self):
+        """Rebuilding the dict must not reshuffle the combo on the user."""
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "cloud", "zzz")
+        assert list(cfg.profiles) == ["zzz", "local"]
+
+    def test_collision_is_refused(self):
+        cfg = _cfg()
+        with pytest.raises(ValueError):
+            SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "cloud")
+
+    def test_empty_name_is_refused(self):
+        cfg = _cfg()
+        with pytest.raises(ValueError):
+            SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "  ")
+
+    def test_renaming_to_itself_is_a_no_op(self):
+        cfg = _cfg()
+        SettingsDialog._rename_profile(_FakeSelf(cfg), "local", "local")
+        assert set(cfg.profiles) == {"cloud", "local"}
+
+
+class TestDelete:
+    def test_profile_is_removed(self):
+        cfg = _cfg()
+        SettingsDialog._delete_profile(_FakeSelf(cfg), "local")
+        assert set(cfg.profiles) == {"cloud"}
+
+    def test_deleting_the_last_profile_is_refused(self):
+        cfg = _cfg()
+        del cfg.profiles["local"]
+        with pytest.raises(ValueError):
+            SettingsDialog._delete_profile(_FakeSelf(cfg), "cloud")
+
+    def test_deleting_the_active_profile_moves_the_pointer(self):
+        cfg = _cfg()
+        SettingsDialog._delete_profile(_FakeSelf(cfg), "cloud")
+        assert cfg.active_profile == "local"
+
+    def test_utilities_pointing_at_it_fall_back_to_inherit(self):
+        """Leaving a dangling name would work — the resolver tolerates it —
+        but clearing it keeps the dialog honest about what is configured."""
+        cfg = _cfg()
+        cfg.utility_profiles = {"compaction": "local"}
+        SettingsDialog._delete_profile(_FakeSelf(cfg), "local")
+        assert cfg.utility_profiles.get("compaction", "") == ""
+
+    def test_deleting_an_unknown_profile_is_refused(self):
+        cfg = _cfg()
+        with pytest.raises(ValueError):
+            SettingsDialog._delete_profile(_FakeSelf(cfg), "nope")
+
+
+class _Edit:
+    """Minimal stand-in for QLineEdit."""
+
+    def __init__(self, text=""):
+        self._t = text
+
+    def text(self):
+        return self._t
+
+    def setText(self, t):
+        self._t = t
+
+
+class _Combo:
+    """QComboBox stand-in that records the order of calls made to it.
+
+    The recording is the point: #75 was caused by setCurrentIndex firing
+    the preset handler during a load, so the guard being present and
+    correctly ordered is the behavior under test.
+    """
+
+    def __init__(self, index=0):
+        self._i = index
+        self.calls = []
+
+    def currentIndex(self):
+        return self._i
+
+    def setCurrentIndex(self, i):
+        self._i = i
+        self.calls.append(("index", i))
+
+    def blockSignals(self, b):
+        self.calls.append(("block", b))
+
+
+class TestProfileFieldRoundTrip:
+    """Editing a profile, browsing away and back preserves the edit (#75)."""
+
+    def _fake(self, cfg, label):
+        import types
+        from freecad_ai.llm.providers import get_provider_names
+        prof = cfg.profiles[label]
+        fake = types.SimpleNamespace(
+            _cfg=cfg,
+            _current_profile_label=label,
+            base_url_edit=_Edit(prof.base_url),
+            api_key_edit=_Edit(prof.api_key),
+            model_edit=_Edit(prof.model),
+            provider_combo=_Combo(get_provider_names().index(prof.name)),
+        )
+        fake._load_model_params_table = lambda model, cfg=None: None
+        return fake
+
+    def test_edited_base_url_survives_switching_away_and_back(self):
+        from freecad_ai.config import AppConfig, ProviderConfig
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+
+        cfg = AppConfig()
+        cfg.profiles = {
+            "main": ProviderConfig(name="anthropic",
+                                   base_url="https://api.anthropic.com/v1",
+                                   api_key="k1", model="m1"),
+            "local": ProviderConfig(name="ollama",
+                                    base_url="http://localhost:11434/v1",
+                                    api_key="", model="m2"),
+        }
+        cfg.active_profile = "main"
+
+        fake = self._fake(cfg, "local")
+        fake.base_url_edit.setText("http://spark-2448:11434/v1")
+        SettingsDialog._commit_profile_fields(fake)
+        assert cfg.profiles["local"].base_url == "http://spark-2448:11434/v1"
+
+        # Browse to the other profile and back.
+        SettingsDialog._show_profile(fake, "main")
+        assert fake.base_url_edit.text() == "https://api.anthropic.com/v1"
+        assert cfg.profiles["local"].base_url == "http://spark-2448:11434/v1"
+
+        SettingsDialog._show_profile(fake, "local")
+        assert fake.base_url_edit.text() == "http://spark-2448:11434/v1"
+
+    def test_programmatic_provider_move_is_signal_guarded(self):
+        from freecad_ai.config import AppConfig, ProviderConfig
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+
+        cfg = AppConfig()
+        cfg.profiles = {
+            "main": ProviderConfig(name="anthropic", base_url="u1",
+                                   api_key="k1", model="m1"),
+            "local": ProviderConfig(name="ollama", base_url="u2",
+                                    api_key="", model="m2"),
+        }
+        cfg.active_profile = "main"
+
+        fake = self._fake(cfg, "main")
+        fake.provider_combo.calls.clear()
+        SettingsDialog._show_profile(fake, "local")
+
+        # setCurrentIndex must happen between block(True) and block(False),
+        # or _on_provider_changed fires and overwrites the profile's URL
+        # with the new vendor's preset — which is exactly bug #75.
+        kinds = [c[0] for c in fake.provider_combo.calls]
+        assert kinds == ["block", "index", "block"]
+        assert fake.provider_combo.calls[0][1] is True
+        assert fake.provider_combo.calls[2][1] is False

--- a/tests/unit/test_profiles.py
+++ b/tests/unit/test_profiles.py
@@ -1,0 +1,100 @@
+"""Named connection profiles.
+
+A profile is a ProviderConfig (vendor, url, key, model) plus its own params
+dict. AppConfig holds them in a label-keyed dict; ``cfg.provider`` is a
+property returning the active one, so the 44 existing ``cfg.provider.*``
+sites keep meaning "the active chat connection".
+
+Note the two different names in play: ``profile.name`` is the *vendor*
+(inherited from ProviderConfig, e.g. "ollama"), while a profile's own
+*label* is its key in ``cfg.profiles`` (e.g. "ollama-remote").
+"""
+
+from freecad_ai.config import AppConfig, ProviderConfig
+
+
+class TestDefaultProfile:
+    def test_bare_appconfig_has_exactly_one_profile(self):
+        cfg = AppConfig()
+        assert len(cfg.profiles) == 1
+
+    def test_active_profile_names_that_profile(self):
+        cfg = AppConfig()
+        assert cfg.active_profile in cfg.profiles
+
+    def test_provider_property_returns_the_active_profile(self):
+        cfg = AppConfig()
+        assert cfg.provider is cfg.profiles[cfg.active_profile]
+
+    def test_default_profile_matches_prior_provider_defaults(self):
+        """Prior-version behavior: a fresh config is still Anthropic."""
+        cfg = AppConfig()
+        assert cfg.provider.name == "anthropic"
+        assert cfg.provider.base_url == "https://api.anthropic.com"
+        assert cfg.provider.model == "claude-sonnet-4-6"
+
+    def test_writes_through_the_property_reach_the_profile(self):
+        """The param-store bridge and settings dialog both assign through
+        cfg.provider.*; those writes must land in the stored profile."""
+        cfg = AppConfig()
+        cfg.provider.model = "gemma4:27b"
+        assert cfg.profiles[cfg.active_profile].model == "gemma4:27b"
+
+
+class TestSwitchingActiveProfile:
+    def test_provider_follows_active_profile(self):
+        cfg = AppConfig()
+        cfg.profiles["local"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1", model="qwen3:8b")
+        cfg.active_profile = "local"
+        assert cfg.provider.model == "qwen3:8b"
+
+    def test_editing_one_profile_leaves_the_other_intact(self):
+        """The #75 shape: browsing between connections destroys nothing."""
+        cfg = AppConfig()
+        original = cfg.active_profile
+        cfg.profiles["remote"] = ProviderConfig(
+            name="ollama", base_url="https://gpu.example.net/v1", model="qwen3:32b")
+        cfg.active_profile = "remote"
+        cfg.provider.base_url = "https://gpu.example.net/v1/edited"
+        cfg.active_profile = original
+        cfg.active_profile = "remote"
+        assert cfg.provider.base_url == "https://gpu.example.net/v1/edited"
+        assert cfg.profiles[original].name == "anthropic"
+
+
+class TestProfileParams:
+    def test_params_default_empty(self):
+        assert ProviderConfig().params == {}
+
+    def test_two_profiles_have_independent_params(self):
+        """Retires #30 structurally: there is no shared params namespace."""
+        a = ProviderConfig(model="m", params={"temperature": 0.8})
+        b = ProviderConfig(model="m", params={"temperature": 0.1})
+        assert a.params == {"temperature": 0.8}
+        assert b.params == {"temperature": 0.1}
+
+
+class TestUtilityMapping:
+    def test_utility_profiles_default_empty(self):
+        """Empty means every utility inherits the active profile — the
+        prior-version behavior."""
+        assert AppConfig().utility_profiles == {}
+
+    def test_provider_keys_default_empty(self):
+        assert AppConfig().provider_keys == {}
+
+
+class TestParamStoreBridgeWritesReachTheProfile:
+    def test_apply_overrides_pattern_edits_active_profile(self):
+        """_apply_param_store_overrides assigns cfg.provider.model /
+        .base_url / .api_key / .name. Simulate those assignments and
+        assert they land in the active profile rather than a temporary."""
+        cfg = AppConfig()
+        cfg.provider.name = "ollama"
+        cfg.provider.model = "qwen3:8b"
+        cfg.provider.base_url = "http://localhost:11434/v1"
+        cfg.provider.api_key = "sk-test"
+        stored = cfg.profiles[cfg.active_profile]
+        assert (stored.name, stored.model, stored.base_url, stored.api_key) == (
+            "ollama", "qwen3:8b", "http://localhost:11434/v1", "sk-test")

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -4,8 +4,6 @@ Migration is where the risk concentrates: a wrong call here silently
 mangles a config a user has been running for months.
 """
 
-import pytest
-
 from freecad_ai.config import AppConfig, ProviderConfig
 
 
@@ -187,14 +185,43 @@ class TestEdgeCases:
             rerank_llm_model="gemma3:4b", rerank_params="nope"))
         assert cfg.profiles["rerank"].params == {}
 
-    def test_non_mapping_profile_value_still_raises_typeerror(self):
-        """A malformed *individual* profile (not the profiles dict itself)
-        is a distinct failure mode: it already raised TypeError before this
-        change (caught by load_config's except tuple), and must keep doing
-        so — the exception type is part of the contract even though nothing
-        declares it, so a later refactor can't silently change it."""
-        with pytest.raises(TypeError):
-            AppConfig.from_dict({"profiles": {"a": "nope"}})
+    def test_non_mapping_profile_value_degrades_in_place(self):
+        """A malformed *individual* profile used to raise TypeError, which
+        load_config caught by discarding the entire config and returning
+        bare defaults — which the next save then wrote over the top of.
+        The other four malformed shapes on this path all degrade in place;
+        so does this one now."""
+        cfg = AppConfig.from_dict({
+            "profiles": {
+                "a": "nope",
+                "b": {"name": "ollama", "model": "qwen3:8b",
+                      "base_url": "http://localhost:11434/v1"},
+            },
+            "active_profile": "b",
+            "max_tokens": 8192,
+        })
+        assert isinstance(cfg.profiles["a"], ProviderConfig)
+        assert cfg.profiles["a"] == ProviderConfig()
+        # The rest of the user's config survives.
+        assert cfg.profiles["b"].model == "qwen3:8b"
+        assert cfg.active_profile == "b"
+        assert cfg.max_tokens == 8192
+
+    def test_a_bad_profile_does_not_discard_the_file(self, tmp_config_dir):
+        """The end of the same path: load_config must not fall back to
+        bare defaults."""
+        import json
+        import os
+        import freecad_ai.config as config_mod
+        os.makedirs(os.path.dirname(config_mod.CONFIG_FILE), exist_ok=True)
+        with open(config_mod.CONFIG_FILE, "w") as f:
+            json.dump({
+                "profiles": {"a": "nope"},
+                "active_profile": "a",
+                "max_tokens": 8192,
+            }, f)
+        cfg = config_mod.load_config()
+        assert cfg.max_tokens == 8192
 
 
 class TestLegacyMirrorOnSave:

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -52,9 +52,32 @@ class TestPlainMigration:
         cfg = AppConfig.from_dict(_old_shape())
         assert cfg.model_params == {"qwen3:32b": {"temperature": 0.8, "top_p": 0.9}}
 
-    def test_api_key_also_seeds_the_provider_default(self):
+    def test_the_key_lands_on_the_profile_and_nowhere_else(self):
+        """provider_keys is a hand-written per-vendor default, never
+        auto-populated. Seeding it put a copy of the credential where no
+        widget could see, edit or delete it, so clearing the API Key field
+        to rotate a leaked key left it on disk and still sending."""
         cfg = AppConfig.from_dict(_old_shape())
-        assert cfg.provider_keys["ollama"] == "sk-main"
+        assert cfg.provider.api_key == "sk-main"
+        assert cfg.provider_keys == {}
+
+    def test_clearing_the_migrated_key_actually_clears_it(self):
+        """The end of the same path: with nothing seeded, emptying the
+        profile's key resolves to no key at all."""
+        from freecad_ai.llm.client import create_client
+        cfg = AppConfig.from_dict(_old_shape())
+        cfg.provider.api_key = ""
+        assert create_client(cfg).api_key == ""
+
+    def test_a_hand_written_vendor_default_still_resolves(self):
+        """The fallback itself is unchanged — only its auto-seeding is
+        gone. A user who writes provider_keys into config.json by hand
+        still has every keyless profile on that vendor pick it up."""
+        from freecad_ai.llm.client import create_client
+        cfg = AppConfig.from_dict(_old_shape(
+            provider_keys={"ollama": "sk-vendor-wide"}))
+        cfg.provider.api_key = ""
+        assert create_client(cfg).api_key == "sk-vendor-wide"
 
     def test_no_utility_overrides_without_a_rerank_model(self):
         cfg = AppConfig.from_dict(_old_shape())

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -207,6 +207,29 @@ class TestEdgeCases:
         assert cfg.active_profile == "b"
         assert cfg.max_tokens == 8192
 
+    def test_unknown_profile_key_degrades_in_place(self):
+        """A profile carrying a field this version does not know — written
+        by a *newer* version, then opened by this one — must not take the
+        whole config down with it. Same failure mode as a non-mapping
+        value: ProviderConfig(**p) raises TypeError, load_config catches it
+        by discarding everything, and the next save overwrites the file.
+        This branch is itself about to add profile fields, so the forward
+        direction is the one that will actually happen."""
+        cfg = AppConfig.from_dict({
+            "profiles": {
+                "a": {"name": "ollama", "model": "qwen3:8b",
+                      "invented_by_a_later_version": True},
+            },
+            "active_profile": "a",
+            "max_tokens": 8192,
+        })
+        assert cfg.profiles["a"].model == "qwen3:8b"
+        assert cfg.profiles["a"].name == "ollama"
+        assert not hasattr(cfg.profiles["a"], "invented_by_a_later_version")
+        # The rest of the user's config survives.
+        assert cfg.active_profile == "a"
+        assert cfg.max_tokens == 8192
+
     def test_a_bad_profile_does_not_discard_the_file(self, tmp_config_dir):
         """The end of the same path: load_config must not fall back to
         bare defaults."""

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -207,6 +207,39 @@ class TestEdgeCases:
         assert cfg.active_profile == "b"
         assert cfg.max_tokens == 8192
 
+    def test_pre_rerank_params_config_keeps_the_reranker_params(self):
+        """A config last written before rerank_params existed (<= v0.16.4)
+        kept the override reranker's params in the shared model_params
+        dict, keyed by the reranker's model. load_config used to seed
+        rerank_params from there *after* from_dict returned — too late for
+        the migration running inside it, and into a field nothing reads
+        any more. Fold the same fallback into the migration instead, or
+        the params vanish on upgrade with nothing logged."""
+        cfg = AppConfig.from_dict({
+            "provider": {"name": "moonshot", "model": "kimi-k2.6",
+                         "base_url": "https://api.moonshot.ai/v1"},
+            "model_params": {
+                "qwen3:8b": {"temperature": 0.0, "top_k": 20,
+                             "num_predict": 512},
+            },
+            "rerank_llm_provider_name": "ollama",
+            "rerank_llm_base_url": "http://localhost:11434/v1",
+            "rerank_llm_model": "qwen3:8b",
+        })
+        assert cfg.profiles["rerank"].params == {
+            "temperature": 0.0, "top_k": 20, "num_predict": 512}
+
+    def test_explicit_rerank_params_beat_the_legacy_model_params(self):
+        """Post-#30 configs carry rerank_params; that is the authority and
+        the legacy per-model dict must not merge into it."""
+        cfg = AppConfig.from_dict({
+            "provider": {"name": "moonshot", "model": "kimi-k2.6"},
+            "model_params": {"qwen3:8b": {"temperature": 0.0, "top_k": 20}},
+            "rerank_params": {"temperature": 0.3},
+            "rerank_llm_model": "qwen3:8b",
+        })
+        assert cfg.profiles["rerank"].params == {"temperature": 0.3}
+
     def test_unknown_profile_key_degrades_in_place(self):
         """A profile carrying a field this version does not know — written
         by a *newer* version, then opened by this one — must not take the

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -6,7 +6,7 @@ mangles a config a user has been running for months.
 
 import pytest
 
-from freecad_ai.config import AppConfig
+from freecad_ai.config import AppConfig, ProviderConfig
 
 
 def _old_shape(**extra):
@@ -171,3 +171,43 @@ class TestEdgeCases:
         declares it, so a later refactor can't silently change it."""
         with pytest.raises(TypeError):
             AppConfig.from_dict({"profiles": {"a": "nope"}})
+
+
+from dataclasses import asdict  # noqa: E402
+
+
+class TestLegacyMirrorOnSave:
+    def test_save_still_emits_a_provider_key(self):
+        """Downgrade safety: an older version reads `provider` and finds
+        the user's live connection, not an empty dialog."""
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.to_dict()["provider"]["model"] == "qwen3:32b"
+
+    def test_mirror_tracks_the_active_profile(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        cfg.profiles["cloud"] = ProviderConfig(
+            name="anthropic", model="claude-sonnet-4-6")
+        cfg.active_profile = "cloud"
+        assert cfg.to_dict()["provider"]["name"] == "anthropic"
+
+    def test_profiles_are_serialised(self):
+        d = AppConfig.from_dict(_old_shape()).to_dict()
+        assert d["profiles"]["ollama"]["model"] == "qwen3:32b"
+        assert d["active_profile"] == "ollama"
+
+    def test_round_trip_is_stable(self):
+        first = AppConfig.from_dict(_old_shape())
+        second = AppConfig.from_dict(first.to_dict())
+        assert second.active_profile == first.active_profile
+        assert second.provider.model == first.provider.model
+        assert second.provider.params == first.provider.params
+
+    def test_round_trip_preserves_a_rerank_override(self):
+        first = AppConfig.from_dict(_old_shape(
+            rerank_llm_model="gemma3:4b",
+            rerank_params={"temperature": 0.1},
+        ))
+        second = AppConfig.from_dict(first.to_dict())
+        assert second.utility_profiles == {"rerank": "rerank"}
+        assert second.profiles["rerank"].model == "gemma3:4b"
+        assert second.profiles["rerank"].params == {"temperature": 0.1}

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -4,7 +4,9 @@ Migration is where the risk concentrates: a wrong call here silently
 mangles a config a user has been running for months.
 """
 
-from freecad_ai.config import AppConfig, ProviderConfig
+import pytest
+
+from freecad_ai.config import AppConfig
 
 
 def _old_shape(**extra):
@@ -145,3 +147,27 @@ class TestEdgeCases:
     def test_unknown_keys_are_still_ignored(self):
         cfg = AppConfig.from_dict(_old_shape(nonsense_key=1))
         assert not hasattr(cfg, "nonsense_key")
+
+    def test_non_mapping_profiles_degrades_to_defaults(self):
+        """A hand-edited config.json with 'profiles' as the wrong JSON type
+        (e.g. a list) must not crash config loading — treat it as absent,
+        same as a missing key."""
+        cfg = AppConfig.from_dict({"profiles": ["a"]})
+        assert len(cfg.profiles) == 1
+        assert cfg.provider.name == "anthropic"
+
+    def test_non_mapping_rerank_params_degrades_to_empty(self):
+        """A hand-edited 'rerank_params' that isn't an object (e.g. a
+        string) must not crash migration — treat it as no override params."""
+        cfg = AppConfig.from_dict(_old_shape(
+            rerank_llm_model="gemma3:4b", rerank_params="nope"))
+        assert cfg.profiles["rerank"].params == {}
+
+    def test_non_mapping_profile_value_still_raises_typeerror(self):
+        """A malformed *individual* profile (not the profiles dict itself)
+        is a distinct failure mode: it already raised TypeError before this
+        change (caught by load_config's except tuple), and must keep doing
+        so — the exception type is part of the contract even though nothing
+        declares it, so a later refactor can't silently change it."""
+        with pytest.raises(TypeError):
+            AppConfig.from_dict({"profiles": {"a": "nope"}})

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -1,0 +1,147 @@
+"""Old-shape config.json files load into profiles without behavior change.
+
+Migration is where the risk concentrates: a wrong call here silently
+mangles a config a user has been running for months.
+"""
+
+from freecad_ai.config import AppConfig, ProviderConfig
+
+
+def _old_shape(**extra):
+    """A config.json as written by v0.23.1-alpha and earlier."""
+    data = {
+        "provider": {
+            "name": "ollama",
+            "api_key": "sk-main",
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen3:32b",
+        },
+        "model_params": {"qwen3:32b": {"temperature": 0.8, "top_p": 0.9}},
+        "max_tokens": 8192,
+    }
+    data.update(extra)
+    return data
+
+
+class TestPlainMigration:
+    def test_creates_one_profile_labelled_by_vendor(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert list(cfg.profiles) == ["ollama"]
+
+    def test_that_profile_is_active(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.active_profile == "ollama"
+
+    def test_connection_fields_survive(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.provider.name == "ollama"
+        assert cfg.provider.api_key == "sk-main"
+        assert cfg.provider.base_url == "http://localhost:11434/v1"
+        assert cfg.provider.model == "qwen3:32b"
+
+    def test_model_params_seed_the_profile_params(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.provider.params == {"temperature": 0.8, "top_p": 0.9}
+
+    def test_model_params_dict_is_left_intact(self):
+        """profile.params layers ON TOP of model_params; it does not
+        replace it, and other models' entries must not be disturbed."""
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.model_params == {"qwen3:32b": {"temperature": 0.8, "top_p": 0.9}}
+
+    def test_api_key_also_seeds_the_provider_default(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.provider_keys["ollama"] == "sk-main"
+
+    def test_no_utility_overrides_without_a_rerank_model(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.utility_profiles == {}
+
+    def test_unrelated_fields_still_load(self):
+        cfg = AppConfig.from_dict(_old_shape())
+        assert cfg.max_tokens == 8192
+
+
+class TestRerankOverrideMigration:
+    def _cfg(self):
+        return AppConfig.from_dict(_old_shape(
+            rerank_llm_provider_name="",
+            rerank_llm_base_url="",
+            rerank_llm_api_key="",
+            rerank_llm_model="gemma3:4b",
+            rerank_params={"temperature": 0.1, "top_k": 20},
+        ))
+
+    def test_creates_a_second_profile(self):
+        assert set(self._cfg().profiles) == {"ollama", "rerank"}
+
+    def test_rerank_utility_points_at_it(self):
+        assert self._cfg().utility_profiles == {"rerank": "rerank"}
+
+    def test_empty_override_fields_inherit_from_the_main_profile(self):
+        """The old builder used `or` fallbacks per field; an empty
+        provider/url/key meant "same as main". Migration must bake that in."""
+        rr = self._cfg().profiles["rerank"]
+        assert rr.name == "ollama"
+        assert rr.base_url == "http://localhost:11434/v1"
+        assert rr.api_key == "sk-main"
+
+    def test_override_model_is_kept(self):
+        assert self._cfg().profiles["rerank"].model == "gemma3:4b"
+
+    def test_rerank_params_become_the_profile_params(self):
+        assert self._cfg().profiles["rerank"].params == {
+            "temperature": 0.1, "top_k": 20}
+
+    def test_full_override_keeps_its_own_vendor(self):
+        cfg = AppConfig.from_dict(_old_shape(
+            rerank_llm_provider_name="openai",
+            rerank_llm_base_url="https://api.openai.com/v1",
+            rerank_llm_api_key="sk-rr",
+            rerank_llm_model="gpt-4o-mini",
+        ))
+        rr = cfg.profiles["rerank"]
+        assert (rr.name, rr.base_url, rr.api_key) == (
+            "openai", "https://api.openai.com/v1", "sk-rr")
+
+
+class TestEdgeCases:
+    def test_new_shape_config_is_left_alone(self):
+        """Idempotence: loading an already-migrated config must not
+        re-migrate it from the stale legacy mirror."""
+        cfg = AppConfig.from_dict({
+            "profiles": {
+                "cloud": {"name": "anthropic", "api_key": "sk-a",
+                          "base_url": "https://api.anthropic.com",
+                          "model": "claude-sonnet-4-6", "params": {}},
+                "local": {"name": "ollama", "api_key": "",
+                          "base_url": "http://localhost:11434/v1",
+                          "model": "qwen3:8b", "params": {"top_k": 40}},
+            },
+            "active_profile": "local",
+            "utility_profiles": {"compaction": "local"},
+            "provider": {"name": "stale", "api_key": "", "base_url": "",
+                         "model": "stale-model"},
+        })
+        assert set(cfg.profiles) == {"cloud", "local"}
+        assert cfg.active_profile == "local"
+        assert cfg.provider.model == "qwen3:8b"
+        assert cfg.utility_profiles == {"compaction": "local"}
+
+    def test_custom_provider_with_empty_preset_fields_migrates(self):
+        cfg = AppConfig.from_dict({
+            "provider": {"name": "custom", "api_key": "k",
+                         "base_url": "https://gw.example.net/v1",
+                         "model": "my-model"},
+        })
+        assert cfg.active_profile == "custom"
+        assert cfg.provider.base_url == "https://gw.example.net/v1"
+
+    def test_empty_dict_yields_a_usable_default(self):
+        cfg = AppConfig.from_dict({})
+        assert len(cfg.profiles) == 1
+        assert cfg.provider.name == "anthropic"
+
+    def test_unknown_keys_are_still_ignored(self):
+        cfg = AppConfig.from_dict(_old_shape(nonsense_key=1))
+        assert not hasattr(cfg, "nonsense_key")

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -46,8 +46,9 @@ class TestPlainMigration:
         assert cfg.provider.params == {"temperature": 0.8, "top_p": 0.9}
 
     def test_model_params_dict_is_left_intact(self):
-        """profile.params layers ON TOP of model_params; it does not
-        replace it, and other models' entries must not be disturbed."""
+        """The copy into profile.params does not consume the legacy dict.
+        It stays in the JSON, unread, so a downgrade still finds it and
+        other models' entries are not disturbed."""
         cfg = AppConfig.from_dict(_old_shape())
         assert cfg.model_params == {"qwen3:32b": {"temperature": 0.8, "top_p": 0.9}}
 

--- a/tests/unit/test_profiles_migration.py
+++ b/tests/unit/test_profiles_migration.py
@@ -173,9 +173,6 @@ class TestEdgeCases:
             AppConfig.from_dict({"profiles": {"a": "nope"}})
 
 
-from dataclasses import asdict  # noqa: E402
-
-
 class TestLegacyMirrorOnSave:
     def test_save_still_emits_a_provider_key(self):
         """Downgrade safety: an older version reads `provider` and finds

--- a/tests/unit/test_reranker_namespace.py
+++ b/tests/unit/test_reranker_namespace.py
@@ -17,6 +17,8 @@ These tests now pin that the reranker reads its own profile's params and
 that an inheriting reranker gets the active profile's.
 """
 
+from unittest import mock
+
 import pytest
 
 # settings_dialog/chat_widget import through ui/compat.py which needs PySide.
@@ -31,6 +33,8 @@ except ImportError:
 
 from freecad_ai.config import AppConfig, ProviderConfig  # noqa: E402
 from freecad_ai.llm.client import create_client  # noqa: E402
+from freecad_ai.ui.chat_widget import _run_reranker  # noqa: E402
+from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
 
 
 def _cfg_with_params():
@@ -71,3 +75,77 @@ class TestRerankProfileParams:
         cfg.utility_profiles["rerank"] = "rr"
         create_client(cfg, "rerank")
         assert cfg.profiles["main"].params == {"temperature": 0.8, "top_p": 0.9}
+
+
+# Covers the legacy override persistence path (SettingsDialog._resolve_rerank_
+# params); goes away when the reranker override widgets do.
+class TestResolveRerankParamsWriteRule:
+    def test_override_persists_table(self):
+        """With an override model set, the reranker table is persisted."""
+        out = SettingsDialog._resolve_rerank_params(
+            "rr-model", {"temperature": 0.1, "top_k": 20})
+        assert out == {"temperature": 0.1, "top_k": 20}
+
+    def test_inherit_persists_nothing(self):
+        """Empty override → reranker stores nothing; the main Model
+        Parameters table is the sole owner of the main model's slot. This is
+        the exact guard that fixes the issue #30 clobber."""
+        out = SettingsDialog._resolve_rerank_params(
+            "", {"temperature": 0.1, "top_k": 20})
+        assert out == {}
+
+    def test_whitespace_override_treated_as_inherit(self):
+        """A blank-but-spaces override field is still inherit mode."""
+        out = SettingsDialog._resolve_rerank_params(
+            "   ", {"temperature": 0.1})
+        assert out == {}
+
+
+def _cfg_for_call_site():
+    cfg = AppConfig()
+    cfg.rerank_method = "llm"
+    cfg.profiles = {
+        "main": ProviderConfig(name="ollama",
+                               base_url="http://localhost:11434/v1",
+                               model="main-model"),
+        "rr": ProviderConfig(name="ollama",
+                             base_url="http://localhost:11434/v1",
+                             model="rr-model",
+                             params={"temperature": 0.1, "top_k": 20}),
+    }
+    cfg.active_profile = "main"
+    cfg.utility_profiles["rerank"] = "rr"
+    return cfg
+
+
+class TestRunRerankerCallSite:
+    """_run_reranker (freecad_ai/ui/chat_widget.py) is the actual call site
+    this task rewrote; nothing else in this file exercises it."""
+
+    def test_call_site_passes_job_settings_and_merged_params(self):
+        cfg = _cfg_for_call_site()
+        pairs = [("tool_a", "does a thing")]
+        with mock.patch("freecad_ai.llm.client.create_client") as mock_create, \
+                mock.patch("freecad_ai.tools.reranker.rerank_tools_llm") as mock_llm:
+            mock_llm.return_value = ["tool_a"]
+            _run_reranker(cfg, pairs, "hello")
+
+        assert mock_create.called
+        _, kwargs = mock_create.call_args
+        assert kwargs["max_tokens"] == 1024
+        assert kwargs["thinking"] == "off"
+        assert kwargs["temperature"] == 0.1
+
+    def test_broken_client_falls_back_to_keyword_reranking(self):
+        cfg = _cfg_for_call_site()
+        pairs = [("tool_a", "does a thing")]
+        with mock.patch("freecad_ai.llm.client.create_client",
+                        side_effect=RuntimeError("boom")), \
+                mock.patch("freecad_ai.tools.reranker.rerank_tools_llm") as mock_llm, \
+                mock.patch("freecad_ai.tools.reranker.rerank_tools") as mock_kw:
+            mock_kw.return_value = ["tool_a"]
+            result = _run_reranker(cfg, pairs, "hello")
+
+        assert mock_kw.called
+        assert not mock_llm.called
+        assert result == ["tool_a"]

--- a/tests/unit/test_reranker_namespace.py
+++ b/tests/unit/test_reranker_namespace.py
@@ -77,30 +77,6 @@ class TestRerankProfileParams:
         assert cfg.profiles["main"].params == {"temperature": 0.8, "top_p": 0.9}
 
 
-# Covers the legacy override persistence path (SettingsDialog._resolve_rerank_
-# params); goes away when the reranker override widgets do.
-class TestResolveRerankParamsWriteRule:
-    def test_override_persists_table(self):
-        """With an override model set, the reranker table is persisted."""
-        out = SettingsDialog._resolve_rerank_params(
-            "rr-model", {"temperature": 0.1, "top_k": 20})
-        assert out == {"temperature": 0.1, "top_k": 20}
-
-    def test_inherit_persists_nothing(self):
-        """Empty override → reranker stores nothing; the main Model
-        Parameters table is the sole owner of the main model's slot. This is
-        the exact guard that fixes the issue #30 clobber."""
-        out = SettingsDialog._resolve_rerank_params(
-            "", {"temperature": 0.1, "top_k": 20})
-        assert out == {}
-
-    def test_whitespace_override_treated_as_inherit(self):
-        """A blank-but-spaces override field is still inherit mode."""
-        out = SettingsDialog._resolve_rerank_params(
-            "   ", {"temperature": 0.1})
-        assert out == {}
-
-
 def _cfg_for_call_site():
     cfg = AppConfig()
     cfg.rerank_method = "llm"
@@ -149,3 +125,89 @@ class TestRunRerankerCallSite:
         assert mock_kw.called
         assert not mock_llm.called
         assert result == ["tool_a"]
+
+
+class TestTestRerankerProbeMatchesCreateClient:
+    """The dialog's "Test Reranker" button must resolve its five values
+    (provider, base_url, api_key, model, params) exactly the way
+    create_client(cfg, "rerank") does. Two prior fix rounds on this file
+    were both caused by a probe or editor drifting from create_client —
+    this pins the reranker probe specifically.
+
+    Uses a fake self (only the attributes _test_reranker touches) rather
+    than constructing a real dialog, and patches _TestRerankerThread to
+    capture its constructor args instead of starting a real QThread.
+    """
+
+    def _run_probe(self, cfg, rerank_selection, monkeypatch):
+        captured = {}
+
+        class _CapturingThread:
+            def __init__(self, provider_name, base_url, api_key, model,
+                         model_params, parent=None):
+                captured.update(
+                    provider_name=provider_name, base_url=base_url,
+                    api_key=api_key, model=model, model_params=model_params)
+                self.finished = mock.MagicMock()
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr(
+            "freecad_ai.ui.settings_dialog._TestRerankerThread",
+            _CapturingThread)
+
+        combo = mock.MagicMock()
+        combo.currentData.return_value = rerank_selection
+
+        fake = mock.MagicMock()
+        fake._cfg = cfg
+        fake._profiles = cfg.profiles
+        fake._active_profile = cfg.active_profile
+        fake.utility_combos = {"rerank": combo}
+
+        SettingsDialog._test_reranker(fake)
+        return captured
+
+    def test_override_matches_resolve_profile_and_resolve_params(
+            self, monkeypatch):
+        from freecad_ai.llm.client import resolve_profile, resolve_params
+
+        cfg = _cfg_for_call_site()
+        captured = self._run_probe(cfg, "rr", monkeypatch)
+
+        profile = resolve_profile(cfg, "rerank")
+        assert profile.name == "ollama" and profile.model == "rr-model"
+        assert captured["provider_name"] == profile.name
+        assert captured["base_url"] == profile.base_url
+        assert captured["api_key"] == (
+            profile.api_key or cfg.provider_keys.get(profile.name, ""))
+        assert captured["model"] == profile.model
+        assert captured["model_params"] == resolve_params(cfg, profile) \
+            == {"temperature": 0.1, "top_k": 20}
+
+    def test_inherit_falls_back_to_active_profile(self, monkeypatch):
+        from freecad_ai.llm.client import resolve_profile, resolve_params
+
+        cfg = _cfg_for_call_site()
+        del cfg.utility_profiles["rerank"]  # dropdown on "same as active"
+        captured = self._run_probe(cfg, "", monkeypatch)
+
+        profile = resolve_profile(cfg, "rerank")
+        assert profile is cfg.profiles["main"]
+        assert captured["provider_name"] == profile.name == "ollama"
+        assert captured["model"] == profile.model == "main-model"
+        assert captured["model_params"] == resolve_params(cfg, profile)
+
+    def test_vendor_default_key_fallback_matches_create_client(
+            self, monkeypatch):
+        """A profile with no api_key of its own falls back to the
+        vendor-wide provider_keys entry — exactly like create_client()."""
+        from freecad_ai.llm.client import create_client
+
+        cfg = _cfg_for_call_site()
+        cfg.provider_keys["ollama"] = "vendor-wide-key"
+        captured = self._run_probe(cfg, "rr", monkeypatch)
+
+        client = create_client(cfg, "rerank")
+        assert captured["api_key"] == client.api_key == "vendor-wide-key"

--- a/tests/unit/test_reranker_namespace.py
+++ b/tests/unit/test_reranker_namespace.py
@@ -11,8 +11,10 @@ The fix gives the reranker its own ``cfg.rerank_params`` field:
   - inherit mode (override field empty) → reranker uses the main model's
     params (``cfg.model_params[provider.model]``), and saves nothing of its own.
 
-These tests pin both the runtime read path (``_build_rerank_llm_client``) and the
-persistence rule (``SettingsDialog._resolve_rerank_params``).
+Profiles retire this class of bug structurally: params are a field of a
+profile, so there is no shared namespace for the reranker to reach into.
+These tests now pin that the reranker reads its own profile's params and
+that an inheriting reranker gets the active profile's.
 """
 
 import pytest
@@ -27,57 +29,45 @@ except ImportError:
     except ImportError:
         pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
 
-from freecad_ai.config import AppConfig  # noqa: E402
-from freecad_ai.ui.chat_widget import _build_rerank_llm_client  # noqa: E402
-from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
+from freecad_ai.config import AppConfig, ProviderConfig  # noqa: E402
+from freecad_ai.llm.client import create_client  # noqa: E402
 
 
 def _cfg_with_params():
     cfg = AppConfig()
-    cfg.provider.name = "ollama"
-    cfg.provider.base_url = "http://localhost:11434/v1"
-    cfg.provider.model = "main-model"
-    cfg.model_params = {"main-model": {"temperature": 0.8, "top_p": 0.9}}
-    cfg.rerank_params = {"temperature": 0.1, "top_k": 20}
+    cfg.profiles = {
+        "main": ProviderConfig(name="ollama",
+                               base_url="http://localhost:11434/v1",
+                               model="main-model",
+                               params={"temperature": 0.8, "top_p": 0.9}),
+    }
+    cfg.active_profile = "main"
     return cfg
 
 
-class TestBuildRerankClientReadPath:
-    def test_override_uses_rerank_params(self):
-        """Distinct reranker model → params come from cfg.rerank_params,
-        NOT from cfg.model_params (which has nothing for this model)."""
+class TestRerankProfileParams:
+    def test_override_uses_its_own_profile_params(self):
         cfg = _cfg_with_params()
-        cfg.rerank_llm_model = "rr-model"
-        client = _build_rerank_llm_client(cfg)
+        cfg.profiles["rr"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1",
+            model="rr-model", params={"temperature": 0.1, "top_k": 20})
+        cfg.utility_profiles["rerank"] = "rr"
+        client = create_client(cfg, "rerank")
         assert client.model == "rr-model"
         assert client.model_params == {"temperature": 0.1, "top_k": 20}
 
-    def test_inherit_uses_main_model_params(self):
-        """Empty override → reranker inherits the main model and its params."""
+    def test_inherit_uses_the_active_profile(self):
         cfg = _cfg_with_params()
-        cfg.rerank_llm_model = ""
-        client = _build_rerank_llm_client(cfg)
+        client = create_client(cfg, "rerank")
         assert client.model == "main-model"
         assert client.model_params == {"temperature": 0.8, "top_p": 0.9}
 
-
-class TestResolveRerankParamsWriteRule:
-    def test_override_persists_table(self):
-        """With an override model set, the reranker table is persisted."""
-        out = SettingsDialog._resolve_rerank_params(
-            "rr-model", {"temperature": 0.1, "top_k": 20})
-        assert out == {"temperature": 0.1, "top_k": 20}
-
-    def test_inherit_persists_nothing(self):
-        """Empty override → reranker stores nothing; the main Model
-        Parameters table is the sole owner of the main model's slot. This is
-        the exact guard that fixes the issue #30 clobber."""
-        out = SettingsDialog._resolve_rerank_params(
-            "", {"temperature": 0.1, "top_k": 20})
-        assert out == {}
-
-    def test_whitespace_override_treated_as_inherit(self):
-        """A blank-but-spaces override field is still inherit mode."""
-        out = SettingsDialog._resolve_rerank_params(
-            "   ", {"temperature": 0.1})
-        assert out == {}
+    def test_reranker_params_cannot_reach_the_main_profile(self):
+        """The #30 regression, now impossible by construction."""
+        cfg = _cfg_with_params()
+        cfg.profiles["rr"] = ProviderConfig(
+            name="ollama", base_url="http://localhost:11434/v1",
+            model="main-model", params={"temperature": 0.1})
+        cfg.utility_profiles["rerank"] = "rr"
+        create_client(cfg, "rerank")
+        assert cfg.profiles["main"].params == {"temperature": 0.8, "top_p": 0.9}

--- a/tests/unit/test_settings_dialog_base_url_guard.py
+++ b/tests/unit/test_settings_dialog_base_url_guard.py
@@ -1,0 +1,130 @@
+"""Saving a profile with no Base URL warns instead of failing at request time.
+
+``LLMClient`` builds every request URL as ``f"{base_url}/chat/completions"``,
+so a blank Base URL produces a relative path and a network-layer error far
+from the mistake. The profile restructure deliberately does *not* heal this
+by falling back to the provider preset (that silent substitution is the
+shape of issue #75), so the dialog has to say so out loud at save time.
+"""
+
+import copy
+import types
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+# settings_dialog imports through ui/compat.py, which needs Qt.
+try:
+    import PySide6  # noqa: F401
+except ImportError:
+    try:
+        import PySide2  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from freecad_ai.config import AppConfig, ProviderConfig  # noqa: E402
+from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
+
+
+def _profiles(**base_urls):
+    return {label: ProviderConfig(name="openai", base_url=url, model="m")
+            for label, url in base_urls.items()}
+
+
+class TestFindsIncompleteProfiles:
+    def test_blank_base_url_is_reported_by_label(self):
+        found = SettingsDialog._profiles_missing_base_url(
+            _profiles(Work="https://api.openai.com/v1", Scratch=""))
+        assert found == ["Scratch"]
+
+    def test_whitespace_only_base_url_counts_as_blank(self):
+        found = SettingsDialog._profiles_missing_base_url(
+            _profiles(Scratch="   "))
+        assert found == ["Scratch"]
+
+    def test_complete_profiles_report_nothing(self):
+        found = SettingsDialog._profiles_missing_base_url(
+            _profiles(Work="https://api.openai.com/v1",
+                      Local="http://localhost:11434/v1"))
+        assert found == []
+
+    def test_several_incomplete_profiles_are_all_named(self):
+        found = SettingsDialog._profiles_missing_base_url(
+            _profiles(Zeta="", Alpha="", Work="https://api.openai.com/v1"))
+        # Sorted, so the warning reads the same way twice running.
+        assert found == ["Alpha", "Zeta"]
+
+
+class TestTheWarning:
+    """The guard asks; it does not decide. A pre-existing config with an
+    unused half-filled profile must still be able to save unrelated
+    settings, so declining is a veto the user casts, not one we cast."""
+
+    @staticmethod
+    def _fake(**base_urls):
+        # The real staticmethod, so these exercise the pair as it ships.
+        return types.SimpleNamespace(
+            _profiles=_profiles(**base_urls),
+            _profiles_missing_base_url=SettingsDialog._profiles_missing_base_url)
+
+    def test_no_warning_when_every_profile_is_complete(self):
+        fake = self._fake(Work="https://api.openai.com/v1")
+        with mock.patch("freecad_ai.ui.settings_dialog.QMessageBox") as box:
+            assert SettingsDialog._confirm_incomplete_profiles(fake) is True
+        box.question.assert_not_called()
+
+    def test_confirming_lets_the_save_proceed(self):
+        fake = self._fake(Scratch="")
+        with mock.patch("freecad_ai.ui.settings_dialog.QMessageBox") as box:
+            box.question.return_value = box.Yes
+            assert SettingsDialog._confirm_incomplete_profiles(fake) is True
+        assert box.question.called
+
+    def test_declining_stops_the_save(self):
+        fake = self._fake(Scratch="")
+        with mock.patch("freecad_ai.ui.settings_dialog.QMessageBox") as box:
+            box.question.return_value = box.No
+            assert SettingsDialog._confirm_incomplete_profiles(fake) is False
+
+    def test_the_warning_names_the_offending_profiles(self):
+        fake = self._fake(Scratch="", Spare="")
+        with mock.patch("freecad_ai.ui.settings_dialog.QMessageBox") as box:
+            box.question.return_value = box.Yes
+            SettingsDialog._confirm_incomplete_profiles(fake)
+        text = " ".join(str(a) for a in box.question.call_args[0])
+        assert "Scratch" in text and "Spare" in text
+
+
+class TestSaveIsWiredToTheGuard:
+    """The guard is worth nothing if _save does not consult it, and consult
+    it before anything reaches the live config singleton."""
+
+    def _fake(self, allowed):
+        return types.SimpleNamespace(
+            _commit_profile_fields=MagicMock(),
+            _confirm_incomplete_profiles=MagicMock(return_value=allowed),
+            accept=MagicMock())
+
+    def test_declining_leaves_the_live_config_untouched(self):
+        cfg = AppConfig()
+        cfg.profiles = _profiles(Work="https://api.openai.com/v1")
+        cfg.active_profile = "Work"
+        before = copy.deepcopy(cfg.profiles)
+        fake = self._fake(allowed=False)
+        with mock.patch("freecad_ai.ui.settings_dialog.get_config",
+                        return_value=cfg):
+            SettingsDialog._save(fake)
+        assert cfg.profiles == before
+        fake.accept.assert_not_called()
+
+    def test_the_visible_edits_are_committed_before_the_guard_runs(self):
+        # The guard inspects _profiles, so an edit still sitting in the
+        # widgets has to land there first or a just-cleared Base URL slips
+        # through unremarked.
+        cfg = AppConfig()
+        fake = self._fake(allowed=False)
+        with mock.patch("freecad_ai.ui.settings_dialog.get_config",
+                        return_value=cfg):
+            SettingsDialog._save(fake)
+        fake._commit_profile_fields.assert_called_once()

--- a/tests/unit/test_settings_dialog_provider_change.py
+++ b/tests/unit/test_settings_dialog_provider_change.py
@@ -11,7 +11,7 @@ pattern — no QApplication required.
 
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,20 +26,30 @@ except ImportError:
     except ImportError:
         pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
 
-from freecad_ai.config import PROVIDER_PRESETS  # noqa: E402
+from freecad_ai.config import (  # noqa: E402
+    AppConfig,
+    PROVIDER_PRESETS,
+    ProviderConfig,
+)
 from freecad_ai.llm.providers import get_provider_names  # noqa: E402
 from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
 
 
-def _make_fake_dialog(base_url="http://gateway.example/v1", model="my-model"):
+def _make_fake_dialog(base_url="http://gateway.example/v1", model="my-model",
+                     profile=None):
     """Build a fake dialog with just the attributes _on_provider_changed touches."""
     base_url_edit = MagicMock()
     base_url_edit.text.return_value = base_url
     model_edit = MagicMock()
     model_edit.text.return_value = model
+    cfg = AppConfig()
+    profiles = {"p": profile} if profile is not None else {}
     return SimpleNamespace(
         base_url_edit=base_url_edit,
         model_edit=model_edit,
+        _cfg=cfg,
+        _profiles=profiles,
+        _current_profile_label="p",
         _load_model_params_table=MagicMock(),
         _rerank_at_factory_defaults=MagicMock(return_value=False),
         _apply_rerank_defaults=MagicMock(),
@@ -54,8 +64,7 @@ def test_switch_to_custom_preserves_fields():
 
     fake = _make_fake_dialog()
     custom_idx = get_provider_names().index("custom")
-    with patch("freecad_ai.ui.settings_dialog.get_config", return_value=MagicMock()):
-        SettingsDialog._on_provider_changed(cast(SettingsDialog, fake),custom_idx)
+    SettingsDialog._on_provider_changed(cast(SettingsDialog, fake), custom_idx)
 
     fake.base_url_edit.setText.assert_not_called()
     fake.model_edit.setText.assert_not_called()
@@ -69,8 +78,7 @@ def test_switch_to_real_provider_applies_preset():
     """Anthropic (or any non-custom provider) overwrites fields as before."""
     fake = _make_fake_dialog()
     anthropic_idx = get_provider_names().index("anthropic")
-    with patch("freecad_ai.ui.settings_dialog.get_config", return_value=MagicMock()):
-        SettingsDialog._on_provider_changed(cast(SettingsDialog, fake),anthropic_idx)
+    SettingsDialog._on_provider_changed(cast(SettingsDialog, fake), anthropic_idx)
 
     fake.base_url_edit.setText.assert_called_once_with(
         PROVIDER_PRESETS["anthropic"]["base_url"])
@@ -86,3 +94,19 @@ def test_invalid_index_is_noop():
     fake.base_url_edit.setText.assert_not_called()
     fake.model_edit.setText.assert_not_called()
     fake._load_model_params_table.assert_not_called()
+
+
+def test_params_table_reload_gets_the_working_copy_profile():
+    """A vendor switch must keep the profile's own parameters. Passing
+    the working-copy profile (never the get_config() singleton, and never
+    None) is what makes the new preset's default_params a fallback rather
+    than an override."""
+    profile = ProviderConfig(name="ollama", model="qwen3:8b",
+                             params={"top_k": 40})
+    fake = _make_fake_dialog(profile=profile)
+    SettingsDialog._on_provider_changed(
+        cast(SettingsDialog, fake), get_provider_names().index("anthropic"))
+
+    args, kwargs = fake._load_model_params_table.call_args
+    assert args[1] is fake._cfg
+    assert args[2] is profile

--- a/tests/unit/test_settings_dialog_provider_change.py
+++ b/tests/unit/test_settings_dialog_provider_change.py
@@ -43,6 +43,7 @@ def _make_fake_dialog(base_url="http://gateway.example/v1", model="my-model"):
         _load_model_params_table=MagicMock(),
         _rerank_at_factory_defaults=MagicMock(return_value=False),
         _apply_rerank_defaults=MagicMock(),
+        _commit_profile_fields=MagicMock(),
     )
 
 

--- a/tests/unit/test_utility_call_sites.py
+++ b/tests/unit/test_utility_call_sites.py
@@ -42,3 +42,41 @@ class TestToolOptimizer:
             _ask_llm_for_modification("skill", 1, 0.5, "results", "strategy")
         assert mk.call_args.args[1:] == ("tool_optimize",) or \
             mk.call_args.kwargs.get("utility") == "tool_optimize"
+
+
+class TestSkillEvaluator:
+    def test_skill_eval_schema_follows_its_own_profile_not_the_active_one(self):
+        from freecad_ai.config import AppConfig, ProviderConfig
+        from freecad_ai.extensions.skill_evaluator import SkillEvaluator
+
+        cfg = AppConfig()
+        cfg.profiles = {
+            "cloud": ProviderConfig(name="openai", api_key="sk-cloud",
+                                     base_url="https://api.openai.com/v1",
+                                     model="gpt-4o"),
+            "eval": ProviderConfig(name="anthropic", api_key="sk-eval",
+                                    base_url="https://api.anthropic.com",
+                                    model="claude-sonnet-4-6"),
+        }
+        cfg.active_profile = "cloud"
+        cfg.utility_profiles["skill_eval"] = "eval"
+
+        fake_client = MagicMock()
+        fake_client.api_style = "anthropic"
+
+        fake_registry = MagicMock()
+        fake_registry.to_anthropic_schema.return_value = []
+        fake_registry.to_openai_schema.return_value = []
+
+        evaluator = SkillEvaluator({}, tool_executor=None)
+        with patch("freecad_ai.config.get_config", return_value=cfg), \
+             patch("freecad_ai.llm.client.create_client",
+                   return_value=fake_client), \
+             patch("freecad_ai.tools.setup.create_default_registry",
+                   return_value=fake_registry), \
+             patch("freecad_ai.core.system_prompt.build_system_prompt",
+                   return_value="system prompt"):
+            evaluator.evaluate("s", "content", test_cases=[])
+
+        assert fake_registry.to_anthropic_schema.called is True
+        assert fake_registry.to_openai_schema.called is False

--- a/tests/unit/test_utility_call_sites.py
+++ b/tests/unit/test_utility_call_sites.py
@@ -1,0 +1,44 @@
+"""Each utility call site asks for its own identifier.
+
+Testing intent rather than plumbing: patch create_client, run the call
+site, assert which utility name it requested. Without this, a call site
+silently keeps using the chat model and nobody notices.
+"""
+
+import pytest
+
+# settings_dialog/chat_widget import through ui/compat.py, which needs Qt.
+try:
+    import PySide6  # noqa: F401
+except ImportError:
+    try:
+        import PySide2  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+
+class TestCompaction:
+    def test_requests_the_compaction_utility(self):
+        from freecad_ai.ui.chat_widget import _CompactionWorker
+        worker = _CompactionWorker("some conversation text")
+        fake = MagicMock()
+        fake.send.return_value = "summary"
+        with patch("freecad_ai.llm.client.create_client",
+                   return_value=fake) as mk:
+            worker.run()
+        assert mk.call_args.args[1:] == ("compaction",) or \
+            mk.call_args.kwargs.get("utility") == "compaction"
+
+
+class TestToolOptimizer:
+    def test_requests_the_tool_optimize_utility(self):
+        from freecad_ai.tools.optimize_tools import _ask_llm_for_modification
+        fake = MagicMock()
+        fake.send.return_value = "```skill\ncontent\n```"
+        with patch("freecad_ai.llm.client.create_client",
+                   return_value=fake) as mk:
+            _ask_llm_for_modification("skill", 1, 0.5, "results", "strategy")
+        assert mk.call_args.args[1:] == ("tool_optimize",) or \
+            mk.call_args.kwargs.get("utility") == "tool_optimize"

--- a/tests/unit/test_utility_call_sites.py
+++ b/tests/unit/test_utility_call_sites.py
@@ -71,12 +71,20 @@ class TestSkillEvaluator:
         evaluator = SkillEvaluator({}, tool_executor=None)
         with patch("freecad_ai.config.get_config", return_value=cfg), \
              patch("freecad_ai.llm.client.create_client",
-                   return_value=fake_client), \
+                   return_value=fake_client) as mk, \
              patch("freecad_ai.tools.setup.create_default_registry",
                    return_value=fake_registry), \
              patch("freecad_ai.core.system_prompt.build_system_prompt",
                    return_value="system prompt"):
             evaluator.evaluate("s", "content", test_cases=[])
 
+        # The identifier, like the other three call sites. Without this the
+        # test passes whether production asks for "skill_eval" or takes the
+        # active profile, because the patched client answers "anthropic"
+        # either way.
+        assert mk.call_args.args[1:] == ("skill_eval",) or \
+            mk.call_args.kwargs.get("utility") == "skill_eval"
+        # And the schema still follows that client's own api_style — the
+        # Task 5 guard, which is a different failure.
         assert fake_registry.to_anthropic_schema.called is True
         assert fake_registry.to_openai_schema.called is False

--- a/tests/unit/test_utility_dropdowns.py
+++ b/tests/unit/test_utility_dropdowns.py
@@ -42,7 +42,7 @@ class TestUtilityIdentifiers:
             assert f'QT_TRANSLATE_NOOP("SettingsDialog", "{label}")' in source
 
     def test_the_noop_leaves_the_label_untouched_at_runtime(self):
-        from freecad_ai.ui.compat import QT_TRANSLATE_NOOP
+        from freecad_ai.i18n import QT_TRANSLATE_NOOP
         assert QT_TRANSLATE_NOOP("SettingsDialog", "Tool reranking") == \
             "Tool reranking"
 

--- a/tests/unit/test_utility_dropdowns.py
+++ b/tests/unit/test_utility_dropdowns.py
@@ -1,0 +1,48 @@
+"""Utility → profile mapping, as the dialog collects it.
+
+_collect_utility_profiles takes what the dropdowns hold and produces the
+config dict, so the filtering rule (inherit is stored as absent, not as a
+dangling name) is testable without Qt.
+"""
+
+import pytest
+
+# settings_dialog/chat_widget import through ui/compat.py, which needs Qt.
+try:
+    import PySide6  # noqa: F401
+except ImportError:
+    try:
+        import PySide2  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
+
+
+class TestUtilityIdentifiers:
+    def test_all_four_are_offered(self):
+        assert {u for u, _ in SettingsDialog.UTILITIES} == {
+            "compaction", "skill_eval", "tool_optimize", "rerank"}
+
+    def test_each_has_a_label(self):
+        assert all(label for _, label in SettingsDialog.UTILITIES)
+
+
+class TestCollect:
+    def test_inherit_is_stored_as_absent(self):
+        """An empty selection means inherit; storing it as a key with an
+        empty value would work but leaves noise in config.json."""
+        assert SettingsDialog._collect_utility_profiles(
+            {"compaction": "", "rerank": ""}) == {}
+
+    def test_explicit_choices_are_kept(self):
+        assert SettingsDialog._collect_utility_profiles(
+            {"compaction": "cheap", "rerank": ""}) == {
+                "compaction": "cheap"}
+
+    def test_unknown_utilities_are_dropped(self):
+        """Defends the config against a stale key from a future version
+        being written back by an older one."""
+        assert SettingsDialog._collect_utility_profiles(
+            {"compaction": "cheap", "not_a_utility": "x"}) == {
+                "compaction": "cheap"}

--- a/tests/unit/test_utility_dropdowns.py
+++ b/tests/unit/test_utility_dropdowns.py
@@ -27,6 +27,25 @@ class TestUtilityIdentifiers:
     def test_each_has_a_label(self):
         assert all(label for _, label in SettingsDialog.UTILITIES)
 
+    def test_each_label_is_extractable_for_translation(self):
+        """translations/update_translations.sh runs pylupdate5, which
+        extracts string *literals* only. The labels are translated at the
+        use site through a loop variable, so the literal pylupdate sees has
+        to be here, in the table — otherwise these four strings can never
+        be translated, however correct the runtime translate() call looks.
+        """
+        import inspect
+        from freecad_ai.ui import settings_dialog
+
+        source = inspect.getsource(settings_dialog)
+        for _utility, label in SettingsDialog.UTILITIES:
+            assert f'QT_TRANSLATE_NOOP("SettingsDialog", "{label}")' in source
+
+    def test_the_noop_leaves_the_label_untouched_at_runtime(self):
+        from freecad_ai.ui.compat import QT_TRANSLATE_NOOP
+        assert QT_TRANSLATE_NOOP("SettingsDialog", "Tool reranking") == \
+            "Tool reranking"
+
 
 class TestCollect:
     def test_inherit_is_stored_as_absent(self):


### PR DESCRIPTION
I'm an AI assistant handling this on Alfred's behalf.

Closes #75.

## What this is

LLM connection settings become **named profiles**. Every call site that talks to a model — chat, context compaction, skill evaluation, tool optimisation, tool reranking — picks a profile, or inherits the one chat is on.

`ollama-local` and `ollama-remote` can now coexist with different URLs and keys. Chat can run on a large cloud model while the throwaway utility work runs somewhere cheap or local.

## Why, rather than a targeted fix

#75 is that switching provider silently overwrites a Base URL you edited. The narrow fix is to stop clobbering the field. The reason it clobbers is structural: there is exactly **one** connection in the config, so every screen that wants a different endpoint has to either overwrite that one or grow a parallel set of fields beside it.

The reranker had already grown that parallel set — four override fields plus a params dict — and #30 was the collision that followed, its params landing in the same `model_params` slot as the chat model's. A second such feature would have grown a third set.

So: one profile type, many named instances, and every consumer names the one it wants.

- **#75** is fixed by construction — a profile owns its own URL, so nothing can overwrite another's.
- **#30** is retired by construction — the reranker is a profile, with its own params. (Already closed; the shared slot it collided in is now gone.)

Pointing a profile at a *different vendor* still loads that vendor's preset URL and model, as it always has. That is an explicit "point this profile elsewhere", not the silent clobber #75 is about.

## Upgrading

Your existing flat config migrates into a profile named after its provider, which becomes the active one. An existing reranker override becomes a profile named `rerank`, wired to the reranking utility. Nothing to do by hand.

That claim is measured, not asserted. A probe resolves the `LLMClient` arguments (provider, base URL, key, model, params) for chat and all four utilities, on this branch and on master at `1577402`, across five config fixtures: a pre-v0.16.5 config, a post-#30 config, one with no reranker override, a bare config, and a copy of a real one. **All five resolve byte-identically to master.** The probe was then confirmed to redden at `aa0853b^`, so it is a real guard rather than a tautology.

## Notes for review

- **`cfg.model_params` and `cfg.provider_keys` are now legacy** — read only by migration. Sampling parameters live on the profile, which makes removing a row in the Model Parameters table actually remove the parameter. It previously did not: the shared dict was underlaid at resolution time and no widget could write it.
  - That "a store decides the outcome, and no widget can write it" shape turned up **seven times** across this branch's reviews. It is invisible to a `cfg.<attr> =` audit, because the defect is an *absent* write. Worth knowing about if you touch this area.
  - `provider_keys` is consequently never auto-populated any more. It stays supported as a hand-edited default in `config.json`; the dialog edits a profile's own key, and clearing that field clears it. Documented in the README.
- **Saving a profile with a blank Base URL now asks first**, naming the profiles concerned. Resolution deliberately does *not* substitute the provider preset for a blank — that silent substitution is #75's own shape — so a blank would otherwise fail at request time with a bare connection error. It asks rather than refuses, so a pre-existing half-filled profile you never select cannot strand every other setting in the dialog behind it.
- **Selecting a profile in the dropdown only opens it for editing.** A separate "Use this profile for chat" checkbox says which one chat runs on, and the dropdown marks it `(active)`. Browsing your profiles never re-points chat.
- The design doc and implementation plan are included under `docs/superpowers/`.

## Testing

**1356 unit tests pass** (`env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py`), up from 1218 on master. Rebased onto `4863ad4` with no conflicts.

**What is not covered:** none of this has been driven in a live FreeCAD GUI — this was built on a headless box, and the parts that need a real dialog plus real API spend (the profile dropdown's ten state transitions, Test Connection against each profile, the vision probe) were verified against an offscreen `SettingsDialog` and by unit test, not by hand. Worth a pass before release.
