### PR TITLE
fix: sandbox segfault, false-positive Invalid/null-shape flags on Arch/BIM code

### DIFF
--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -287,6 +287,20 @@ try:
     # runs. The sandbox dry-runs against a copy of the saved document, so an
     # imported-and-converted mesh→solid that OCC considers invalid is present
     # on every run; without this snapshot it would fail unrelated code.
+    #
+    # Recompute once here, BEFORE snapshotting the baseline. The document was
+    # opened fresh (its on-disk cached shapes reflect whatever environment
+    # last saved it — typically the real GUI process), but the post-execution
+    # check further down forces its own doc.recompute() unconditionally. Some
+    # objects (e.g. a complex Arch::Wall whose Draft/OCC boolean fuse is
+    # sensitive to the fake-FreeCADGui/headless environment here) recompute
+    # differently under this sandbox than they did live — genuinely fine in
+    # the user's document, but landing in an Invalid state the moment this
+    # harness recomputes it. Without matching that recompute before the
+    # baseline snapshot, such an object is absent from `_baseline_bad` and
+    # every subsequent call — even a no-op read — gets its Invalid state
+    # blamed on that call's code.
+    doc.recompute()
     _baseline_bad = set()
     for _obj in doc.Objects:
         _s = _snap(_obj)

--- a/freecad_ai/core/executor.py
+++ b/freecad_ai/core/executor.py
@@ -160,14 +160,24 @@ def _collect_object_issues(objects_state, baseline_bad):
     # still lands in an Invalid state and is caught by the invalid_state report
     # below. Kept local so it ships with the function source into the sandbox
     # harness (inspect.getsource doesn't carry module globals).
+    # Arch/BIM containers (Site, Building, BuildingPart/Floor) are pure
+    # organizational groups — they hold no geometry of their own and report a
+    # null Shape for their entire lifetime, empty or fully populated. Flagging
+    # that blocked every Arch.makeSite/makeBuilding/makeFloor call. These are
+    # scripted objects (Part::FeaturePython / App::GeometryPython) — the
+    # generic TypeId is shared with countless unrelated object types, so the
+    # semantic type has to come from Proxy.Type instead (e.g. "Site",
+    # "BuildingPart" — Building and Floor are both BuildingPart under the hood).
     null_shape_ok_types = {"Sketcher::SketchObject", "PartDesign::Body"}
+    null_shape_ok_proxy_types = {"Site", "Building", "BuildingPart", "Floor"}
     issues = []
     for st in objects_state:
         name = st["name"]
         if name in baseline_bad:
             continue
         if st.get("null"):
-            if st.get("type") not in null_shape_ok_types:
+            if (st.get("type") not in null_shape_ok_types
+                    and st.get("proxy_type") not in null_shape_ok_proxy_types):
                 issues.append("Object '" + name + "' has null shape")
         elif st.get("invalid"):
             issues.append("Object '" + name + "' has invalid shape")
@@ -268,7 +278,9 @@ try:
                 pass
         _state = getattr(_obj, "State", None)
         _bad_state = bool(_state and "Invalid" in _state)
+        _proxy_type = getattr(getattr(_obj, "Proxy", None), "Type", "")
         return {{"name": _obj.Name, "type": getattr(_obj, "TypeId", ""),
+                 "proxy_type": _proxy_type,
                  "null": _null, "invalid": _invalid, "invalid_state": _bad_state}}
 
     # Baseline: objects already broken in the opened document BEFORE user code

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -474,6 +474,56 @@ class TestCollectObjectIssues:
         issues = executor._collect_object_issues(objects_state, set())
         assert issues == ["Object 'Pad' has null shape"]
 
+    def test_arch_container_null_shape_is_not_reported(self):
+        # PR #81: Arch/BIM containers are organizational groups that hold no
+        # geometry of their own — Shape.isNull() stays True for their whole
+        # lifetime, empty or fully populated, while State stays "Up-to-date".
+        # Flagging that failed every Arch.makeSite/makeBuilding/makeFloor call.
+        # Their TypeId (Part::FeaturePython / App::GeometryPython) is shared
+        # with countless unrelated scripted objects, so the exemption is keyed
+        # on Proxy.Type. Values below are as observed on FreeCAD 1.1.1:
+        # makeSite -> "Site", makeBuilding AND makeFloor -> "BuildingPart".
+        objects_state = [
+            {"name": "Site", "type": "Part::FeaturePython",
+             "proxy_type": "Site",
+             "null": True, "invalid": False, "invalid_state": False},
+            {"name": "BuildingPart", "type": "App::GeometryPython",
+             "proxy_type": "BuildingPart",
+             "null": True, "invalid": False, "invalid_state": False},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == [], (
+            "Arch containers (null shape, Up-to-date) must not be reported as "
+            "broken; this blocked all Arch/BIM tooling"
+        )
+
+    def test_scripted_object_without_arch_proxy_type_still_reported(self):
+        # Guards the exemption's narrowness AND the key name itself: _snap()
+        # writes "proxy_type" and this predicate reads it, with no other
+        # coupling between them. A typo on either side would silently exempt
+        # nothing (or everything) — here the same TypeId as an Arch container,
+        # carrying the empty Proxy.Type of a plain non-scripted object, must
+        # still be reported.
+        objects_state = [
+            {"name": "SomeFeature", "type": "Part::FeaturePython",
+             "proxy_type": "",
+             "null": True, "invalid": False, "invalid_state": False},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == ["Object 'SomeFeature' has null shape"]
+
+    def test_broken_arch_container_still_reported(self):
+        # Safety net, mirroring the sketch case above: the null-shape
+        # exemption must not swallow a container that genuinely failed to
+        # recompute — the separate invalid_state report still catches it.
+        objects_state = [
+            {"name": "Site", "type": "Part::FeaturePython",
+             "proxy_type": "Site",
+             "null": True, "invalid": False, "invalid_state": True},
+        ]
+        issues = executor._collect_object_issues(objects_state, set())
+        assert issues == ["Object 'Site' is in Invalid state"]
+
 
 class _FakeDoc:
     """Minimal stand-in for the App::Document slice ``_auto_save`` touches.


### PR DESCRIPTION
Fixes two sandbox pre-check bugs that made the validator reject legitimate Arch/BIM code.

- **False "null shape" on Arch containers.** `Arch.makeSite`/`makeBuilding`/`makeFloor` create organizational scripted objects whose `Shape` is legitimately null for their entire lifetime, empty or fully populated, while `State` stays `Up-to-date`. These are now recognised via `Proxy.Type` instead of the generic, ambiguous `TypeId` (`Part::FeaturePython` / `App::GeometryPython` are shared with countless unrelated scripted objects).

- **False "Invalid state" on later calls.** The baseline snapshot didn't recompute the document first, so objects that recompute differently under the sandbox's headless fake-GUI environment than they did live were missing from `_baseline_bad` — causing any unrelated subsequent call to get blamed for that object's Invalid state.

Plus regression tests covering the exemption, a negative control, and the still-reported failure case.

---

*Maintainer note: an earlier revision of this description also listed the `getHomePath()` / `FreeCADGui`-stub segfault fix. That shipped separately as `e6cb6f7` and reached this branch through its merge of master, so it is not part of this diff — trimmed here to keep the changelog entry accurate.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
