### PR TITLE
fix: detected capabilities belong to the profile they were detected on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `"ollama-local": Connected! ...` or `"ollama-local": Failed: ...`. The
   name is captured when the probe starts, so switching profiles while one
   is in flight cannot mislabel the result.
+- The **Model supports vision** checkbox moved out of **Behavior** and into
+  the **LLM Provider** group, directly under the model it describes. It is
+  a property of one profile's model, not a global setting, and now reads
+  and writes the profile currently open in the dialog.
 
 ### Fixed
+
+- Detected model capabilities now belong to the profile they were detected
+  on. Test Connection probes whichever profile is open in the dialog, but
+  vision, tool-calling and thinking support were recorded once for the
+  whole configuration — so testing a reranking or utility profile
+  overwrote the chat model's capabilities, and saved them to disk
+  immediately. The sharpest edge was tool support: probe an embedding
+  model on any profile and the answer "no tools" applied to chat, which
+  then stopped sending tools altogether. Each profile now carries its own
+  detection, retyping a profile's provider or model clears only that
+  profile's now-stale results, and a probe result lands in the dialog's
+  working copy like every other profile field — reaching `config.json` on
+  OK rather than the moment the probe returns. Existing settings migrate
+  onto the active profile on first load, and are still written to the top
+  level of `config.json` so an older version reads them.
 
 - Switching between profiles in the Settings dialog is lossless (#75).
   Each profile keeps its own base URL, key, model and parameters, so

--- a/freecad_ai/config.py
+++ b/freecad_ai/config.py
@@ -385,6 +385,18 @@ class ProviderConfig:
     base_url: str = "https://api.anthropic.com"
     model: str = "claude-sonnet-4-6"
     params: dict = field(default_factory=dict)
+    # Capabilities are a property of *this* connection's model, so they
+    # live here rather than on AppConfig. Test Connection probes whichever
+    # profile is on screen; global flags meant probing a reranker profile
+    # rewrote the chat model's capabilities — and tools_detected=False
+    # silently disables tool calling for chat entirely.
+    vision_detected: bool | None = None   # None=not tested, True/False=probe
+    vision_override: bool | None = None   # user manual override, wins
+    tools_detected: bool | None = None    # Ollama /api/show "tools"
+    thinking_detected: bool | None = None  # Ollama /api/show "thinking"
+
+    CAPABILITY_FIELDS = ("vision_detected", "vision_override",
+                         "tools_detected", "thinking_detected")
 
     def apply_preset(self, provider_name: str):
         """Apply a provider preset, updating base_url and model to defaults."""
@@ -486,14 +498,12 @@ class AppConfig:
     # an MDI sub-window of the main window.
     use_external_editor: bool = False
     system_prompt_override: str = ""  # empty = use default; non-empty = use as-is
-    vision_detected: bool | None = None   # None=not tested, True/False=probe result
-    vision_override: bool | None = None   # user manual override, takes precedence
-    # Tool-calling capability (Ollama /api/show "tools"). None=untested or
-    # non-Ollama (in which case provider.supports_tools is the source of truth).
-    # False explicitly = the model doesn't support tools (e.g. embedding/reranker
-    # picked as main model) → suppress tools array in chat sends.
+    # LEGACY, unread since capabilities moved onto the profile. Kept in the
+    # JSON for one release so a downgrade still finds them, and mirrored
+    # from the active profile on save — like the ``provider`` mirror.
+    vision_detected: bool | None = None
+    vision_override: bool | None = None
     tools_detected: bool | None = None
-    # Thinking capability (Ollama /api/show "thinking"). Diagnostic-only today.
     thinking_detected: bool | None = None
 
     # Tool reranking — when active, only the top-N most relevant tools
@@ -579,11 +589,12 @@ class AppConfig:
 
     @property
     def supports_vision(self) -> bool:
-        """Whether the current LLM supports vision (images in content blocks)."""
-        if self.vision_override is not None:
-            return self.vision_override
-        if self.vision_detected is not None:
-            return self.vision_detected
+        """Whether the active profile's LLM supports vision."""
+        profile = self.provider
+        if profile.vision_override is not None:
+            return profile.vision_override
+        if profile.vision_detected is not None:
+            return profile.vision_detected
         return False
 
     @property
@@ -595,10 +606,11 @@ class AppConfig:
         as the main model on a provider that the static table marks as
         tool-capable. Otherwise fall back to the provider-wide flag.
         """
-        if self.tools_detected is not None:
-            return self.tools_detected
+        profile = self.provider
+        if profile.tools_detected is not None:
+            return profile.tools_detected
         from .llm.providers import supports_tools as _provider_supports_tools
-        return _provider_supports_tools(self.provider.name)
+        return _provider_supports_tools(profile.name)
 
     def to_dict(self) -> dict:
         """Serialise, including a legacy ``provider`` mirror.
@@ -616,6 +628,8 @@ class AppConfig:
             "base_url": self.provider.base_url,
             "model": self.provider.model,
         }
+        for name in ProviderConfig.CAPABILITY_FIELDS:
+            data[name] = getattr(self.provider, name)
         return data
 
     @classmethod
@@ -652,7 +666,25 @@ class AppConfig:
 
         if not raw_profiles:
             cls._migrate_flat_provider(cfg, legacy_provider or {}, data)
