### PR TITLE
fix(settings): size the dialog from its layout so Delete is not clipped

### DIFF
--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -236,13 +236,26 @@ class SettingsDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle(translate("SettingsDialog", "FreeCAD AI Settings"))
-        self.setMinimumWidth(500)
         self.setMinimumHeight(400)
-        self.resize(540, 700)
         self._test_thread = None
         self._last_default_prompt = ""
         self._cfg = get_config()
         self._build_ui()
+        # Width comes from the built layout, never a constant. The profile
+        # row (combo + New/Rename/Delete) is the widest thing on the form
+        # and its buttons are translated, so a hardcoded width clips the
+        # rightmost one in some locale — which is how a 540 predating that
+        # row came to hide Delete behind a horizontal scrollbar. Must run
+        # after _build_ui(): sizeHint() before it describes an empty dialog.
+        # Height stays fixed; the content is taller than most screens and
+        # is meant to scroll — which is also why the vertical scrollbar is
+        # always there, and why its width has to be added on: sizeHint()
+        # does not reserve room for it, leaving the form overflowing by
+        # exactly one scrollbar and growing a horizontal one to say so.
+        width = self.sizeHint().width() + self.style().pixelMetric(
+            QtWidgets.QStyle.PM_ScrollBarExtent)
+        self.setMinimumWidth(width)
+        self.resize(width, 700)
         self._load_from_config()
 
     def _build_ui(self):

--- a/tests/unit/test_settings_dialog_geometry.py
+++ b/tests/unit/test_settings_dialog_geometry.py
@@ -1,0 +1,74 @@
+"""The Settings dialog must open wide enough to show everything on it.
+
+Geometry is one of the few things no fake-self test can reach: the bug
+this guards against (the profile row's Delete button falling off the right
+edge) is invisible to every assertion that does not lay real widgets out.
+"""
+
+import os
+
+import pytest
+
+# Must be set before the first QApplication is constructed.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6 import QtCore, QtWidgets
+except ImportError:
+    try:
+        from PySide2 import QtCore, QtWidgets  # noqa: F401
+    except ImportError:
+        pytest.skip("PySide6/PySide2 not available", allow_module_level=True)
+
+from freecad_ai.ui.settings_dialog import SettingsDialog  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+@pytest.fixture
+def dialog(qapp, tmp_config_dir):
+    dlg = SettingsDialog()
+    dlg.show()
+    qapp.processEvents()
+    yield dlg
+    dlg.close()
+    dlg.deleteLater()
+    qapp.processEvents()
+
+
+def _right_edge_in(widget, container):
+    return widget.mapTo(
+        container, QtCore.QPoint(widget.width(), 0)).x()
+
+
+@pytest.mark.parametrize(
+    "button", ["profile_add_btn", "profile_rename_btn", "profile_delete_btn"])
+def test_every_profile_button_is_visible_at_the_default_size(dialog, button):
+    # Delete is the rightmost and so the first to be clipped, but the row is
+    # translated: in another locale a different one runs off the edge first.
+    btn = getattr(dialog, button)
+    assert _right_edge_in(btn, dialog) <= dialog.width(), (
+        "%s extends past the dialog's right edge" % button)
+
+
+def test_the_default_size_is_at_least_what_the_layout_asks_for(dialog):
+    # The regression was a hardcoded resize() that had fallen behind the
+    # content it was sizing, so compare against the layout's own answer
+    # rather than against another constant.
+    assert dialog.width() >= dialog.sizeHint().width()
+
+
+def test_the_content_fits_without_a_horizontal_scrollbar(dialog):
+    areas = dialog.findChildren(QtWidgets.QScrollArea)
+    assert areas, "expected the settings body to be scrollable"
+    for area in areas:
+        assert (area.horizontalScrollBar().isVisible() is False
+                or area.widget().sizeHint().width()
+                <= area.viewport().width()), (
+            "settings content is wider than its viewport")


### PR DESCRIPTION
I'm an AI assistant handling this on Alfred's behalf.

Reported by the maintainer with a screenshot: the **Delete** button on the new profile row is cut off by the dialog's right edge, and the settings body has a horizontal scrollbar along the bottom.

## Cause

`resize(540, 700)` in `SettingsDialog.__init__` predates the profile row added by #77. That row — combo + New + Rename + Delete — is now the widest thing on the form. Measured on the reported build, Delete spans x=484..564 inside a 540px dialog, and the scrollable body wants 583px against a 505px viewport.

Only unreleased master is affected; the clipping never reached a release, so there is no CHANGELOG entry.

## Fix

The width now comes from the built layout instead of a constant, computed after `_build_ui()` — before it, `sizeHint()` describes an empty dialog. A new constant would rot the same way the next time the form grows, and the buttons are translated, so which one is rightmost is not knowable here.

`sizeHint()` alone was still 14px short. A `QScrollArea`'s hint does not reserve room for its own vertical scrollbar; this form is always taller than the dialog, so that bar is always present, takes its width out of the viewport, and Qt adds a *horizontal* scrollbar to report the overflow. `PM_ScrollBarExtent` adds it back at the current style's width, so it stays correct under a different theme.

Measured 605 → 619 wide; content 583 now fits a 583 viewport, and the horizontal scrollbar is gone. Verified by rendering the dialog offscreen and inspecting the image, not only by assertion.

## Tests

**1361 pass** (was 1356). The five new tests build a **real offscreen dialog** — a first for this repo, and necessary: geometry is invisible to every fake-self test, which is why 1356 passing tests did not catch this.

They assert on all three profile buttons rather than only Delete, since the row is translated and a different button is rightmost in another locale, and they compare the dialog's width against the layout's own answer rather than against another hardcoded number.

Caveat as usual: verified offscreen on a headless box, not in a live FreeCAD GUI.