+        cls._adopt_legacy_capabilities(cfg, data)
         return cfg
+
+    @staticmethod
+    def _adopt_legacy_capabilities(cfg: "AppConfig", data: dict) -> None:
+        """Move top-level capability flags onto the profile chat runs on.
+
+        Runs for both shapes: a pre-profiles config (the flags describe the
+        one connection there was) and a profiles-era config written before
+        the flags moved. Only the active profile can be spoken for — what a
+        probe found about the chat model says nothing about a reranker
+        profile — and a profile that already carries its own value is never
+        overwritten, so this is idempotent across loads.
+        """
+        cfg._ensure_profile()
+        profile = cfg.profiles[cfg.active_profile]
+        for name in ProviderConfig.CAPABILITY_FIELDS:
+            if getattr(profile, name) is None and data.get(name) is not None:
+                setattr(profile, name, data[name])
 
     @staticmethod
     def _migrate_flat_provider(cfg: "AppConfig", legacy: dict, data: dict) -> None:

--- a/freecad_ai/ui/chat_widget.py
+++ b/freecad_ai/ui/chat_widget.py
@@ -1387,7 +1387,8 @@ class ChatDockWidget(QDockWidget):
         # Show one-time hint if vision not tested and user is sending images
         pending_images = self._attachment_strip.get_images()
         cfg = get_config()
-        if pending_images and cfg.vision_detected is None and not self._vision_hint_shown:
+        if (pending_images and cfg.provider.vision_detected is None
+                and not self._vision_hint_shown):
             self._vision_hint_shown = True
             self._append_html(
                 '<div style="color: #888; font-size: 9pt; margin: 4px 12px;">'
@@ -1666,7 +1667,7 @@ class ChatDockWidget(QDockWidget):
         """Enable/disable image controls based on vision capability."""
         cfg = get_config()
         # Disable only when we know there's no vision AND no fallback
-        disable = (cfg.vision_detected is not None
+        disable = (cfg.provider.vision_detected is not None
                    and not cfg.supports_vision
                    and self._vision_fallback_tool is None)
 

--- a/freecad_ai/ui/settings_dialog.py
+++ b/freecad_ai/ui/settings_dialog.py
@@ -336,6 +336,39 @@ class SettingsDialog(QDialog):
         self._last_model_name = ""  # track model name for param save/load
         provider_layout.addRow(translate("SettingsDialog", "Model:"), self.model_edit)
 
+        # Vision support. A profile field, not a global one: it describes
+        # this profile's model, and Test Connection probes whichever
+        # profile is on screen.
+        vision_layout = QHBoxLayout()
+        self.vision_check = QCheckBox(
+            translate("SettingsDialog", "Model supports vision")
+        )
+        self.vision_check.setToolTip(
+            translate("SettingsDialog",
+                      "When enabled, images are sent directly to the LLM.\n"
+                      "When disabled, images are described via MCP before sending.\n"
+                      "Use Test Connection to auto-detect.")
+        )
+        self.vision_check.stateChanged.connect(self._on_vision_override_changed)
+        vision_layout.addWidget(self.vision_check)
+
+        self._vision_status_label = QLabel()
+        self._vision_status_label.setStyleSheet("color: #888;")
+        vision_layout.addWidget(self._vision_status_label)
+
+        self._vision_reset_btn = QPushButton(translate("SettingsDialog", "Reset"))
+        self._vision_reset_btn.setMaximumWidth(50)
+        self._vision_reset_btn.setToolTip(
+            translate("SettingsDialog", "Clear manual override, use auto-detected value")
+        )
+        self._vision_reset_btn.clicked.connect(self._reset_vision_override)
+        self._vision_reset_btn.hide()
+        vision_layout.addWidget(self._vision_reset_btn)
+
+        vision_layout.addStretch()
+        provider_layout.addRow(translate("SettingsDialog", "Vision:"),
+                               vision_layout)
+
         provider_group.setLayout(provider_layout)
         layout.addWidget(provider_group)
 
@@ -586,36 +619,6 @@ class SettingsDialog(QDialog):
         resolution_layout.addWidget(self.viewport_resolution_combo)
         resolution_layout.addStretch()
         behavior_layout.addLayout(resolution_layout)
-
-        # Vision support
-        vision_layout = QHBoxLayout()
-        self.vision_check = QCheckBox(
-            translate("SettingsDialog", "Model supports vision")
-        )
-        self.vision_check.setToolTip(
-            translate("SettingsDialog",
-                      "When enabled, images are sent directly to the LLM.\n"
-                      "When disabled, images are described via MCP before sending.\n"
-                      "Use Test Connection to auto-detect.")
-        )
-        self.vision_check.stateChanged.connect(self._on_vision_override_changed)
-        vision_layout.addWidget(self.vision_check)
-
-        self._vision_status_label = QLabel()
-        self._vision_status_label.setStyleSheet("color: #888;")
-        vision_layout.addWidget(self._vision_status_label)
-
-        self._vision_reset_btn = QPushButton(translate("SettingsDialog", "Reset"))
-        self._vision_reset_btn.setMaximumWidth(50)
-        self._vision_reset_btn.setToolTip(
-            translate("SettingsDialog", "Clear manual override, use auto-detected value")
-        )
-        self._vision_reset_btn.clicked.connect(self._reset_vision_override)
-        self._vision_reset_btn.hide()
-        vision_layout.addWidget(self._vision_reset_btn)
-
-        vision_layout.addStretch()
-        behavior_layout.addLayout(vision_layout)
 
         behavior_group.setLayout(behavior_layout)
         layout.addWidget(behavior_group)
@@ -988,11 +991,6 @@ class SettingsDialog(QDialog):
         resolution_map = {"low": 0, "medium": 1, "high": 2}
         self.viewport_resolution_combo.setCurrentIndex(resolution_map.get(cfg.viewport_resolution, 1))
 
-        # Vision
-        self._original_provider = cfg.provider.name
-        self._original_model = cfg.provider.model
-        self._update_vision_ui(cfg)
-
         # MCP servers
         self.mcp_list.clear()
         self._mcp_configs = list(cfg.mcp_servers)
@@ -1142,11 +1140,23 @@ class SettingsDialog(QDialog):
             return
         names = get_provider_names()
         idx = self.provider_combo.currentIndex()
-        if 0 <= idx < len(names):
-            prof.name = names[idx]
+        new_name = names[idx] if 0 <= idx < len(names) else prof.name
+        new_model = self.model_edit.text()
+        # A probe result describes one provider+model pair. Retype either
+        # and the stored answer is about something else, so drop it —
+        # per profile, since another profile's probe is still valid.
+        if new_name != prof.name or new_model != prof.model:
+            prof.vision_detected = None
+            prof.tools_detected = None
+            prof.thinking_detected = None
+        prof.name = new_name
         prof.base_url = self.base_url_edit.text()
         prof.api_key = self.api_key_edit.text()
-        prof.model = self.model_edit.text()
+        prof.model = new_model
+        # The vision checkbox is a profile widget like the four above; the
+        # dialog holds its pending value so a tri-state (None) survives.
+        if hasattr(self, "_vision_override_value"):
+            prof.vision_override = self._vision_override_value
         # The table is the profile's params in full (see
         # _load_model_params_table), so this is a straight write-back and
         # a removed row is a removed parameter. Do not reintroduce a
@@ -1176,6 +1186,7 @@ class SettingsDialog(QDialog):
         self.base_url_edit.setText(prof.base_url)
         self.model_edit.setText(prof.model)
         self._load_model_params_table(prof.model, self._cfg, prof)
+        self._update_vision_ui(prof)
 
         is_active = label == self._active_profile
         # blockSignals, or populating the widgets would itself re-point
@@ -1565,17 +1576,6 @@ class SettingsDialog(QDialog):
         resolution_values = ["low", "medium", "high"]
         cfg.viewport_resolution = resolution_values[self.viewport_resolution_combo.currentIndex()]
 
-        # Vision override
-        if hasattr(self, '_vision_override_value'):
-            cfg.vision_override = self._vision_override_value
-        # Reset all detected capabilities if provider or model changed —
-        # the previous probe results are about a different model.
-        if (hasattr(self, '_original_provider') and cfg.provider.name != self._original_provider) or \
-           (hasattr(self, '_original_model') and cfg.provider.model != self._original_model):
-            cfg.vision_detected = None
-            cfg.tools_detected = None
-            cfg.thinking_detected = None
-
         cfg.mcp_servers = list(self._mcp_configs) if hasattr(self, "_mcp_configs") else []
         cfg.mcp_server_host, cfg.mcp_server_port = self._parse_server_address(
             self.mcp_server_host_edit.text(),
@@ -1747,15 +1747,32 @@ class SettingsDialog(QDialog):
                 label, translate("SettingsDialog", "Failed: ") + message))
             self.test_status.setStyleSheet("color: #c62828;")
 
+    def _probed_profile(self):
+        """The profile Test Connection actually probed, or None.
+
+        Captured at probe start (``_test_profile_label``) so a profile
+        switch while the probe is in flight cannot land the result on the
+        wrong profile.
+        """
+        label = getattr(self, "_test_profile_label", None)
+        return self._profiles.get(label)
+
     def _on_vision_probed(self, supports_vision: bool):
-        """Handle vision probe result — persists to config immediately."""
+        """Handle vision probe result — records it on the probed profile.
+
+        Test Connection probes whichever profile is on screen, which need
+        not be the active one, so the answer belongs to that profile and
+        nowhere else. It lands in the dialog's working copy like every
+        other profile field and reaches the config on OK.
+        """
         self.test_btn.setEnabled(True)
         self.save_btn.setEnabled(True)
         self.cancel_btn.setEnabled(True)
-        cfg = get_config()
-        cfg.vision_detected = supports_vision
-        save_current_config()
-        self._update_vision_ui(cfg)
+        profile = self._probed_profile()
+        if profile is not None:
+            profile.vision_detected = supports_vision
+            if self._test_profile_label == self._current_profile_label:
+                self._update_vision_ui(profile)
         # Append vision status to test output
         current = self.test_status.text()
         if supports_vision:
@@ -1773,17 +1790,17 @@ class SettingsDialog(QDialog):
     def _on_capabilities_detected(self, caps: dict):
         """Handle full capabilities dict (Ollama only emits tools/thinking).
 
-        Persists tools_detected/thinking_detected to config and appends a
-        readable summary to the test status. Non-Ollama providers emit
-        only "vision" — tools/thinking stay None to keep falling back to
-        the provider-wide static flag.
+        Records tools_detected/thinking_detected on the probed profile and
+        appends a readable summary to the test status. Non-Ollama providers
+        emit only "vision" — tools/thinking stay None to keep falling back
+        to the provider-wide static flag.
         """
-        cfg = get_config()
-        if "tools" in caps:
-            cfg.tools_detected = bool(caps["tools"])
-        if "thinking" in caps:
-            cfg.thinking_detected = bool(caps["thinking"])
-        save_current_config()
+        profile = self._probed_profile()
+        if profile is not None:
+            if "tools" in caps:
+                profile.tools_detected = bool(caps["tools"])
+            if "thinking" in caps:
+                profile.thinking_detected = bool(caps["thinking"])
 
         # Build a single-line summary for the status label
         parts = []
@@ -2068,19 +2085,19 @@ class SettingsDialog(QDialog):
         """Re-scan and refresh the user tools list."""
         self._load_user_tools_list()
 
-    def _update_vision_ui(self, cfg):
-        """Update vision checkbox and label from config state."""
-        self._vision_override_value = cfg.vision_override
+    def _update_vision_ui(self, profile):
+        """Update vision checkbox and label from one profile's state."""
+        self._vision_override_value = profile.vision_override
         # Temporarily disconnect to avoid triggering _on_vision_override_changed
         self.vision_check.stateChanged.disconnect(self._on_vision_override_changed)
-        if cfg.vision_override is not None:
-            self.vision_check.setChecked(cfg.vision_override)
+        if profile.vision_override is not None:
+            self.vision_check.setChecked(profile.vision_override)
             self._vision_status_label.setText(
                 translate("SettingsDialog", "(manual override)")
             )
             self._vision_reset_btn.show()
-        elif cfg.vision_detected is not None:
-            self.vision_check.setChecked(cfg.vision_detected)
+        elif profile.vision_detected is not None:
+            self.vision_check.setChecked(profile.vision_detected)
             self._vision_status_label.setText(
                 translate("SettingsDialog", "(auto-detected)")
             )
@@ -2106,9 +2123,11 @@ class SettingsDialog(QDialog):
 
     def _reset_vision_override(self):
         """Clear the manual override, revert to auto-detected value."""
-        cfg = get_config()
-        self._vision_override_value = None
-        self._update_vision_ui(cfg)
+        profile = self._profiles.get(self._current_profile_label)
+        if profile is None:
+            return
+        profile.vision_override = None
+        self._update_vision_ui(profile)
 
     # --- Hooks methods ---
 

--- a/tests/unit/test_per_profile_capabilities.py
+++ b/tests/unit/test_per_profile_capabilities.py
@@ -1,0 +1,307 @@
+"""Detected capabilities belong to the profile, not to the config.
+
+``vision_detected``/``vision_override``/``tools_detected``/``thinking_detected``
+described "the model" back when there was exactly one connection. With
+connection profiles there are several, and Test Connection probes whichever
+profile is on screen — so a probe of a reranker or utility profile used to
+overwrite the chat model's capabilities globally, and persist it to disk
+immediately.
+
+The sharp edge was ``tools_detected``: ``cfg.supports_tools`` prefers it over
+the provider's static flag, and chat gates Act mode on that, so probing an
+embedding model on any profile silently stopped sending tools altogether.
+
+These pin the flags to the profile they were detected on.
+"""
+
+import copy
+
+import pytest
+
+from freecad_ai.config import AppConfig, ProviderConfig
+
+
+def _two_profiles():
+    cfg = AppConfig()
+    cfg.profiles = {
+        "chat": ProviderConfig(name="ollama", model="qwen3-coder:30b"),
+        "rerank": ProviderConfig(name="ollama", model="nomic-embed-text"),
+    }
+    cfg.active_profile = "chat"
+    return cfg
+
+
+class TestProfileCarriesItsOwnCapabilities:
+
+    def test_fields_default_to_untested(self):
+        p = ProviderConfig()
+        assert p.vision_detected is None
+        assert p.vision_override is None
+        assert p.tools_detected is None
+        assert p.thinking_detected is None
+
+    def test_supports_vision_reads_the_active_profile(self):
+        cfg = _two_profiles()
+        cfg.profiles["chat"].vision_detected = True
+        cfg.profiles["rerank"].vision_detected = False
+        assert cfg.supports_vision is True
+
+    def test_manual_override_still_wins_over_detection(self):
+        cfg = _two_profiles()
+        cfg.profiles["chat"].vision_detected = True
+        cfg.profiles["chat"].vision_override = False
+        assert cfg.supports_vision is False
+        # ...and in the other direction, where a global-flag fallback
+        # could not produce the right answer by accident.
+        cfg.profiles["chat"].vision_detected = False
+        cfg.profiles["chat"].vision_override = True
+        assert cfg.supports_vision is True
+
+    def test_supports_tools_reads_the_active_profile(self):
+        cfg = _two_profiles()
+        cfg.profiles["rerank"].tools_detected = False
+        # The embedding profile says "no tools"; chat's is untested, so the
+        # provider-wide static flag answers for chat.
+        assert cfg.supports_tools is True
+        cfg.profiles["chat"].tools_detected = False
+        assert cfg.supports_tools is False
+
+    def test_switching_the_active_profile_switches_the_answers(self):
+        cfg = _two_profiles()
+        cfg.profiles["chat"].vision_detected = True
+        cfg.profiles["rerank"].vision_detected = False
+        assert cfg.supports_vision is True
+        cfg.active_profile = "rerank"
+        assert cfg.supports_vision is False
+
+
+class TestMigration:
+
+    def test_pre_profiles_config_moves_flags_onto_the_migrated_profile(self):
+        cfg = AppConfig.from_dict({
+            "provider": {"name": "ollama", "model": "qwen3-coder:30b"},
+            "vision_detected": True,
+            "tools_detected": False,
+            "thinking_detected": True,
+            "vision_override": True,
+        })
+        prof = cfg.profiles[cfg.active_profile]
+        assert prof.vision_detected is True
+        assert prof.tools_detected is False
+        assert prof.thinking_detected is True
+        assert prof.vision_override is True
+
+    def test_profiles_era_config_moves_flags_onto_the_active_profile(self):
+        """Configs written by the unreleased profiles work keep the flags at
+        top level; adopt them once, into the profile chat runs on."""
+        cfg = AppConfig.from_dict({
+            "profiles": {
+                "chat": {"name": "ollama", "model": "a"},
+                "rerank": {"name": "ollama", "model": "b"},
+            },
+            "active_profile": "chat",
+            "vision_detected": True,
+            "tools_detected": True,
+        })
+        assert cfg.profiles["chat"].vision_detected is True
+        assert cfg.profiles["chat"].tools_detected is True
+        # Never guessed for a profile that was not the one probed.
+        assert cfg.profiles["rerank"].vision_detected is None
+        assert cfg.profiles["rerank"].tools_detected is None
+
+    def test_a_profile_that_already_has_flags_is_left_alone(self):
+        cfg = AppConfig.from_dict({
+            "profiles": {"chat": {"name": "ollama", "model": "a",
+                                  "vision_detected": False}},
+            "active_profile": "chat",
+            "vision_detected": True,
+        })
+        assert cfg.profiles["chat"].vision_detected is False
+
+    def test_flags_survive_a_save_load_round_trip_per_profile(self):
+        cfg = _two_profiles()
+        cfg.profiles["chat"].vision_detected = True
+        cfg.profiles["rerank"].tools_detected = False
+
+        back = AppConfig.from_dict(cfg.to_dict())
+
+        assert back.profiles["chat"].vision_detected is True
+        assert back.profiles["rerank"].tools_detected is False
+        assert back.profiles["chat"].tools_detected is None
+
+    def test_to_dict_mirrors_the_active_profile_for_a_downgrade(self):
+        """Like the legacy ``provider`` mirror: an older version reads the
+        top-level flags, so write the active profile's there too."""
+        cfg = _two_profiles()
+        cfg.profiles["chat"].vision_detected = True
+        cfg.profiles["rerank"].vision_detected = False
+
+        data = cfg.to_dict()
+
+        assert data["vision_detected"] is True
+
+
+# --- Settings dialog: the probes write to the profile they probed ---------
+
+try:
+    import PySide6  # noqa: F401
+    _HAVE_QT = True
+except ImportError:  # pragma: no cover - dev venv without either binding
+    try:
+        import PySide2  # noqa: F401
+        _HAVE_QT = True
+    except ImportError:
+        _HAVE_QT = False
+
+pytestmark_qt = pytest.mark.skipif(
+    not _HAVE_QT, reason="PySide6/PySide2 not available")
+
+
+def _fake_dialog(cfg, shown="chat"):
+    """A fake self carrying only what the methods under test touch."""
+    from unittest import mock
+    fake = mock.MagicMock()
+    fake._cfg = cfg
+    fake._profiles = cfg.profiles
+    fake._active_profile = cfg.active_profile
+    fake._current_profile_label = shown
+    prof = cfg.profiles[shown]
+    fake.provider_combo.currentIndex.return_value = -1  # keep prof.name
+    fake.base_url_edit.text.return_value = prof.base_url
+    fake.api_key_edit.text.return_value = prof.api_key
+    fake.model_edit.text.return_value = prof.model
+    fake._read_model_params_table.return_value = dict(prof.params)
+    # Real method, not a MagicMock stand-in — it is code under test.
+    from freecad_ai.ui.settings_dialog import SettingsDialog
+    fake._probed_profile = lambda: SettingsDialog._probed_profile(fake)
+    return fake
+
+
+@pytestmark_qt
+class TestProbesWriteToTheProbedProfile:
+    """The user's report: creating a reranker profile and pressing Test
+    Connection on it rewrote the *chat* model's vision flag."""
+
+    def test_vision_probe_writes_to_the_probed_profile(self):
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        cfg = _two_profiles()
+        fake = _fake_dialog(cfg, shown="rerank")
+        fake._test_profile_label = "rerank"
+
+        SettingsDialog._on_vision_probed(fake, True)
+
+        assert cfg.profiles["rerank"].vision_detected is True
+        assert cfg.profiles["chat"].vision_detected is None
+
+    def test_capability_probe_writes_to_the_probed_profile(self):
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        cfg = _two_profiles()
+        fake = _fake_dialog(cfg, shown="rerank")
+        fake._test_profile_label = "rerank"
+
+        SettingsDialog._on_capabilities_detected(
+            fake, {"vision": False, "tools": False, "thinking": True})
+
+        assert cfg.profiles["rerank"].tools_detected is False
+        assert cfg.profiles["rerank"].thinking_detected is True
+        assert cfg.profiles["chat"].tools_detected is None
+        assert cfg.profiles["chat"].thinking_detected is None
+
+    def test_probe_results_do_not_touch_the_live_config(self):
+        """They land in the dialog's working copy, like every other
+        profile field, and reach the real config on OK."""
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        cfg = _two_profiles()
+        working = copy.deepcopy(cfg.profiles)
+        fake = _fake_dialog(cfg, shown="rerank")
+        fake._profiles = working
+        fake._test_profile_label = "rerank"
+
+        SettingsDialog._on_vision_probed(fake, True)
+
+        assert working["rerank"].vision_detected is True
+        assert cfg.profiles["rerank"].vision_detected is None
+
+
+@pytestmark_qt
+class TestStaleDetectionIsClearedPerProfile:
+    """A probe result describes one model. Retype the model and the old
+    answer is about something else."""
+
+    def test_changing_the_model_clears_that_profiles_detection(self):
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        cfg = _two_profiles()
+        cfg.profiles["chat"].vision_detected = True
+        cfg.profiles["chat"].tools_detected = True
+        cfg.profiles["chat"].thinking_detected = True
+        fake = _fake_dialog(cfg, shown="chat")
+        fake.model_edit.text.return_value = "some-other-model"
+
+        SettingsDialog._commit_profile_fields(fake)
+
+        prof = cfg.profiles["chat"]
+        assert prof.model == "some-other-model"
+        assert prof.vision_detected is None
+        assert prof.tools_detected is None
+        assert prof.thinking_detected is None
+
+    def test_unchanged_model_keeps_the_detection(self):
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        cfg = _two_profiles()
+        cfg.profiles["chat"].vision_detected = True
+        cfg.profiles["chat"].tools_detected = False
+        fake = _fake_dialog(cfg, shown="chat")
+
+        SettingsDialog._commit_profile_fields(fake)
+
+        assert cfg.profiles["chat"].vision_detected is True
+        assert cfg.profiles["chat"].tools_detected is False
+
+    def test_changing_the_provider_clears_that_profiles_detection(self):
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        from freecad_ai.llm.providers import get_provider_names
+        cfg = _two_profiles()
+        cfg.profiles["chat"].vision_detected = True
+        fake = _fake_dialog(cfg, shown="chat")
+        names = get_provider_names()
+        fake.provider_combo.currentIndex.return_value = names.index("anthropic")
+
+        SettingsDialog._commit_profile_fields(fake)
+
+        assert cfg.profiles["chat"].name == "anthropic"
+        assert cfg.profiles["chat"].vision_detected is None
+
+    def test_the_other_profiles_detection_is_untouched(self):
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        cfg = _two_profiles()
+        cfg.profiles["rerank"].vision_detected = False
+        fake = _fake_dialog(cfg, shown="chat")
+        fake.model_edit.text.return_value = "some-other-model"
+
+        SettingsDialog._commit_profile_fields(fake)
+
+        assert cfg.profiles["rerank"].vision_detected is False
+
+
+@pytestmark_qt
+class TestVisionOverrideIsAProfileField:
+    def test_commit_writes_the_override_into_the_shown_profile(self):
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        cfg = _two_profiles()
+        fake = _fake_dialog(cfg, shown="rerank")
+        fake._vision_override_value = True
+
+        SettingsDialog._commit_profile_fields(fake)
+
+        assert cfg.profiles["rerank"].vision_override is True
+        assert cfg.profiles["chat"].vision_override is None
+
+    def test_showing_a_profile_renders_its_own_flags(self):
+        from freecad_ai.ui.settings_dialog import SettingsDialog
+        cfg = _two_profiles()
+        cfg.profiles["rerank"].vision_detected = False
+        fake = _fake_dialog(cfg, shown="chat")
+
+        SettingsDialog._show_profile(fake, "rerank")
+
+        fake._update_vision_ui.assert_called_once_with(cfg.profiles["rerank"])

--- a/tests/unit/test_profile_selector.py
+++ b/tests/unit/test_profile_selector.py
@@ -283,6 +283,7 @@ class TestProfileFieldRoundTrip:
         fake._load_model_params_table = lambda model, cfg=None, profile=None: None
         fake._read_model_params_table = (
             lambda: dict(fake._profiles[fake._current_profile_label].params))
+        fake._update_vision_ui = lambda profile: None
         return fake
 
     def test_edited_base_url_survives_switching_away_and_back(self):
@@ -680,6 +681,7 @@ class TestParamsDoNotLeakBetweenProfiles:
             lambda model, cfg=None, profile=None:
                 SettingsDialog._load_model_params_table(
                     fake, model, cfg, profile))
+        fake._update_vision_ui = lambda profile: None
 
         SettingsDialog._show_profile(fake, "a")
         assert table["temperature"] == 0.1
@@ -849,6 +851,7 @@ def _selector_fake(cfg, label="cloud"):
     fake._refresh_utility_combos = lambda: None
     fake._rename_profile = (
         lambda old, new: SettingsDialog._rename_profile(fake, old, new))
+    fake._update_vision_ui = lambda profile: None
     return fake
 
 

--- a/tests/unit/test_vision_routing.py
+++ b/tests/unit/test_vision_routing.py
@@ -8,23 +8,23 @@ class TestVisionConfig:
 
     def test_defaults(self):
         cfg = AppConfig()
-        assert cfg.vision_detected is None
-        assert cfg.vision_override is None
+        assert cfg.provider.vision_detected is None
+        assert cfg.provider.vision_override is None
 
     def test_supports_vision_override_takes_precedence(self):
         cfg = AppConfig()
-        cfg.vision_detected = False
-        cfg.vision_override = True
+        cfg.provider.vision_detected = False
+        cfg.provider.vision_override = True
         assert cfg.supports_vision is True
 
     def test_supports_vision_detected_used_when_no_override(self):
         cfg = AppConfig()
-        cfg.vision_detected = True
+        cfg.provider.vision_detected = True
         assert cfg.supports_vision is True
 
     def test_supports_vision_false_when_detected_false(self):
         cfg = AppConfig()
-        cfg.vision_detected = False
+        cfg.provider.vision_detected = False
         assert cfg.supports_vision is False
 
     def test_supports_vision_false_when_untested(self):
@@ -33,19 +33,19 @@ class TestVisionConfig:
 
     def test_vision_fields_roundtrip_json(self):
         cfg = AppConfig()
-        cfg.vision_detected = True
-        cfg.vision_override = False
+        cfg.provider.vision_detected = True
+        cfg.provider.vision_override = False
         d = cfg.to_dict()
         cfg2 = AppConfig.from_dict(d)
-        assert cfg2.vision_detected is True
-        assert cfg2.vision_override is False
+        assert cfg2.provider.vision_detected is True
+        assert cfg2.provider.vision_override is False
 
     def test_vision_fields_none_roundtrip(self):
         cfg = AppConfig()
         d = cfg.to_dict()
         cfg2 = AppConfig.from_dict(d)
-        assert cfg2.vision_detected is None
-        assert cfg2.vision_override is None
+        assert cfg2.provider.vision_detected is None
+        assert cfg2.provider.vision_override is None
 
 
 class TestVisionProbe:
@@ -251,32 +251,32 @@ class TestSupportsToolsConfig:
         from freecad_ai.config import AppConfig
         cfg = AppConfig()
         cfg.provider.name = "ollama"  # statically marked tool-capable
-        cfg.tools_detected = False    # detected: model doesn't support tools
+        cfg.provider.tools_detected = False    # detected: model doesn't support tools
         assert cfg.supports_tools is False
 
     def test_supports_tools_falls_back_to_provider_when_untested(self):
         from freecad_ai.config import AppConfig
         cfg = AppConfig()
         cfg.provider.name = "anthropic"
-        cfg.tools_detected = None
+        cfg.provider.tools_detected = None
         assert cfg.supports_tools is True  # anthropic provider flag is True
 
     def test_supports_tools_detected_true_overrides_provider(self):
         from freecad_ai.config import AppConfig
         cfg = AppConfig()
         cfg.provider.name = "openrouter"
-        cfg.tools_detected = True
+        cfg.provider.tools_detected = True
         assert cfg.supports_tools is True
 
     def test_tools_detected_roundtrip_json(self):
         from freecad_ai.config import AppConfig
         cfg = AppConfig()
-        cfg.tools_detected = True
-        cfg.thinking_detected = False
+        cfg.provider.tools_detected = True
+        cfg.provider.thinking_detected = False
         d = cfg.to_dict()
         cfg2 = AppConfig.from_dict(d)
-        assert cfg2.tools_detected is True
-        assert cfg2.thinking_detected is False
+        assert cfg2.provider.tools_detected is True
+        assert cfg2.provider.thinking_detected is False
 
     def test_custom_provider_supports_tools_by_default(self):
         """Issue #38: a custom OpenAI-compatible endpoint must get tools.
@@ -291,7 +291,7 @@ class TestSupportsToolsConfig:
         from freecad_ai.config import AppConfig
         cfg = AppConfig()
         cfg.provider.name = "custom"
-        cfg.tools_detected = None  # no Ollama probe runs for custom
+        cfg.provider.tools_detected = None  # no Ollama probe runs for custom
         assert cfg.supports_tools is True
 
     def test_custom_provider_tools_opt_out_still_honored(self):
@@ -303,7 +303,7 @@ class TestSupportsToolsConfig:
         from freecad_ai.config import AppConfig
         cfg = AppConfig()
         cfg.provider.name = "custom"
-        cfg.tools_detected = False
+        cfg.provider.tools_detected = False
         assert cfg.supports_tools is False
 
 
@@ -454,40 +454,40 @@ class TestImageControlGating:
         """Controls should NOT be disabled when vision_detected is None."""
         cfg = AppConfig()
         # vision_detected=None, no fallback
-        should_disable = (cfg.vision_detected is not None
+        should_disable = (cfg.provider.vision_detected is not None
                           and not cfg.supports_vision
                           and True)  # simulate no fallback
         assert should_disable is False  # optimistic for untested
 
     def test_gating_disabled_when_no_vision_no_fallback(self):
         cfg = AppConfig()
-        cfg.vision_detected = False
-        should_disable = (cfg.vision_detected is not None
+        cfg.provider.vision_detected = False
+        should_disable = (cfg.provider.vision_detected is not None
                           and not cfg.supports_vision
                           and True)  # no fallback
         assert should_disable is True
 
     def test_gating_enabled_when_fallback_exists(self):
         cfg = AppConfig()
-        cfg.vision_detected = False
+        cfg.provider.vision_detected = False
         fallback = "server__describe_image"  # simulate fallback exists
-        should_disable = (cfg.vision_detected is not None
+        should_disable = (cfg.provider.vision_detected is not None
                           and not cfg.supports_vision
                           and fallback is None)
         assert should_disable is False
 
     def test_gating_enabled_when_vision_supported(self):
         cfg = AppConfig()
-        cfg.vision_detected = True
-        should_disable = (cfg.vision_detected is not None
+        cfg.provider.vision_detected = True
+        should_disable = (cfg.provider.vision_detected is not None
                           and not cfg.supports_vision)
         assert should_disable is False
 
     def test_gating_enabled_with_override(self):
         cfg = AppConfig()
-        cfg.vision_detected = False
-        cfg.vision_override = True
-        should_disable = (cfg.vision_detected is not None
+        cfg.provider.vision_detected = False
+        cfg.provider.vision_override = True
+        should_disable = (cfg.provider.vision_detected is not None
                           and not cfg.supports_vision
                           and True)
         assert should_disable is False  # override makes supports_vision True


### PR DESCRIPTION
I'm an AI assistant handling this on Alfred's behalf.

Follow-up to #77. No GitHub issue — Alfred found this during the manual GUI pass over the connection-profiles branch.

## The bug

`vision_detected`, `vision_override`, `tools_detected` and `thinking_detected` lived on `AppConfig`: one set of answers for the whole configuration. That was correct when there was exactly one connection. With profiles there are several, and **Test Connection deliberately probes whichever profile is open in the dialog** — so pressing it on a newly created reranking or utility profile overwrote the *chat* model's capabilities, and `save_current_config()` wrote them to disk before you ever pressed OK.

The sharp edge is `tools_detected`. `AppConfig.supports_tools` prefers it over the provider's static flag, and Act mode gates on that — so probing an embedding model on any profile recorded "no tools" for chat, which then silently stopped sending tools at all.

## The fix

The four flags move onto `ProviderConfig`. Each profile remembers its own detection.

- `supports_vision` / `supports_tools` resolve through the active profile, so every consumer keeps working untouched; the two direct reads in `chat_widget.py` re-point to `cfg.provider`.
- The old top-level fields stay in `config.json`, unread, for one release, and are mirrored from the active profile on save — the same downgrade-safety trick the existing `provider` mirror uses. `_adopt_legacy_capabilities` migrates them onto the active profile at load, and never onto a profile that already carries its own value, so it is idempotent across loads. Only the active profile can be spoken for: what a probe found about the chat model says nothing about a reranker profile.

In the Settings dialog the flags become profile widgets, like Base URL and Model:

- `_show_profile` renders them, `_commit_profile_fields` writes them back.
- Retyping a profile's provider or model clears **that profile's** now-stale detection. This replaces the global `_original_provider`/`_original_model` snapshot, which only ever tracked the active profile.
- `_probed_profile()` resolves the label captured when the probe started, so a profile switch while a probe is in flight cannot land the result on the wrong profile — the same capture the status-line naming in `f902410` uses.
- The **Model supports vision** checkbox moves out of *Behavior* and into the *LLM Provider* group, directly under the model it describes.

## One behaviour change worth flagging

A probe result now lands in the dialog's working copy and reaches `config.json` **on OK**, not the instant the probe returns. Previously `_on_vision_probed` wrote the live config singleton and saved immediately.

This makes capabilities consistent with every other profile field, and removes one contributor to #76 (Test Connection flushing unsaved dialog state to disk). The cost: probe, then Cancel, and the detection is discarded rather than kept.

## Testing

**1390 unit tests pass** (`env PYTHONPATH= .venv/bin/pytest tests/unit/ --ignore=tests/unit/test_document_attach.py`), up from 1371 on master at `f902410`. 19 new tests, written failing first:

- `tests/unit/test_per_profile_capabilities.py` (new, 19) — the flags round-trip per profile; migration from both a pre-profiles and a profiles-era config; each probe writes to the profile it probed and not to its neighbour or to the live config; stale detection is cleared per profile on a provider or model change and only there; the override is a profile field; `_show_profile` renders the shown profile's own state.
- `tests/unit/test_vision_routing.py` — re-pointed to the new contract (the flags are read and written on the profile).

**What is not covered:** as with #77, none of this has been driven in a live FreeCAD GUI. The moved vision row and the per-profile rendering were verified against an offscreen `SettingsDialog` — switching to a profile with `vision_detected=False` correctly renders unchecked plus `(auto-detected)` — but not by hand in FreeCAD. Worth a look during the release pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcF4dNh1eE1SdpM4aPgGn8
